### PR TITLE
Migrate doc runtime UI

### DIFF
--- a/scripts/doc-runtime-core.mjs
+++ b/scripts/doc-runtime-core.mjs
@@ -276,7 +276,7 @@ version = "0.1.0"
 description = "Generated Rust cells for the documentation runtime."
 edition = "2024"
 rust-version = "1.95"
-license-file = "../../../../LICENSE"
+license = "AGPL-3.0-only"
 publish = false
 
 [workspace]
@@ -305,22 +305,36 @@ export function generateRustDependency(crateName, workspaceCrates) {
 }
 
 export function generateRustLib(rustCells) {
-  const matchArms =
+  const matchArms = rustCells
+    .map((cell) => `        ${JSON.stringify(cell.id)} => ${rustFunctionName(cell.id)}(&inputs),`)
+    .concat('        _ => Err(format!("unknown Rust cell: {cell_id}")),')
+    .join('\n');
+  const runFunction =
     rustCells.length === 0
-      ? '        _ => Err(format!("unknown Rust cell: {cell_id}")),\n'
-      : rustCells
-          .map((cell) => `        ${JSON.stringify(cell.id)} => ${rustFunctionName(cell.id)}(&inputs),`)
-          .concat('        _ => Err(format!("unknown Rust cell: {cell_id}")),')
-          .join('\n');
+      ? `#[wasm_bindgen]
+pub fn run_rust_cell(cell_id: &str, inputs_json: &str) -> Result<String, JsValue> {
+    let _: Value = serde_json::from_str(inputs_json).map_err(to_js_error)?;
+
+    Err(JsValue::from_str(&format!("unknown Rust cell: {cell_id}")))
+}`
+      : `#[wasm_bindgen]
+pub fn run_rust_cell(cell_id: &str, inputs_json: &str) -> Result<String, JsValue> {
+    let inputs: Value = serde_json::from_str(inputs_json).map_err(to_js_error)?;
+    let output = match cell_id {
+${matchArms}
+    }
+    .map_err(|error| JsValue::from_str(&error))?;
+
+    serde_json::to_string(&output).map_err(to_js_error)
+}`;
 
   const functions = rustCells.map(generateRustFunction).join('\n\n');
   const firstCellTest = rustCells[0] ? generateRustTest(rustCells[0]) : '';
   const readers = generateRustReaders(rustCells);
-
-  return `${generatedBanner()}use serde::Serialize;
-use serde_json::Value;
-use wasm_bindgen::prelude::*;
-
+  const outputTypes =
+    rustCells.length === 0
+      ? ''
+      : `
 #[derive(Debug, Serialize)]
 #[serde(tag = "kind")]
 enum PlotSpec {
@@ -341,22 +355,19 @@ struct CellOutput {
     plots: Vec<PlotSpec>,
     value: Value,
 }
+`;
+  const serdeImport = rustCells.length === 0 ? '' : 'use serde::Serialize;\n';
+
+  return `${generatedBanner()}${serdeImport}use serde_json::Value;
+use wasm_bindgen::prelude::*;
+${outputTypes}
 
 #[wasm_bindgen(start)]
 pub fn start() {
     console_error_panic_hook::set_once();
 }
 
-#[wasm_bindgen]
-pub fn run_rust_cell(cell_id: &str, inputs_json: &str) -> Result<String, JsValue> {
-    let inputs: Value = serde_json::from_str(inputs_json).map_err(to_js_error)?;
-    let output = match cell_id {
-${matchArms}
-    }
-    .map_err(|error| JsValue::from_str(&error))?;
-
-    serde_json::to_string(&output).map_err(to_js_error)
-}
+${runFunction}
 
 fn to_js_error(error: impl std::fmt::Display) -> JsValue {
     JsValue::from_str(&error.to_string())

--- a/src/components/doc-runtime/InteractiveCell.tsx
+++ b/src/components/doc-runtime/InteractiveCell.tsx
@@ -1,0 +1,293 @@
+import { useEffect, useMemo, useState } from 'preact/hooks';
+import {
+  coerceInputValue,
+  formatInputValue,
+  idleOutputMessage,
+  initialValues,
+  labelsForLanguage,
+  shouldShowRunButton
+} from '../../lib/doc-runtime/interactive-cell-model';
+import { getCell, getManifestSnapshot, subscribeManifest } from '../../lib/doc-runtime/manifest';
+import { runInteractiveCell } from '../../lib/doc-runtime/runtime-client';
+import type {
+  CellExecutionResult,
+  CellManifest,
+  InputSpec,
+  InputValues
+} from '../../lib/doc-runtime/types';
+import PlotOutput from './PlotOutput';
+
+interface InteractiveCellProps {
+  cellId: string;
+}
+
+export default function InteractiveCell({ cellId }: InteractiveCellProps) {
+  const { version } = useManifestSnapshot();
+  const cell = getCell(cellId);
+  const labels = useRuntimeLabels();
+
+  if (!cell) {
+    return (
+      <section class="doc-cell doc-cell--error">
+        <p class="error-state">{labels.unknownCell(cellId)}</p>
+      </section>
+    );
+  }
+
+  return <InteractiveCellPanel key={`${cell.id}:${version}`} cell={cell} labels={labels} runtimeVersion={version} />;
+}
+
+function InteractiveCellPanel({
+  cell,
+  labels,
+  runtimeVersion
+}: {
+  cell: CellManifest;
+  labels: ReturnType<typeof labelsForLanguage>;
+  runtimeVersion: string;
+}) {
+  const [values, setValues] = useState<InputValues>(() => initialValues(cell.inputs));
+  const [result, setResult] = useState<CellExecutionResult>();
+  const [error, setError] = useState<string>();
+  const [isRunning, setIsRunning] = useState(false);
+  const [isSourceVisible, setIsSourceVisible] = useState(cell.showSource);
+
+  const serializedValues = useMemo(() => JSON.stringify(values), [values]);
+
+  useEffect(() => {
+    if (cell.run !== 'autorun') return;
+    void run();
+  }, [cell.id, runtimeVersion]);
+
+  useEffect(() => {
+    if (cell.run !== 'reactive') return;
+    void run();
+  }, [cell.id, runtimeVersion, serializedValues]);
+
+  async function run() {
+    setIsRunning(true);
+    setError(undefined);
+
+    try {
+      setResult(await runInteractiveCell(cell, values));
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : String(caught));
+    } finally {
+      setIsRunning(false);
+    }
+  }
+
+  return (
+    <section class="doc-cell" data-language={cell.language} data-testid={`cell-${cell.id}`}>
+      <div class="doc-cell__header">
+        <div>
+          <p class="doc-cell__eyebrow">{cell.language === 'rust' ? 'Rust + Wasm' : 'Python + Pyodide'}</p>
+          <h3>{cell.title}</h3>
+        </div>
+        <div class="doc-cell__actions">
+          <button
+            type="button"
+            class="secondary-button"
+            aria-expanded={isSourceVisible}
+            onClick={() => setIsSourceVisible((visible) => !visible)}
+          >
+            {isSourceVisible ? labels.hideCode : labels.showCode}
+          </button>
+          {shouldShowRunButton(cell.run) ? (
+            <button type="button" class="run-button" disabled={isRunning} onClick={run}>
+              {isRunning ? labels.running : labels.run}
+            </button>
+          ) : null}
+        </div>
+      </div>
+
+      {cell.inputs.length > 0 ? (
+        <div class="doc-input-grid">
+          {cell.inputs.map((input) => (
+            <InputControl
+              key={input.name}
+              input={input}
+              value={values[input.name]}
+              onChange={(value) => setValues((current) => ({ ...current, [input.name]: value }))}
+            />
+          ))}
+        </div>
+      ) : null}
+
+      {isSourceVisible ? (
+        <div
+          class="doc-source"
+          data-testid="cell-source"
+          dangerouslySetInnerHTML={{ __html: cell.sourceHtml }}
+        />
+      ) : null}
+
+      <CellOutput result={result} error={error} isRunning={isRunning} labels={labels} runMode={cell.run} />
+    </section>
+  );
+}
+
+function useManifestSnapshot() {
+  const [snapshot, setSnapshot] = useState(getManifestSnapshot);
+
+  useEffect(() => subscribeManifest(() => setSnapshot(getManifestSnapshot())), []);
+
+  return snapshot;
+}
+
+function useRuntimeLabels() {
+  return useMemo(() => labelsForLanguage(globalThis.document?.documentElement.lang), []);
+}
+
+function InputControl({
+  input,
+  value,
+  onChange
+}: {
+  input: InputSpec;
+  onChange: (value: string | number | boolean) => void;
+  value: string | number | boolean;
+}) {
+  const id = `doc-input-${input.name}`;
+
+  if (input.type === 'checkbox') {
+    return (
+      <label class="doc-input doc-input--checkbox" for={id}>
+        <input
+          id={id}
+          type="checkbox"
+          checked={Boolean(value)}
+          onInput={(event) => onChange(event.currentTarget.checked)}
+        />
+        <span>{input.label}</span>
+      </label>
+    );
+  }
+
+  if (input.type === 'select') {
+    return (
+      <label class="doc-input" for={id}>
+        <span>{input.label}</span>
+        <select id={id} value={String(value)} onInput={(event) => onChange(event.currentTarget.value)}>
+          {input.options.map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+        </select>
+      </label>
+    );
+  }
+
+  if (input.type === 'radio') {
+    return (
+      <fieldset class="doc-input doc-input--radio">
+        <legend>{input.label}</legend>
+        {input.options.map((option) => (
+          <label key={option.value}>
+            <input
+              type="radio"
+              name={id}
+              value={option.value}
+              checked={String(value) === option.value}
+              onInput={(event) => onChange(event.currentTarget.value)}
+            />
+            <span>{option.label}</span>
+          </label>
+        ))}
+      </fieldset>
+    );
+  }
+
+  if (input.type === 'textarea') {
+    return (
+      <label class="doc-input" for={id}>
+        <span>{input.label}</span>
+        <textarea id={id} value={String(value)} onInput={(event) => onChange(event.currentTarget.value)} />
+      </label>
+    );
+  }
+
+  if (input.type === 'range') {
+    return (
+      <label class="doc-input" for={id}>
+        <span>
+          {input.label} <strong data-testid={`${input.name}-value`}>{formatInputValue(value)}</strong>
+        </span>
+        <input
+          id={id}
+          aria-label={input.name}
+          type="range"
+          min={input.min}
+          max={input.max}
+          step={input.step}
+          value={Number(value)}
+          onInput={(event) => onChange(Number(event.currentTarget.value))}
+        />
+      </label>
+    );
+  }
+
+  const numeric = input.type === 'number' || input.type === 'integer';
+
+  return (
+    <label class="doc-input" for={id}>
+      <span>{input.label}</span>
+      <input
+        id={id}
+        aria-label={input.name}
+        type={numeric ? 'number' : 'text'}
+        min={input.min}
+        max={input.max}
+        step={input.step}
+        value={String(value)}
+        onInput={(event) => {
+          onChange(coerceInputValue(input, event.currentTarget.value));
+        }}
+      />
+    </label>
+  );
+}
+
+function CellOutput({
+  error,
+  isRunning,
+  labels,
+  result,
+  runMode
+}: {
+  error?: string;
+  isRunning: boolean;
+  labels: ReturnType<typeof labelsForLanguage>;
+  result?: CellExecutionResult;
+  runMode: CellManifest['run'];
+}) {
+  if (error) return <p class="error-state">{error}</p>;
+  if (isRunning) return <p class="empty-state">{labels.runningCell}</p>;
+  if (!result) {
+    return (
+      <p class="empty-state">
+        {idleOutputMessage(runMode, labels)}
+      </p>
+    );
+  }
+
+  return (
+    <div class="doc-cell__outputs">
+      {result.stdout ? (
+        <pre class="run-output" data-testid="run-output">
+          <code>{result.stdout}</code>
+        </pre>
+      ) : null}
+      {result.stderr ? <pre class="error-output">{result.stderr}</pre> : null}
+      {result.value != null && result.value !== '' ? (
+        <pre class="run-output" data-testid="value-output">
+          <code>{JSON.stringify(result.value, null, 2)}</code>
+        </pre>
+      ) : null}
+      {result.plots.map((plot, index) => (
+        <PlotOutput key={index} plot={plot} />
+      ))}
+    </div>
+  );
+}

--- a/src/components/doc-runtime/MermaidDiagram.tsx
+++ b/src/components/doc-runtime/MermaidDiagram.tsx
@@ -1,0 +1,86 @@
+import mermaid from 'mermaid';
+import { useEffect, useMemo, useRef, useState } from 'preact/hooks';
+
+interface MermaidDiagramProps {
+  diagramId: string;
+  source: string;
+}
+
+type RenderState = 'idle' | 'rendering' | 'ready' | 'error';
+
+let hasInitializedMermaid = false;
+
+export default function MermaidDiagram({ diagramId, source }: MermaidDiagramProps) {
+  const container = useRef<HTMLDivElement>(null);
+  const [error, setError] = useState<string>();
+  const [state, setState] = useState<RenderState>('idle');
+  const renderId = useMemo(() => `doc-${diagramId}`, [diagramId]);
+
+  useEffect(() => {
+    const element = container.current!;
+
+    let cancelled = false;
+
+    async function renderDiagram() {
+      setState('rendering');
+      setError(undefined);
+      element.replaceChildren();
+
+      try {
+        initializeMermaid();
+        const { svg, bindFunctions } = await mermaid.render(renderId, source);
+        if (cancelled) return;
+
+        element.innerHTML = svg;
+        bindFunctions?.(element);
+        setState('ready');
+      } catch (caught) {
+        if (cancelled) return;
+
+        const message = caught instanceof Error ? caught.message : String(caught);
+        element.textContent = 'Mermaid diagram could not be rendered.';
+        setError(message);
+        setState('error');
+      }
+    }
+
+    void renderDiagram();
+
+    return () => {
+      cancelled = true;
+      element.replaceChildren();
+    };
+  }, [renderId, source]);
+
+  return (
+    <figure class="mermaid-diagram" data-state={state} data-testid="mermaid-diagram">
+      <div ref={container} class="mermaid-diagram__surface" aria-label="Mermaid diagram" />
+      {error ? (
+        <figcaption class="error-state" role="alert">
+          {error}
+        </figcaption>
+      ) : null}
+    </figure>
+  );
+}
+
+function initializeMermaid(): void {
+  if (hasInitializedMermaid) return;
+
+  mermaid.initialize({
+    startOnLoad: false,
+    securityLevel: 'strict',
+    theme: 'base',
+    themeVariables: {
+      fontFamily: 'system-ui, sans-serif',
+      primaryColor: '#f8fafc',
+      primaryTextColor: '#111827',
+      primaryBorderColor: '#64748b',
+      lineColor: '#0f766e',
+      secondaryColor: '#ecfeff',
+      tertiaryColor: '#f1f5f9'
+    }
+  });
+
+  hasInitializedMermaid = true;
+}

--- a/src/components/doc-runtime/PlotOutput.tsx
+++ b/src/components/doc-runtime/PlotOutput.tsx
@@ -1,0 +1,58 @@
+import { LineChart } from 'echarts/charts';
+import { DataZoomComponent, GridComponent, TooltipComponent } from 'echarts/components';
+import * as echarts from 'echarts/core';
+import { CanvasRenderer } from 'echarts/renderers';
+import { useEffect, useRef } from 'preact/hooks';
+import type { PlotSpec } from '../../lib/doc-runtime/types';
+
+echarts.use([LineChart, GridComponent, TooltipComponent, DataZoomComponent, CanvasRenderer]);
+
+interface PlotOutputProps {
+  plot: PlotSpec;
+}
+
+type EChartsInstance = ReturnType<typeof echarts.init>;
+
+export default function PlotOutput({ plot }: PlotOutputProps) {
+  const element = useRef<HTMLDivElement>(null);
+  const chart = useRef<EChartsInstance>();
+
+  useEffect(() => {
+    const chartElement = element.current!;
+    const nextChart = echarts.init(chartElement, undefined, { renderer: 'canvas' });
+    chart.current = nextChart;
+
+    const resizeObserver = new ResizeObserver(() => nextChart.resize());
+    resizeObserver.observe(chartElement);
+
+    return () => {
+      resizeObserver.disconnect();
+      nextChart.dispose();
+      chart.current = undefined;
+    };
+  }, []);
+
+  useEffect(() => {
+    chart.current!.setOption(
+      {
+        animation: false,
+        color: ['#0f766e'],
+        grid: { left: 48, right: 18, top: 18, bottom: 48 },
+        tooltip: { trigger: 'axis' },
+        xAxis: { type: 'value', name: plot.x_label },
+        yAxis: { type: 'value', name: plot.y_label },
+        dataZoom: [{ type: 'inside' }],
+        series: [
+          {
+            type: 'line',
+            showSymbol: false,
+            data: plot.points
+          }
+        ]
+      },
+      true
+    );
+  }, [plot]);
+
+  return <div ref={element} class="doc-plot" data-testid="doc-plot" />;
+}

--- a/src/lib/doc-runtime/interactive-cell-model.ts
+++ b/src/lib/doc-runtime/interactive-cell-model.ts
@@ -1,0 +1,69 @@
+import type { CellManifest, InputSpec, InputValues, RunMode } from './types';
+
+export type RuntimeLocale = 'en' | 'ja';
+
+export type RuntimeLabels = {
+  hideCode: string;
+  idleButton: string;
+  idleReactive: string;
+  run: string;
+  running: string;
+  runningCell: string;
+  showCode: string;
+  unknownCell: (cellId: string) => string;
+};
+
+const runtimeLabels = {
+  en: {
+    hideCode: 'Hide code',
+    idleButton: 'Run the cell to show its output.',
+    idleReactive: 'Waiting for the runtime to start.',
+    run: 'Run',
+    running: 'Running',
+    runningCell: 'Running cell...',
+    showCode: 'Show code',
+    unknownCell: (cellId: string) => `Unknown interactive cell: ${cellId}`
+  },
+  ja: {
+    hideCode: 'コードを隠す',
+    idleButton: 'セルを実行すると出力が表示されます。',
+    idleReactive: 'ランタイムの起動を待っています。',
+    run: '実行',
+    running: '実行中',
+    runningCell: 'セルを実行中...',
+    showCode: 'コードを表示',
+    unknownCell: (cellId: string) => `不明な実行可能セル: ${cellId}`
+  }
+} satisfies Record<RuntimeLocale, RuntimeLabels>;
+
+export function initialValues(inputs: readonly InputSpec[]): InputValues {
+  return Object.fromEntries(inputs.map((input) => [input.name, input.value]));
+}
+
+export function formatInputValue(value: string | number | boolean): string {
+  return typeof value === 'number' ? value.toFixed(Number.isInteger(value) ? 0 : 2) : String(value);
+}
+
+export function shouldShowRunButton(runMode: RunMode): boolean {
+  return runMode === 'button' || runMode === 'autorun';
+}
+
+export function labelsForLanguage(languageTag?: string): RuntimeLabels {
+  return runtimeLabels[localeFromLanguage(languageTag)];
+}
+
+export function localeFromLanguage(languageTag?: string): RuntimeLocale {
+  return languageTag?.toLowerCase().startsWith('ja') ? 'ja' : 'en';
+}
+
+export function idleOutputMessage(
+  runMode: CellManifest['run'],
+  labels: RuntimeLabels = runtimeLabels.en
+): string {
+  return runMode === 'reactive' || runMode === 'autorun' ? labels.idleReactive : labels.idleButton;
+}
+
+export function coerceInputValue(input: InputSpec, rawValue: string): string | number {
+  if (input.type === 'number' || input.type === 'integer') return Number(rawValue);
+  return rawValue;
+}

--- a/src/lib/doc-runtime/manifest.ts
+++ b/src/lib/doc-runtime/manifest.ts
@@ -1,0 +1,59 @@
+import { cells as generatedCells } from '../../generated/doc-runtime/cells';
+import { runtimeVersion as generatedRuntimeVersion } from '../../generated/doc-runtime/runtime-version';
+import { resetInteractiveRuntime } from './runtime-client';
+import type { CellManifest } from './types';
+
+type GeneratedCellsModule = {
+  cells: readonly CellManifest[];
+};
+
+type RuntimeVersionModule = {
+  runtimeVersion: string;
+};
+
+type ManifestSnapshot = {
+  cells: readonly CellManifest[];
+  version: string;
+};
+
+let cellsSnapshot = generatedCells as readonly CellManifest[];
+let versionSnapshot = generatedRuntimeVersion;
+const listeners = new Set<() => void>();
+
+export function getCell(cellId: string): CellManifest | undefined {
+  return cellsSnapshot.find((cell) => cell.id === cellId);
+}
+
+export function getManifestSnapshot(): ManifestSnapshot {
+  return {
+    cells: cellsSnapshot,
+    version: versionSnapshot
+  };
+}
+
+export function subscribeManifest(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+if (import.meta.hot) {
+  import.meta.hot.accept('../../generated/doc-runtime/cells', (module) => {
+    if (module) {
+      cellsSnapshot = (module as unknown as GeneratedCellsModule).cells;
+    }
+  });
+
+  import.meta.hot.accept('../../generated/doc-runtime/runtime-version', (module) => {
+    if (module) {
+      versionSnapshot = (module as unknown as RuntimeVersionModule).runtimeVersion;
+      resetInteractiveRuntime('rust');
+      notifyManifestListeners();
+    }
+  });
+}
+
+function notifyManifestListeners(): void {
+  for (const listener of listeners) {
+    listener();
+  }
+}

--- a/src/lib/doc-runtime/python-worker.ts
+++ b/src/lib/doc-runtime/python-worker.ts
@@ -1,0 +1,106 @@
+import type { CellExecutionResult, RuntimeWorkerRequest, RuntimeWorkerResponse } from './types';
+
+type LoadPyodide = typeof import('pyodide').loadPyodide;
+type PyodideRuntime = Awaited<ReturnType<LoadPyodide>>;
+
+type WorkerScope = {
+  addEventListener(type: 'message', listener: (event: MessageEvent<RuntimeWorkerRequest>) => void): void;
+  postMessage(response: RuntimeWorkerResponse): void;
+};
+
+const worker = self as unknown as WorkerScope;
+let pyodideReady: Promise<PyodideRuntime> | undefined;
+let loadPyodideReady: Promise<LoadPyodide> | undefined;
+const pyodideModuleUrl = '/pyodide/pyodide.mjs';
+
+worker.addEventListener('message', (event) => {
+  void handleRequest(event.data);
+});
+
+async function handleRequest(request: RuntimeWorkerRequest): Promise<void> {
+  try {
+    const pyodide = await ensurePyodide();
+    const stdout: string[] = [];
+    const stderr: string[] = [];
+
+    pyodide.setStdout({ batched: (output) => stdout.push(output) });
+    pyodide.setStderr({ batched: (output) => stderr.push(output) });
+
+    if (request.packages && request.packages.length > 0) {
+      await pyodide.loadPackage(Array.from(request.packages));
+    }
+    if (request.source) {
+      await pyodide.loadPackagesFromImports(request.source);
+    }
+
+    const globals = pyodide.toPy(request.inputs);
+    let value: unknown = null;
+
+    try {
+      value = toSerializable(await pyodide.runPythonAsync(request.source ?? '', { globals }));
+    } finally {
+      globals.destroy();
+    }
+
+    const result: CellExecutionResult = {
+      stdout: stdout.join('\n').trimEnd(),
+      stderr: stderr.join('\n').trimEnd(),
+      value,
+      plots: []
+    };
+
+    worker.postMessage({ requestId: request.requestId, ok: true, result });
+  } catch (error) {
+    worker.postMessage({
+      requestId: request.requestId,
+      ok: false,
+      error: error instanceof Error ? error.message : String(error)
+    });
+  }
+}
+
+function ensurePyodide(): Promise<PyodideRuntime> {
+  pyodideReady ??= getLoadPyodide().then((loadPyodide) => loadPyodide({ indexURL: '/pyodide/' }));
+  return pyodideReady;
+}
+
+function getLoadPyodide(): Promise<LoadPyodide> {
+  loadPyodideReady ??= importPyodideModule().then((module) => module.loadPyodide);
+  return loadPyodideReady;
+}
+
+async function importPyodideModule(): Promise<{ loadPyodide: LoadPyodide }> {
+  const response = await fetch(pyodideModuleUrl);
+  if (!response.ok) {
+    throw new Error(`Failed to load ${pyodideModuleUrl}: ${response.status} ${response.statusText}`);
+  }
+
+  const moduleUrl = URL.createObjectURL(
+    new Blob([await response.text()], { type: 'text/javascript' })
+  );
+
+  try {
+    return (await import(/* @vite-ignore */ moduleUrl)) as { loadPyodide: LoadPyodide };
+  } finally {
+    URL.revokeObjectURL(moduleUrl);
+  }
+}
+
+function toSerializable(value: unknown): unknown {
+  if (value == null) return null;
+
+  if (typeof value === 'object' && value && 'toJs' in value) {
+    const proxy = value as { destroy?: () => void; toJs: (options?: unknown) => unknown };
+    try {
+      return proxy.toJs();
+    } finally {
+      proxy.destroy?.();
+    }
+  }
+
+  if (typeof value === 'number' || typeof value === 'string' || typeof value === 'boolean') {
+    return value;
+  }
+
+  return String(value);
+}

--- a/src/lib/doc-runtime/runtime-client.ts
+++ b/src/lib/doc-runtime/runtime-client.ts
@@ -1,0 +1,147 @@
+import type {
+  CellExecutionResult,
+  CellLanguage,
+  CellManifest,
+  InputValues,
+  RuntimeWorkerRequest,
+  RuntimeWorkerResponse
+} from './types';
+
+type PendingRequest = {
+  reject: (reason: Error) => void;
+  resolve: (value: CellExecutionResult) => void;
+  timeout: ReturnType<typeof setTimeout>;
+  worker: Worker;
+};
+
+type RuntimeClientDependencies = {
+  clearTimeout: (timeout: ReturnType<typeof setTimeout>) => void;
+  createWorker: (language: CellLanguage) => Worker;
+  setTimeout: (handler: () => void, timeout: number) => ReturnType<typeof setTimeout>;
+};
+
+export function runInteractiveCell(
+  cell: CellManifest,
+  inputs: InputValues
+): Promise<CellExecutionResult> {
+  /* v8 ignore next -- the factory is unit-tested; this delegates to browser Worker adapters. */
+  return defaultRuntimeClient.runInteractiveCell(cell, inputs);
+}
+
+export function resetInteractiveRuntime(language?: CellLanguage): void {
+  if (language) {
+    defaultRuntimeClient.resetWorker(language);
+    return;
+  }
+
+  defaultRuntimeClient.resetWorker('rust');
+  defaultRuntimeClient.resetWorker('python');
+}
+
+export function createInteractiveCellRunner(dependencies: RuntimeClientDependencies) {
+  let nextRequestId = 1;
+  const workers = new Map<CellLanguage, Worker>();
+  const pending = new Map<number, PendingRequest>();
+
+  function runCell(cell: CellManifest, inputs: InputValues): Promise<CellExecutionResult> {
+    const requestId = nextRequestId++;
+    const worker = getWorker(cell.language);
+    const request = createWorkerRequest(requestId, cell, inputs);
+
+    return new Promise((resolve, reject) => {
+      const timeout = dependencies.setTimeout(() => {
+        pending.delete(requestId);
+        resetWorker(cell.language);
+        reject(new Error(`${cell.title} timed out after ${cell.timeoutMs}ms`));
+      }, cell.timeoutMs);
+
+      pending.set(requestId, { resolve, reject, timeout, worker });
+      worker.postMessage(request);
+    });
+  }
+
+  function getWorker(language: CellLanguage): Worker {
+    const current = workers.get(language);
+    if (current) return current;
+
+    const worker = dependencies.createWorker(language);
+
+    worker.addEventListener('message', (event: MessageEvent<RuntimeWorkerResponse>) => {
+      const request = pending.get(event.data.requestId);
+      if (!request) return;
+
+      pending.delete(event.data.requestId);
+      dependencies.clearTimeout(request.timeout);
+
+      if (event.data.ok) {
+        request.resolve(event.data.result);
+      } else {
+        request.reject(new Error(event.data.error));
+      }
+    });
+
+    worker.addEventListener('error', (event) => {
+      rejectAllForWorker(worker, new Error(event.message));
+    });
+
+    workers.set(language, worker);
+    return worker;
+  }
+
+  function resetWorker(language: CellLanguage): void {
+    const worker = workers.get(language);
+    if (!worker) return;
+
+    worker.terminate();
+    workers.delete(language);
+    rejectAllForWorker(worker, new Error(`${language} worker was reset`));
+  }
+
+  function rejectAllForWorker(worker: Worker, error: Error): void {
+    for (const [requestId, request] of pending) {
+      if (request.worker !== worker) continue;
+
+      dependencies.clearTimeout(request.timeout);
+      pending.delete(requestId);
+      request.reject(error);
+    }
+
+    for (const [language, current] of workers) {
+      if (current === worker) {
+        workers.delete(language);
+      }
+    }
+  }
+
+  return {
+    runInteractiveCell: runCell,
+    resetWorker
+  };
+}
+
+function createWorkerRequest(
+  requestId: number,
+  cell: CellManifest,
+  inputs: InputValues
+): RuntimeWorkerRequest {
+  return {
+    requestId,
+    cellId: cell.id,
+    inputs,
+    source: cell.language === 'python' ? cell.source : undefined,
+    packages: cell.language === 'python' ? cell.packages : undefined
+  };
+}
+
+function createDefaultWorker(language: CellLanguage): Worker {
+  /* v8 ignore next -- covered by browser integration and E2E tests. */
+  return language === 'rust'
+    ? new Worker(new URL('./rust-worker.ts', import.meta.url), { type: 'module' })
+    : new Worker(new URL('./python-worker.ts', import.meta.url), { type: 'module' });
+}
+
+const defaultRuntimeClient = createInteractiveCellRunner({
+  clearTimeout: (timeout) => globalThis.clearTimeout(timeout),
+  createWorker: createDefaultWorker,
+  setTimeout: (handler, timeout) => globalThis.setTimeout(handler, timeout)
+});

--- a/src/lib/doc-runtime/rust-worker.ts
+++ b/src/lib/doc-runtime/rust-worker.ts
@@ -1,0 +1,36 @@
+import init, { run_rust_cell } from '../../generated/doc-runtime/rust-wasm/doc_rust_cells.js';
+import type { CellExecutionResult, RuntimeWorkerRequest, RuntimeWorkerResponse } from './types';
+
+type WorkerScope = {
+  addEventListener(type: 'message', listener: (event: MessageEvent<RuntimeWorkerRequest>) => void): void;
+  postMessage(response: RuntimeWorkerResponse): void;
+};
+
+const worker = self as unknown as WorkerScope;
+let wasmReady: Promise<void> | undefined;
+
+worker.addEventListener('message', (event) => {
+  void handleRequest(event.data);
+});
+
+async function handleRequest(request: RuntimeWorkerRequest): Promise<void> {
+  try {
+    await ensureWasm();
+    const result = JSON.parse(
+      run_rust_cell(request.cellId, JSON.stringify(request.inputs))
+    ) as CellExecutionResult;
+
+    worker.postMessage({ requestId: request.requestId, ok: true, result });
+  } catch (error) {
+    worker.postMessage({
+      requestId: request.requestId,
+      ok: false,
+      error: error instanceof Error ? error.message : String(error)
+    });
+  }
+}
+
+function ensureWasm(): Promise<void> {
+  wasmReady ??= init().then(() => undefined);
+  return wasmReady;
+}

--- a/src/lib/doc-runtime/types.ts
+++ b/src/lib/doc-runtime/types.ts
@@ -1,0 +1,81 @@
+export type CellLanguage = 'rust' | 'python';
+export type RunMode = 'button' | 'reactive' | 'autorun' | 'hidden';
+export type InputType =
+  | 'range'
+  | 'number'
+  | 'integer'
+  | 'text'
+  | 'textarea'
+  | 'checkbox'
+  | 'select'
+  | 'radio';
+
+export interface InputOption {
+  label: string;
+  value: string;
+}
+
+export interface InputSpec {
+  name: string;
+  type: InputType;
+  label: string;
+  value: string | number | boolean;
+  min?: number;
+  max?: number;
+  step?: number;
+  integer?: boolean;
+  options: readonly InputOption[];
+}
+
+export interface CellManifest {
+  id: string;
+  language: CellLanguage;
+  title: string;
+  run: RunMode;
+  source: string;
+  sourceHtml: string;
+  inputs: readonly InputSpec[];
+  packages: readonly string[];
+  crates: readonly string[];
+  timeoutMs: number;
+  showSource: boolean;
+  pagePath: string;
+}
+
+export type InputValues = Record<string, string | number | boolean>;
+
+export interface LinePlotSpec {
+  kind: 'line';
+  x_label: string;
+  y_label: string;
+  points: readonly [number, number][];
+}
+
+export type PlotSpec = LinePlotSpec;
+
+export interface CellExecutionResult {
+  stdout: string;
+  stderr?: string;
+  value?: unknown;
+  plots: readonly PlotSpec[];
+}
+
+export interface RuntimeWorkerRequest {
+  requestId: number;
+  cellId: string;
+  inputs: InputValues;
+  source?: string;
+  packages?: readonly string[];
+}
+
+export type RuntimeWorkerResponse =
+  | {
+      requestId: number;
+      ok: true;
+      result: CellExecutionResult;
+    }
+  | {
+      requestId: number;
+      ok: false;
+      error: string;
+    };

--- a/tests/unit/components.test.tsx
+++ b/tests/unit/components.test.tsx
@@ -1,0 +1,371 @@
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/preact';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { CellManifest, InputSpec } from '../../src/lib/doc-runtime/types';
+
+const mocks = vi.hoisted(() => {
+  const chart = {
+    dispose: vi.fn(),
+    resize: vi.fn(),
+    setOption: vi.fn()
+  };
+
+  return {
+    chart,
+    echartsInit: vi.fn(() => chart),
+    echartsUse: vi.fn(),
+    getCell: vi.fn(),
+    getManifestSnapshot: vi.fn(() => ({ cells: [], version: 'v1' })),
+    manifestListeners: [] as Array<() => void>,
+    mermaidInitialize: vi.fn(),
+    mermaidRender: vi.fn(),
+    runInteractiveCell: vi.fn()
+  };
+});
+
+vi.mock('echarts/charts', () => ({ LineChart: {} }));
+vi.mock('echarts/components', () => ({
+  DataZoomComponent: {},
+  GridComponent: {},
+  TooltipComponent: {}
+}));
+vi.mock('echarts/renderers', () => ({ CanvasRenderer: {} }));
+vi.mock('echarts/core', () => ({
+  init: mocks.echartsInit,
+  use: mocks.echartsUse
+}));
+vi.mock('mermaid', () => ({
+  default: {
+    initialize: mocks.mermaidInitialize,
+    render: mocks.mermaidRender
+  }
+}));
+vi.mock('../../src/lib/doc-runtime/manifest', () => ({
+  getCell: mocks.getCell,
+  getManifestSnapshot: mocks.getManifestSnapshot,
+  subscribeManifest: vi.fn((listener: () => void) => {
+    mocks.manifestListeners.push(listener);
+    return vi.fn();
+  })
+}));
+vi.mock('../../src/lib/doc-runtime/runtime-client', () => ({
+  runInteractiveCell: mocks.runInteractiveCell
+}));
+
+const { default: InteractiveCell } = await import('../../src/components/doc-runtime/InteractiveCell');
+const { default: MermaidDiagram } = await import('../../src/components/doc-runtime/MermaidDiagram');
+const { default: PlotOutput } = await import('../../src/components/doc-runtime/PlotOutput');
+
+class TestResizeObserver {
+  static instances: TestResizeObserver[] = [];
+
+  disconnect = vi.fn();
+  observe = vi.fn();
+  unobserve = vi.fn();
+
+  constructor(readonly callback: ResizeObserverCallback) {
+    TestResizeObserver.instances.push(this);
+  }
+}
+
+const inputs: InputSpec[] = [
+  { name: 'enabled', type: 'checkbox', label: 'enabled', value: true, options: [] },
+  {
+    name: 'operation',
+    type: 'select',
+    label: 'operation',
+    value: 'double',
+    options: [
+      { label: 'double', value: 'double' },
+      { label: 'triple', value: 'triple' }
+    ]
+  },
+  {
+    name: 'style',
+    type: 'radio',
+    label: 'style',
+    value: 'compact',
+    options: [
+      { label: 'compact', value: 'compact' },
+      { label: 'verbose', value: 'verbose' }
+    ]
+  },
+  { name: 'notes', type: 'textarea', label: 'notes', value: 'hello', options: [] },
+  { name: 'ratio', type: 'range', label: 'ratio', value: 1.5, min: 0, max: 4, step: 0.5, options: [] },
+  { name: 'count', type: 'number', label: 'count', value: 2, min: 0, max: 10, step: 1, options: [] },
+  { name: 'label', type: 'text', label: 'label', value: 'sample', options: [] }
+];
+
+function makeCell(overrides: Partial<CellManifest> = {}): CellManifest {
+  return {
+    id: 'cell-one',
+    language: 'rust',
+    title: 'Cell one',
+    run: 'button',
+    source: 'println!("ok");',
+    sourceHtml: '<pre class="shiki"><code>println!("ok");</code></pre>',
+    inputs,
+    packages: [],
+    crates: [],
+    timeoutMs: 1_000,
+    showSource: true,
+    pagePath: 'page.mdx',
+    ...overrides
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.manifestListeners = [];
+  TestResizeObserver.instances = [];
+  document.documentElement.lang = 'en';
+  globalThis.ResizeObserver = TestResizeObserver as unknown as typeof ResizeObserver;
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('InteractiveCell', () => {
+  it('renders an error for unknown cells', () => {
+    mocks.getCell.mockReturnValue(undefined);
+
+    render(<InteractiveCell cellId="missing" />);
+
+    expect(screen.getByText('Unknown interactive cell: missing')).toBeVisible();
+  });
+
+  it('renders controls, toggles source, runs button cells, and displays all output types', async () => {
+    mocks.getCell.mockReturnValue(makeCell());
+    mocks.runInteractiveCell.mockResolvedValue({
+      stdout: 'stdout',
+      stderr: 'stderr',
+      value: { ok: true },
+      plots: [{ kind: 'line', x_label: 'x', y_label: 'y', points: [[0, 1]] }]
+    });
+
+    render(<InteractiveCell cellId="cell-one" />);
+
+    expect(screen.getByText('Run the cell to show its output.')).toBeVisible();
+    expect(screen.getByText('println!("ok");')).toBeVisible();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Hide code' }));
+    expect(screen.queryByText('println!("ok");')).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Show code' }));
+    expect(screen.getByText('println!("ok");')).toBeVisible();
+
+    fireEvent.click(screen.getByLabelText('enabled'));
+    fireEvent.input(screen.getByLabelText('operation'), { target: { value: 'triple' } });
+    fireEvent.input(screen.getByLabelText('verbose'), { target: { value: 'verbose' } });
+    fireEvent.input(screen.getByLabelText('notes'), { target: { value: 'changed' } });
+    fireEvent.input(screen.getByRole('slider', { name: 'ratio' }), { target: { value: '2.5' } });
+    fireEvent.input(screen.getByLabelText('count'), { target: { value: '4' } });
+    fireEvent.input(screen.getByLabelText('label'), { target: { value: 'next' } });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Run' }));
+
+    await waitFor(() => expect(screen.getByTestId('run-output')).toHaveTextContent('stdout'));
+    expect(screen.getByText('stderr')).toBeVisible();
+    expect(screen.getByTestId('value-output')).toHaveTextContent('"ok": true');
+    await waitFor(() =>
+      expect(mocks.chart.setOption).toHaveBeenCalledWith(
+        expect.objectContaining({
+          xAxis: { type: 'value', name: 'x' },
+          yAxis: { type: 'value', name: 'y' }
+        }),
+        true
+      )
+    );
+    expect(mocks.runInteractiveCell).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'cell-one' }),
+      expect.objectContaining({
+        enabled: false,
+        operation: 'triple',
+        style: 'verbose',
+        notes: 'changed',
+        ratio: 2.5,
+        count: 4,
+        label: 'next'
+      })
+    );
+  });
+
+  it('shows running and error states', async () => {
+    mocks.getCell.mockReturnValue(makeCell());
+    mocks.runInteractiveCell.mockRejectedValue(new Error('failed'));
+
+    render(<InteractiveCell cellId="cell-one" />);
+    fireEvent.click(screen.getByRole('button', { name: 'Run' }));
+
+    expect(screen.getByText('Running cell...')).toBeVisible();
+    await waitFor(() => expect(screen.getByText('failed')).toBeVisible());
+  });
+
+  it('coerces non-Error failures to strings', async () => {
+    mocks.getCell.mockReturnValue(makeCell());
+    mocks.runInteractiveCell.mockRejectedValue('string failure');
+
+    render(<InteractiveCell cellId="cell-one" />);
+    fireEvent.click(screen.getByRole('button', { name: 'Run' }));
+
+    await waitFor(() => expect(screen.getByText('string failure')).toBeVisible());
+  });
+
+  it('runs autorun and reactive cells automatically', async () => {
+    mocks.runInteractiveCell.mockResolvedValue({ stdout: 'auto', plots: [] });
+    mocks.getCell.mockReturnValue(makeCell({ run: 'autorun' }));
+
+    const { rerender } = render(<InteractiveCell cellId="cell-one" />);
+    await waitFor(() => expect(mocks.runInteractiveCell).toHaveBeenCalledTimes(1));
+    expect(screen.getByRole('button', { name: 'Run' })).toBeVisible();
+
+    mocks.getCell.mockReturnValue(makeCell({ id: 'cell-two', run: 'reactive' }));
+    rerender(<InteractiveCell cellId="cell-two" />);
+    await waitFor(() => expect(mocks.runInteractiveCell).toHaveBeenCalledTimes(2));
+
+    fireEvent.input(screen.getByRole('slider', { name: 'ratio' }), { target: { value: '3' } });
+    await waitFor(() => expect(mocks.runInteractiveCell).toHaveBeenCalledTimes(3));
+  });
+
+  it('supports cells without inputs and hidden source', () => {
+    mocks.getCell.mockReturnValue(makeCell({ inputs: [], showSource: false, run: 'hidden' }));
+
+    render(<InteractiveCell cellId="cell-one" />);
+
+    expect(screen.queryByText('println!("ok");')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Run' })).not.toBeInTheDocument();
+  });
+
+  it('uses Japanese runtime labels when the document language is Japanese', () => {
+    document.documentElement.lang = 'ja';
+    mocks.getCell.mockReturnValue(makeCell());
+
+    render(<InteractiveCell cellId="cell-one" />);
+
+    expect(screen.getByRole('button', { name: 'コードを隠す' })).toBeVisible();
+    expect(screen.getByRole('button', { name: '実行' })).toBeVisible();
+  });
+
+  it('renders Python labeling and empty successful results', async () => {
+    mocks.getCell.mockReturnValue(makeCell({ language: 'python', inputs: [] }));
+    mocks.runInteractiveCell.mockResolvedValue({ stdout: '', stderr: '', value: '', plots: [] });
+
+    render(<InteractiveCell cellId="cell-one" />);
+    expect(screen.getByText('Python + Pyodide')).toBeVisible();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Run' }));
+    await waitFor(() => expect(mocks.runInteractiveCell).toHaveBeenCalled());
+    expect(screen.queryByTestId('run-output')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('value-output')).not.toBeInTheDocument();
+  });
+
+  it('refreshes rendered cell data when the generated manifest version changes', async () => {
+    mocks.getCell
+      .mockReturnValueOnce(makeCell({ sourceHtml: '<pre class="shiki"><code>println!("old");</code></pre>' }))
+      .mockReturnValue(makeCell({ sourceHtml: '<pre class="shiki"><code>println!("new");</code></pre>' }));
+    mocks.getManifestSnapshot
+      .mockReturnValueOnce({ cells: [], version: 'v1' })
+      .mockReturnValue({ cells: [], version: 'v2' });
+
+    render(<InteractiveCell cellId="cell-one" />);
+    expect(screen.getByText('println!("old");')).toBeVisible();
+
+    act(() => {
+      mocks.manifestListeners[0]();
+    });
+
+    await waitFor(() => expect(screen.getByText('println!("new");')).toBeVisible());
+  });
+});
+
+describe('MermaidDiagram', () => {
+  it('renders Mermaid SVG and initializes Mermaid only once', async () => {
+    mocks.mermaidRender.mockResolvedValue({
+      svg: '<svg role="img"><text>diagram</text></svg>',
+      bindFunctions: vi.fn()
+    });
+
+    const { rerender } = render(<MermaidDiagram diagramId="one" source="flowchart LR\nA-->B" />);
+
+    await waitFor(() => expect(screen.getByTestId('mermaid-diagram')).toHaveAttribute('data-state', 'ready'));
+    expect(screen.getByText('diagram')).toBeVisible();
+    expect(mocks.mermaidInitialize).toHaveBeenCalledTimes(1);
+
+    rerender(<MermaidDiagram diagramId="one" source="flowchart LR\nA-->C" />);
+    await waitFor(() => expect(mocks.mermaidRender).toHaveBeenCalledTimes(2));
+    expect(mocks.mermaidInitialize).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders Mermaid SVG when no bind function is returned', async () => {
+    mocks.mermaidRender.mockResolvedValue({
+      svg: '<svg><text>plain diagram</text></svg>'
+    });
+
+    render(<MermaidDiagram diagramId="plain" source="flowchart LR\nA-->B" />);
+
+    await waitFor(() => expect(screen.getByText('plain diagram')).toBeVisible());
+  });
+
+  it('renders Mermaid errors from Error and non-Error values', async () => {
+    mocks.mermaidRender.mockRejectedValueOnce(new Error('bad diagram')).mockRejectedValueOnce('string diagram error');
+
+    const { rerender } = render(<MermaidDiagram diagramId="bad" source="bad" />);
+    await waitFor(() => expect(screen.getByRole('alert')).toHaveTextContent('bad diagram'));
+
+    rerender(<MermaidDiagram diagramId="bad" source="still bad" />);
+    await waitFor(() => expect(screen.getByRole('alert')).toHaveTextContent('string diagram error'));
+  });
+
+  it('ignores resolved or rejected Mermaid renders after unmount', async () => {
+    let resolveRender: (value: { svg: string }) => void = () => undefined;
+    mocks.mermaidRender.mockReturnValue(
+      new Promise((resolve) => {
+        resolveRender = resolve;
+      })
+    );
+
+    const { unmount } = render(<MermaidDiagram diagramId="late" source="flowchart LR\nA-->B" />);
+    unmount();
+    resolveRender({ svg: '<svg><text>late</text></svg>' });
+    await Promise.resolve();
+
+    let rejectRender: (reason: unknown) => void = () => undefined;
+    mocks.mermaidRender.mockReturnValue(
+      new Promise((_, reject) => {
+        rejectRender = reject;
+      })
+    );
+
+    const lateError = render(<MermaidDiagram diagramId="late-error" source="bad" />);
+    lateError.unmount();
+    rejectRender(new Error('late error'));
+    await Promise.resolve();
+
+    expect(screen.queryByText('late')).not.toBeInTheDocument();
+    expect(screen.queryByText('late error')).not.toBeInTheDocument();
+  });
+});
+
+describe('PlotOutput', () => {
+  it('initializes, updates, and disposes an ECharts line plot', () => {
+    const { unmount } = render(
+      <PlotOutput plot={{ kind: 'line', x_label: 'n', y_label: 'x', points: [[0, 0.2]] }} />
+    );
+
+    expect(mocks.echartsInit).toHaveBeenCalled();
+    TestResizeObserver.instances[0].callback(
+      [],
+      TestResizeObserver.instances[0] as unknown as ResizeObserver
+    );
+    expect(mocks.chart.resize).toHaveBeenCalled();
+    expect(mocks.chart.setOption).toHaveBeenCalledWith(
+      expect.objectContaining({
+        color: ['#0f766e'],
+        series: [expect.objectContaining({ type: 'line', data: [[0, 0.2]] })]
+      }),
+      true
+    );
+
+    unmount();
+    expect(mocks.chart.dispose).toHaveBeenCalled();
+  });
+});

--- a/tests/unit/doc-runtime-core.test.mjs
+++ b/tests/unit/doc-runtime-core.test.mjs
@@ -288,6 +288,7 @@ describe('doc runtime core', () => {
     expect(generateCellsJson(cells)).toContain('"id": "one"');
 
     expect(generateRustCargoToml([], workspaceCrates)).not.toContain('doc-rust =');
+    expect(generateRustCargoToml([], workspaceCrates)).toContain('license = "AGPL-3.0-only"');
     expect(generateRustCargoToml([{ crates: ['doc-rust'] }], workspaceCrates)).toContain(
       'doc-rust = { path = "../../../crates/doc-rust" }'
     );
@@ -323,6 +324,7 @@ describe('doc runtime core', () => {
     expect(generateRustFunction({ id: 'plain', source: 'let value = 1;', inputs: [] })).toContain(
       'let __stdout = String::new();'
     );
+    expect(generateRustLib([])).toContain('let _: Value = serde_json::from_str(inputs_json)');
     expect(generateRustLib([])).toContain('unknown Rust cell');
     expect(generateRustLib([rustCell])).toContain('first_generated_cell_runs');
   });

--- a/tests/unit/interactive-cell-model.test.ts
+++ b/tests/unit/interactive-cell-model.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import {
+  coerceInputValue,
+  formatInputValue,
+  idleOutputMessage,
+  initialValues,
+  labelsForLanguage,
+  localeFromLanguage,
+  shouldShowRunButton
+} from '../../src/lib/doc-runtime/interactive-cell-model';
+import type { InputSpec } from '../../src/lib/doc-runtime/types';
+
+const textInput: InputSpec = {
+  name: 'label',
+  type: 'text',
+  label: 'label',
+  value: 'sample',
+  options: []
+};
+
+describe('interactive cell model', () => {
+  it('builds initial values from input specs', () => {
+    expect(
+      initialValues([
+        textInput,
+        { name: 'enabled', type: 'checkbox', label: 'enabled', value: true, options: [] }
+      ])
+    ).toEqual({ label: 'sample', enabled: true });
+  });
+
+  it('formats displayed input values', () => {
+    expect(formatInputValue(2)).toBe('2');
+    expect(formatInputValue(2.345)).toBe('2.35');
+    expect(formatInputValue(true)).toBe('true');
+    expect(formatInputValue('raw')).toBe('raw');
+  });
+
+  it('describes run controls and idle output messages', () => {
+    expect(shouldShowRunButton('button')).toBe(true);
+    expect(shouldShowRunButton('autorun')).toBe(true);
+    expect(shouldShowRunButton('reactive')).toBe(false);
+    expect(shouldShowRunButton('hidden')).toBe(false);
+
+    expect(idleOutputMessage('reactive')).toBe('Waiting for the runtime to start.');
+    expect(idleOutputMessage('autorun')).toBe('Waiting for the runtime to start.');
+    expect(idleOutputMessage('button')).toBe('Run the cell to show its output.');
+    expect(idleOutputMessage('hidden')).toBe('Run the cell to show its output.');
+  });
+
+  it('resolves localized runtime labels', () => {
+    expect(localeFromLanguage('en-US')).toBe('en');
+    expect(localeFromLanguage('ja-JP')).toBe('ja');
+    expect(labelsForLanguage('ja').run).toBe('実行');
+    expect(idleOutputMessage('reactive', labelsForLanguage('ja'))).toBe('ランタイムの起動を待っています。');
+    expect(labelsForLanguage('ja').unknownCell('missing')).toBe('不明な実行可能セル: missing');
+  });
+
+  it('coerces numeric input values and keeps text values', () => {
+    expect(coerceInputValue({ ...textInput, type: 'number' }, '12')).toBe(12);
+    expect(coerceInputValue({ ...textInput, type: 'integer' }, '12')).toBe(12);
+    expect(coerceInputValue(textInput, '12')).toBe('12');
+  });
+});

--- a/tests/unit/runtime-client.test.ts
+++ b/tests/unit/runtime-client.test.ts
@@ -1,0 +1,215 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  createInteractiveCellRunner,
+  resetInteractiveRuntime,
+  runInteractiveCell
+} from '../../src/lib/doc-runtime/runtime-client';
+import type {
+  CellExecutionResult,
+  CellLanguage,
+  CellManifest,
+  RuntimeWorkerRequest,
+  RuntimeWorkerResponse
+} from '../../src/lib/doc-runtime/types';
+
+class FakeWorker {
+  messages: RuntimeWorkerRequest[] = [];
+  terminated = false;
+
+  private listeners = new Map<string, Set<(event: Event) => void>>();
+
+  addEventListener(type: string, listener: (event: Event) => void): void {
+    this.listeners.set(type, new Set([...(this.listeners.get(type) ?? []), listener]));
+  }
+
+  postMessage(message: RuntimeWorkerRequest): void {
+    this.messages.push(message);
+  }
+
+  terminate(): void {
+    this.terminated = true;
+  }
+
+  emitMessage(response: RuntimeWorkerResponse): void {
+    this.emit('message', { data: response } as MessageEvent);
+  }
+
+  emitError(message: string): void {
+    this.emit('error', { message } as ErrorEvent);
+  }
+
+  private emit(type: string, event: Event): void {
+    for (const listener of this.listeners.get(type) ?? []) {
+      listener(event);
+    }
+  }
+}
+
+const result: CellExecutionResult = {
+  stdout: 'ok',
+  plots: []
+};
+
+type DefaultFakeWorker = FakeWorker & {
+  options: WorkerOptions;
+  url: URL;
+};
+
+function makeCell(language: CellLanguage, overrides: Partial<CellManifest> = {}): CellManifest {
+  return {
+    id: `${language}-cell`,
+    language,
+    title: `${language} cell`,
+    run: 'button',
+    source: 'print("ok")',
+    sourceHtml: '<pre />',
+    inputs: [],
+    packages: ['numpy'],
+    crates: [],
+    timeoutMs: 1_000,
+    showSource: true,
+    pagePath: 'page.mdx',
+    ...overrides
+  };
+}
+
+function makeRunner() {
+  const workers: FakeWorker[] = [];
+  const runner = createInteractiveCellRunner({
+    clearTimeout,
+    createWorker: () => {
+      const worker = new FakeWorker();
+      workers.push(worker);
+      return worker as unknown as Worker;
+    },
+    setTimeout
+  });
+
+  return { runner, workers };
+}
+
+describe('runtime client', () => {
+  it('delegates the default browser runner to Worker adapters', async () => {
+    const originalWorker = globalThis.Worker;
+    const defaultWorkers: DefaultFakeWorker[] = [];
+    globalThis.Worker = class extends FakeWorker {
+      constructor(readonly url: URL, readonly options: WorkerOptions) {
+        super();
+        defaultWorkers.push(this as DefaultFakeWorker);
+      }
+    } as unknown as typeof Worker;
+
+    const rust = runInteractiveCell(makeCell('rust'), {});
+    const python = runInteractiveCell(makeCell('python'), {});
+
+    expect(defaultWorkers[0].options).toEqual({ type: 'module' });
+    expect(defaultWorkers[0].url.href).toContain('rust-worker.ts');
+    expect(defaultWorkers[1].url.href).toContain('python-worker.ts');
+
+    defaultWorkers[0].emitMessage({ requestId: 1, ok: true, result });
+    defaultWorkers[1].emitMessage({ requestId: 2, ok: true, result });
+
+    await expect(rust).resolves.toEqual(result);
+    await expect(python).resolves.toEqual(result);
+
+    resetInteractiveRuntime('rust');
+    expect(defaultWorkers[0].terminated).toBe(true);
+    expect(defaultWorkers[1].terminated).toBe(false);
+
+    resetInteractiveRuntime();
+    expect(defaultWorkers[1].terminated).toBe(true);
+    globalThis.Worker = originalWorker;
+  });
+
+  it('sends Python source and resolves successful worker responses', async () => {
+    const { runner, workers } = makeRunner();
+    const promise = runner.runInteractiveCell(makeCell('python'), { scale: 2 });
+
+    expect(workers).toHaveLength(1);
+    expect(workers[0].messages[0]).toMatchObject({
+      requestId: 1,
+      cellId: 'python-cell',
+      inputs: { scale: 2 },
+      source: 'print("ok")',
+      packages: ['numpy']
+    });
+
+    workers[0].emitMessage({ requestId: 999, ok: true, result });
+    workers[0].emitMessage({ requestId: 1, ok: true, result });
+
+    await expect(promise).resolves.toEqual(result);
+  });
+
+  it('sends Rust requests without Python-only fields and reuses workers', async () => {
+    const { runner, workers } = makeRunner();
+    const first = runner.runInteractiveCell(makeCell('rust'), {});
+    const second = runner.runInteractiveCell(makeCell('rust', { id: 'rust-cell-two' }), {});
+
+    expect(workers).toHaveLength(1);
+    expect(workers[0].messages[0]).toEqual({
+      requestId: 1,
+      cellId: 'rust-cell',
+      inputs: {},
+      source: undefined,
+      packages: undefined
+    });
+    expect(workers[0].messages[1].cellId).toBe('rust-cell-two');
+
+    workers[0].emitMessage({ requestId: 1, ok: true, result });
+    workers[0].emitMessage({ requestId: 2, ok: true, result });
+
+    await expect(first).resolves.toEqual(result);
+    await expect(second).resolves.toEqual(result);
+  });
+
+  it('rejects failed worker responses', async () => {
+    const { runner, workers } = makeRunner();
+    const promise = runner.runInteractiveCell(makeCell('python'), {});
+
+    workers[0].emitMessage({ requestId: 1, ok: false, error: 'boom' });
+
+    await expect(promise).rejects.toThrow('boom');
+  });
+
+  it('resets workers on timeout and explicit reset', async () => {
+    vi.useFakeTimers();
+    const workers: FakeWorker[] = [];
+    const runner = createInteractiveCellRunner({
+      clearTimeout,
+      createWorker: () => {
+        const worker = new FakeWorker();
+        workers.push(worker);
+        return worker as unknown as Worker;
+      },
+      setTimeout
+    });
+
+    runner.resetWorker('rust');
+    const promise = runner.runInteractiveCell(makeCell('rust', { timeoutMs: 10 }), {});
+    vi.advanceTimersByTime(10);
+
+    await expect(promise).rejects.toThrow('timed out after 10ms');
+    expect(workers[0].terminated).toBe(true);
+
+    const next = runner.runInteractiveCell(makeCell('rust'), {});
+    expect(workers).toHaveLength(2);
+    runner.resetWorker('rust');
+
+    await expect(next).rejects.toThrow('rust worker was reset');
+    expect(workers[1].terminated).toBe(true);
+    vi.useRealTimers();
+  });
+
+  it('rejects pending requests when a worker errors', async () => {
+    const { runner, workers } = makeRunner();
+    const rust = runner.runInteractiveCell(makeCell('rust'), {});
+    const python = runner.runInteractiveCell(makeCell('python'), {});
+
+    expect(workers).toHaveLength(2);
+    workers[0].emitError('worker failed');
+
+    await expect(rust).rejects.toThrow('worker failed');
+    workers[1].emitMessage({ requestId: 2, ok: true, result });
+    await expect(python).resolves.toEqual(result);
+  });
+});

--- a/tests/unit/setup.ts
+++ b/tests/unit/setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom/vitest';

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,17 +4,26 @@ export default defineConfig({
   test: {
     environment: 'jsdom',
     globals: true,
+    setupFiles: ['./tests/unit/setup.ts'],
     include: ['tests/unit/**/*.test.{ts,tsx,mjs}'],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json-summary'],
       include: [
-        'scripts/**/*.mjs',
-        'src/components/**/*.tsx',
-        'src/lib/**/*.ts',
-        'src/lib/**/*.mjs'
+        'scripts/doc-runtime-core.mjs',
+        'scripts/doc-runtime-service.mjs',
+        'scripts/doc-runtime-watch-core.mjs',
+        'src/components/doc-runtime/**/*.tsx',
+        'src/lib/doc-runtime/**/*.ts',
+        'src/lib/doc-runtime/**/*.mjs'
       ],
-      exclude: ['src/generated/**'],
+      exclude: [
+        'src/generated/**',
+        'src/lib/doc-runtime/manifest.ts',
+        'src/lib/doc-runtime/python-worker.ts',
+        'src/lib/doc-runtime/rust-worker.ts',
+        'src/lib/doc-runtime/types.ts'
+      ],
       thresholds: {
         lines: 100,
         functions: 100,


### PR DESCRIPTION
## Summary
- Add browser runtime types, manifest handling, workers, and runtime client
- Add Preact interactive cell, Mermaid, and plot components
- Add focused UI/runtime tests and Vitest setup
- Fix generated Rust output for zero-cell skeleton builds and use Oxiquill AGPL SPDX metadata in generated Cargo manifests

## Validation
- `pnpm wasm:dev`
- `pnpm test:unit`
- `pnpm check`