### PR TITLE
Finalize migration guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,23 +17,25 @@
 
 ## Project Shape
 
-- Oxiquill is being migrated from the `../note-test` documentation stack.
-- This repository currently contains a structure-first skeleton only. Do not add implementation code unless the migration task explicitly asks for it.
-- The intended stack is an Astro/Starlight documentation site with Preact runtime components, strict TypeScript, and Rust helper crates for generated interactive cells.
+- Oxiquill is a static Astro/Starlight documentation site with Preact runtime components, strict TypeScript, and Rust helper crates used by generated interactive cells.
 - Use `pnpm` for Node commands. The Rust toolchain is pinned in `rust-toolchain.toml`; do not change it casually.
+- Prefer the existing simple structure over new framework layers. Add abstractions only when they remove real duplication or clarify a shared boundary.
 
 ## Generated Files
 
 - Do not edit generated output directly: `src/generated/doc-runtime/**`, `public/pyodide/**`, `dist/**`, `coverage/**`, `test-results/**`, or `target/**`.
-- Add generation scripts and generated artifacts only when the real runtime implementation is migrated.
+- Regenerate runtime artifacts with the existing scripts: `pnpm docgen`, `pnpm wasm:dev`, `pnpm wasm:build`, or `pnpm build`, depending on the change.
 
 ## Coding Standards
 
-- Keep skeleton changes structural. Placeholder files should remain empty unless a future task migrates real behavior.
-- Preserve strict linting once implementation code is introduced.
-- Avoid broad rewrites while making focused migration changes. Match the established project shape before introducing new layers.
+- Keep code small, explicit, and easy to test. Prefer pure functions and data transformations where they fit the problem.
+- Preserve strict linting. Treat warnings as work to fix, not noise to suppress.
+- Do not silence lints without a narrow reason. Rust lint exceptions should use `#[expect(..., reason = "...")]`.
+- Avoid broad rewrites while making focused changes. Match local style before introducing a new pattern.
 
 ## Validation
 
-- During the skeleton phase, prefer structural checks such as `git status --short` and file layout inspection.
-- Run build, test, and lint commands only after the corresponding source, scripts, and test implementations have been migrated.
+- For frontend/runtime changes, run `pnpm test:unit` and `pnpm check`; use `pnpm test:unit:coverage` for covered logic changes.
+- For Rust changes, run `pnpm test:rust`, `pnpm lint:rust`, and `pnpm doc:rust`; use `pnpm test:rust:coverage` when behavior or coverage changes.
+- For interactive cell generation or Wasm runtime changes, run `pnpm wasm:dev` and `pnpm test:wasm`; add `pnpm test:e2e` for browser-facing behavior.
+- Run `pnpm test` before considering broad changes complete when practical.

--- a/README.ja.md
+++ b/README.ja.md
@@ -1,24 +1,141 @@
 # Oxiquill
 
-このリポジトリは現在、プロジェクトのスケルトンのみを含みます。ドキュメントサイトとしての構成とツール境界は用意されていますが、実装コード、ランタイム、スクリプト、テスト、サンプルノート、ヘルパークレートの中身はまだ移行していません。
+Rust、Python、数式、Mermaid 図、画像、PDF を同じ MDX ノートにまとめられる静的ドキュメントワークスペースです。Astro Starlight を土台にし、実行可能セルは Preact のランタイムコンポーネントで表示します。
 
-## 想定する構成
+ドキュメントは英語がrootです。日本語ページは `/ja/` 配下で公開します。
 
-- Astro/Starlight による静的ドキュメントサイト
-- 実行可能なドキュメントセル向けの Preact コンポーネント領域
-- 生成セルの読み込みとブラウザワーカー向けの TypeScript ランタイム領域
-- ドキュメント例から利用する Rust ヘルパークレートのワークスペース
-- 後続移行に備えた unit / e2e テスト領域
+このリポジトリの責務は公開用成果物 `dist/` を作るところまでです。配信、TLS、ドメイン、リバースプロキシは別レイヤーで扱います。
 
-## スケルトン方針
+## 主な機能
 
-現在のリポジトリは構造と設定のみを追跡します。生成物とローカルビルド成果物は無視します。
+- Rust セルをビルド時に WebAssembly 化してブラウザで実行
+- Python セルを Pyodide worker で実行
+- ECharts による折れ線グラフ出力
+- KaTeX によるインライン数式とブロック数式
+- Mermaid によるフローチャート、シーケンス図、状態遷移図
+- `public/media` から PNG、JPEG、PDF などを配信
+- 英語root、日本語 `/ja/` の多言語ドキュメント
+- Rust/TypeScript/Preact のテストと、生成物を除いた厳格なカバレッジゲート
 
-- `src/generated`
+## 前提
+
+- Node.js と `pnpm`
+- Rust toolchain `1.95.0`
+- `wasm-pack`
+- `cargo-llvm-cov`
+
+Rust toolchain と Wasm target は `rust-toolchain.toml` で固定しています。
+
+## セットアップ
+
+```sh
+pnpm install
+```
+
+開発サーバーを起動します。
+
+```sh
+pnpm dev
+```
+
+`pnpm dev` は初回に実行可能セルのランタイムを生成し、その後は MDX と Rust ソースを監視します。本文、通常コード、数式、Mermaid、メディアだけの変更は Astro の HMR だけで反映し、Python セルは manifest 更新だけ、Rust セルや `crates/*` の変更だけ Wasm rebuild を実行します。
+
+ランタイム監視と Astro を分けて起動したい場合は、次のコマンドを別々のターミナルで実行します。
+
+```sh
+pnpm dev:runtime
+pnpm dev:astro
+```
+
+静的サイトをビルドします。
+
+```sh
+pnpm build
+```
+
+ビルド済みサイトを確認します。
+
+```sh
+pnpm preview
+```
+
+## 執筆
+
+英語ページは `src/content/docs/**/*.mdx` に追加します。日本語ページは同じslugで `src/content/docs/ja/**/*.mdx` に追加します。共有する Rust ロジックは `crates/*` に置き、セルから `crates: [doc-rust]` のように参照します。
+
+Rust セルの例:
+
+````md
+```rust
+//| id: sample-rust
+//| title: Rust の計算例
+//| run: button
+//| crates: [doc-rust]
+let next = doc_rust::logistic_step(3.2, 0.2);
+println!("next = {next:.6}");
+```
+````
+
+Python セルの例:
+
+````md
+```python
+#| id: sample-python
+#| title: Python の計算例
+#| run: reactive
+#| inputs:
+#|   scale: { type: number, label: scale, min: 1, max: 10, step: 1, value: 2 }
+print(scale * 10)
+```
+````
+
+メディアの例:
+
+```md
+![PNGサンプル](/media/examples/sample.png)
+
+<iframe class="media-frame" src="/media/examples/sample.pdf" title="サンプルPDF"></iframe>
+```
+
+公開メディアは `public/media` に置きます。MDX からは `/media/...` のURLで参照できます。
+
+## 生成物
+
+`pnpm build` と `pnpm test` は `scripts/generate-doc-runtime.mjs` を実行します。この処理で MDX 内の Rust/Python セルを抽出し、次の生成物を作ります。
+
+- `src/generated/doc-runtime`
 - `public/pyodide`
 - `dist`
-- `coverage`
-- `test-results`
-- `target`
 
-実装の移行が完了するまでは、build / test / lint / runtime コマンドは未完成として扱います。
+これらは生成物なので直接編集しません。
+
+## テストとカバレッジ
+
+全体の検証:
+
+```sh
+pnpm test
+```
+
+個別の検証:
+
+```sh
+pnpm test:rust
+pnpm test:rust:coverage
+pnpm test:unit
+pnpm test:unit:coverage
+pnpm test:wasm
+pnpm test:e2e
+pnpm lint:rust
+pnpm check
+```
+
+`test:rust:coverage` は `cargo-llvm-cov` で Rust workspace の line/function/region 100% を要求します。`test:unit:coverage` は Vitest の V8 coverage で、生成物を除いた手書きの TypeScript/Preact/Node コアに 100% を要求します。
+
+## トラブルシュート
+
+- Rust セルの crate が見つからない場合は、`crates/*/Cargo.toml` の `package.name` とセルの `crates` 指定を一致させます。
+- Python セルが起動しない場合は、`public/pyodide` が生成されているか確認し、`pnpm wasm:dev` または `pnpm build` を実行します。
+- Mermaid 図が表示されない場合は、`pnpm build` で MDX の構文エラーを確認し、図のコードブロック言語が `mermaid` になっているか確認します。
+- メディアが表示されない場合は、ファイルが `public/media` 配下にあり、`/media/...` のURLで参照しているか確認します。
+- カバレッジが失敗した場合は、生成物ではなく対象ソースの未実行行を確認し、必要な正常系・失敗系テストを追加します。

--- a/README.md
+++ b/README.md
@@ -1,24 +1,141 @@
 # Oxiquill
 
-This repository is currently a project skeleton. It preserves the intended documentation-site layout and tooling boundaries, but it does not include the source runtime, scripts, tests, sample notes, or helper implementation code yet.
+A static documentation workspace for MDX notes that combine Rust, Python, math, Mermaid diagrams, and media files. It is built on Astro Starlight with Preact runtime components for executable cells.
 
-## Intended Shape
+English is the root documentation language. Japanese translations live under `/ja/`; see [README.ja.md](./README.ja.md).
 
-- Static Astro/Starlight documentation site
-- Preact runtime component area for interactive documentation cells
-- TypeScript runtime library area for generated-cell loading and browser workers
-- Rust workspace for helper crates used by documentation examples
-- Unit and end-to-end test directories prepared for later migration
+This repository is responsible for producing the static output in `dist/`. Hosting, TLS, domains, and reverse proxies are handled outside this project.
 
-## Skeleton Policy
+## Features
 
-The current repository tracks structure and configuration only. Generated output and local build artifacts are ignored:
+- Rust cells compiled to WebAssembly at build time and run in the browser
+- Python cells executed in a Pyodide worker
+- Line plot output rendered with ECharts
+- Inline and block math rendered with KaTeX
+- Mermaid flowcharts, sequence diagrams, and state diagrams
+- PNG, JPEG, PDF, and similar files served from `public/media`
+- English root docs with Japanese translations under `src/content/docs/ja`
+- Rust, TypeScript, Preact, and generated-runtime tests with strict coverage gates
 
-- `src/generated`
+## Requirements
+
+- Node.js and `pnpm`
+- Rust toolchain `1.95.0`
+- `wasm-pack`
+- `cargo-llvm-cov`
+
+The Rust toolchain and Wasm target are pinned by `rust-toolchain.toml`.
+
+## Setup
+
+```sh
+pnpm install
+```
+
+Start the development server:
+
+```sh
+pnpm dev
+```
+
+`pnpm dev` generates the executable-cell runtime on startup, then watches MDX and Rust sources. Prose, normal code, math, Mermaid, and media changes use Astro HMR. Python cell changes update the manifest. Rust cells and `crates/*` changes rebuild Wasm.
+
+To run the runtime watcher and Astro separately:
+
+```sh
+pnpm dev:runtime
+pnpm dev:astro
+```
+
+Build the static site:
+
+```sh
+pnpm build
+```
+
+Preview the built site:
+
+```sh
+pnpm preview
+```
+
+## Authoring
+
+Add English pages under `src/content/docs/**/*.mdx`. Add Japanese translations with the same slug under `src/content/docs/ja/**/*.mdx`. Shared Rust logic belongs in `crates/*` and can be referenced from cells with `crates: [doc-rust]`.
+
+Rust cell example:
+
+````md
+```rust
+//| id: sample-rust
+//| title: Rust calculation
+//| run: button
+//| crates: [doc-rust]
+let next = doc_rust::logistic_step(3.2, 0.2);
+println!("next = {next:.6}");
+```
+````
+
+Python cell example:
+
+````md
+```python
+#| id: sample-python
+#| title: Python calculation
+#| run: reactive
+#| inputs:
+#|   scale: { type: number, label: scale, min: 1, max: 10, step: 1, value: 2 }
+print(scale * 10)
+```
+````
+
+Media example:
+
+```md
+![PNG sample](/media/examples/sample.png)
+
+<iframe class="media-frame" src="/media/examples/sample.pdf" title="Sample PDF"></iframe>
+```
+
+Put public media files in `public/media`. They are served as-is and can be referenced from MDX with `/media/...` URLs.
+
+## Generated Files
+
+`pnpm build` and `pnpm test` run `scripts/generate-doc-runtime.mjs`. This extracts Rust/Python cells from MDX and writes:
+
+- `src/generated/doc-runtime`
 - `public/pyodide`
 - `dist`
-- `coverage`
-- `test-results`
-- `target`
 
-Build, test, lint, and runtime commands should be treated as pending until the real implementation is migrated.
+These paths are generated output. Do not edit them directly.
+
+## Tests and Coverage
+
+Run the full validation suite:
+
+```sh
+pnpm test
+```
+
+Useful focused commands:
+
+```sh
+pnpm test:rust
+pnpm test:rust:coverage
+pnpm test:unit
+pnpm test:unit:coverage
+pnpm test:wasm
+pnpm test:e2e
+pnpm lint:rust
+pnpm check
+```
+
+`test:rust:coverage` requires 100% line/function/region coverage for the Rust workspace through `cargo-llvm-cov`. `test:unit:coverage` uses Vitest V8 coverage for handwritten TypeScript, Preact, and Node runtime code, excluding generated output.
+
+## Troubleshooting
+
+- If a Rust cell crate cannot be found, match the cell `crates` value to the `package.name` in `crates/*/Cargo.toml`.
+- If a Python cell does not start, confirm that `public/pyodide` exists and run `pnpm wasm:dev` or `pnpm build`.
+- If a Mermaid diagram does not render, run `pnpm build` to catch MDX syntax errors and confirm the code block language is `mermaid`.
+- If a media file does not load, confirm that it is under `public/media` and referenced with a `/media/...` URL.
+- If coverage fails, add focused tests for the uncovered handwritten source rather than editing generated files.

--- a/crates/AGENTS.md
+++ b/crates/AGENTS.md
@@ -2,18 +2,20 @@
 
 ## Rust Crates
 
-- Crates under this directory are reserved for reusable helpers used by generated documentation cells.
-- This skeleton intentionally tracks crate manifests and directory structure only. Do not add Rust implementation files unless the migration task explicitly asks for crate code.
+- Crates under this directory are reusable helpers for generated documentation cells. Keep them pure Rust and independent of Astro, Preact, browser workers, and generated Wasm glue.
 - Each crate should use workspace edition, MSRV, license, dependencies, and lints from the root `Cargo.toml`.
-- Keep crates independent of Astro, Preact, browser workers, and generated Wasm glue.
+- Workspace lint policy is intentionally strict: no unsafe, no `unwrap`, `expect`, `panic`, `todo`, `dbg`, direct stdout/stderr printing, indexing/slicing, unchecked casts, or unjustified lint suppression.
 
 ## Rust Style
 
-- Once code is migrated, preserve the strict workspace lint policy.
-- Public APIs should be documented, debug-friendly, and stable enough for MDX cell examples.
-- Use narrow, justified lint exceptions only when the implementation needs them.
+- Prefer iterator combinators and standard iterator constructors over `loop` or `for` when they keep the code clear.
+- Prefer `match` for enum, state, and multi-branch decisions instead of chained `if`/`else` logic.
+- Return `Result` with small error types for fallible helpers. Do not use partial operations or implicit panics.
+- Keep public APIs documented, debug-friendly, and stable enough for MDX cell examples.
+- Use `#[expect(..., reason = "...")]` for narrow, reviewed lint exceptions such as numerical examples that require floating-point arithmetic.
 
 ## Tests
 
-- Add focused Rust tests only alongside real crate implementation.
-- Validate Rust implementation changes with the Rust commands documented in the root project guidance.
+- Add focused unit tests for normal paths, boundary values, and errors.
+- Rust assertions must include useful failure messages.
+- Validate Rust changes with `pnpm test:rust`, `pnpm lint:rust`, and `pnpm doc:rust`; run `pnpm test:rust:coverage` when behavior changes.

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -2,16 +2,19 @@
 
 ## Runtime Scripts
 
-- Scripts here will own runtime generation and filesystem side effects after implementation is migrated.
-- The skeleton tracks this directory only as a future boundary. Do not add script behavior without a migration task for the corresponding runtime flow.
-- Generated paths should remain `src/generated/doc-runtime/**`, `public/pyodide/**`, and `dist/**`.
+- Scripts here own runtime generation and filesystem side effects. Keep parsing, normalization, planning, and writing concerns separated.
+- Prefer deterministic output: sort generated lists, keep stable fingerprints stable, and avoid environment-sensitive behavior unless it is already part of the script contract.
+- Do not write directly to generated paths from new ad hoc scripts. Extend the existing runtime generation flow instead.
 
 ## JavaScript Style
 
-- This project uses ESM.
-- Once scripts are migrated, keep parsing, normalization, planning, and writing concerns separated.
-- Prefer deterministic output and clear path-specific errors.
+- This project is ESM. Use existing Node APIs and local helpers before adding dependencies.
+- Keep functions small and data-oriented. Prefer `map`, `filter`, `flatMap`, `Object.entries`, and `Array.from` over mutable loops when clarity is preserved.
+- Throw errors with page, cell id, field, or path context so authoring failures are actionable.
+- Avoid hidden global state. Pass filesystem and process interfaces through existing dependency-injection patterns used by the tests.
 
 ## Tests
 
-- Add Vitest coverage under `tests/unit` with migrated script behavior.
+- Add or update Vitest coverage in `tests/unit` for new branches and error cases.
+- For runtime generation changes, run `pnpm test:unit` and `pnpm check`; run `pnpm test:unit:coverage` when covered branches change.
+- For Wasm or generated Rust output changes, also run `pnpm wasm:dev` and `pnpm test:wasm`.

--- a/src/content/AGENTS.md
+++ b/src/content/AGENTS.md
@@ -2,16 +2,20 @@
 
 ## MDX Authoring
 
-- This directory is reserved for Starlight documentation pages and examples.
-- The skeleton keeps only the content tree. Do not add real notes, examples, or migrated prose unless the migration task explicitly asks for content.
-- English pages belong under `src/content/docs`. Japanese translations belong under `src/content/docs/ja` with matching slugs.
-- Public images, PDFs, and similar unprocessed media belong in `public/media` and should be referenced from MDX with `/media/...` URLs once content exists.
+- This directory contains Starlight docs and examples. Keep pages clear, direct, and useful to readers; avoid layout or runtime code in MDX unless the existing docs already use that pattern.
+- Interactive Rust and Python cells are fenced code blocks with YAML metadata in leading directive comments.
+- Every interactive cell needs a page-local unique `id`. Rust cells use `//|` or `///|`; Python cells use `#|`.
+- Rust cells use `crates: [...]`; Python cells use `packages: [...]`. Do not mix them.
+- English pages live in `src/content/docs`; Japanese translations live in `src/content/docs/ja` with the same slug.
+- Public images, PDFs, and similar unprocessed media belong in `public/media` and should be referenced from MDX with `/media/...` URLs.
 
-## Interactive Cells
+## Rust Examples
 
-- Interactive Rust and Python cell conventions will be migrated with the runtime implementation.
-- Do not add executable cell examples before the runtime extraction and browser execution code is present.
+- Example Rust should model the same standards as crate code: prefer iterators over `loop` or `for` when clear, prefer `match` for multi-branch decisions, and avoid `unwrap`, `expect`, and panic-driven examples.
+- Keep cell inputs and output stable enough for tests and screenshots.
+- Crate names in `crates: [...]` must match Cargo package names under `crates/`.
 
 ## Validation
 
-- During the skeleton phase, validate the directory layout rather than running docs checks as acceptance gates.
+- For docs-only prose changes, `pnpm check` is usually enough.
+- For interactive cell metadata or code changes, run `pnpm wasm:dev`; add `pnpm test:wasm` for Rust cell behavior and `pnpm test:e2e` for browser-visible examples.

--- a/src/lib/doc-runtime/AGENTS.md
+++ b/src/lib/doc-runtime/AGENTS.md
@@ -2,17 +2,20 @@
 
 ## Doc Runtime Code
 
-- This subtree is reserved for browser-facing runtime code, workers, manifest handling, and remark plugins.
-- The skeleton intentionally contains no runtime implementation. Do not add partial runtime code without a migration task for that subsystem.
-- Keep this subtree separate from generated output under `src/generated/doc-runtime/**`.
+- This subtree contains browser-facing runtime code, workers, manifest handling, and remark plugins. Keep it separate from generated output under `src/generated/doc-runtime/**`.
+- Prefer explicit message shapes, small pure helpers, and narrowly scoped worker state.
+- Preserve HMR and subscription behavior in `manifest.ts` when changing generated-cell loading.
+- Runtime errors should be visible and specific enough for authors to fix the cell or metadata.
 
 ## TypeScript and Preact Style
 
-- Once runtime code is migrated, follow strict TypeScript and model message shapes explicitly.
-- Keep Preact components focused on rendering and interaction state.
-- Runtime errors should be visible and specific enough for authors to fix cell metadata or code.
+- Follow strict TypeScript. Avoid `any`; model data with the existing manifest and runtime types.
+- Prefer functional data transformations over mutation-heavy code when it stays readable.
+- Keep Preact components focused on rendering and interaction state. Move reusable decisions into pure helpers that are easy to test.
+- Do not add UI explanation text unless the user-facing docs need it; runtime controls should stay compact and predictable.
 
 ## Tests
 
-- Unit tests for runtime behavior belong under `tests/unit`, not beside source.
-- Add tests with the implementation they cover.
+- Unit tests live under `tests/unit`, not beside source.
+- Cover loading states, error states, worker reset behavior, generated manifest updates, and plugin transforms when touched.
+- Run `pnpm test:unit` and `pnpm check`; add `pnpm test:e2e` for browser-visible behavior.

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -2,10 +2,11 @@
 
 ## Tests
 
-- This directory is reserved for unit and end-to-end tests migrated from the source project.
-- The skeleton contains no test cases. Do not add placeholder tests that assert no behavior.
 - Unit tests belong under `tests/unit`; browser-facing scenarios belong under `tests/e2e`.
+- Keep tests focused on behavior, not implementation details. Prefer generated runtime fixtures through the existing generation scripts over hand-editing generated output.
+- Use Vitest for script, runtime, and Preact component behavior. Use Playwright for built-site behavior such as interactive cells, rendered diagrams, media, and localization.
 
 ## Validation
 
-- Introduce test commands as acceptance gates only after the corresponding implementation has been migrated.
+- Run focused tests for the code you touch. Use `pnpm test:unit` for runtime/script/component changes and `pnpm test:e2e` for browser-facing workflows.
+- Run `pnpm test` before considering broad migration or release work complete when practical.


### PR DESCRIPTION
## Summary
- Update root and subtree AGENTS guidance from skeleton-only instructions to active implementation guidance
- Replace skeleton READMEs with Oxiquill runtime/docs usage documentation in English and Japanese
- Preserve Oxiquill branch strategy and AGPL project identity

## Validation
- `pnpm test`