### PR TITLE
Fix doc runtime execution edge cases

### DIFF
--- a/scripts/doc-runtime-core.mjs
+++ b/scripts/doc-runtime-core.mjs
@@ -15,6 +15,61 @@ const supportedLanguages = new Map([
   ['python', 'python'],
   ['py', 'python']
 ]);
+const rustReservedIdentifiers = new Set([
+  'Self',
+  'abstract',
+  'as',
+  'async',
+  'await',
+  'become',
+  'box',
+  'break',
+  'const',
+  'continue',
+  'crate',
+  'do',
+  'dyn',
+  'else',
+  'enum',
+  'extern',
+  'false',
+  'final',
+  'fn',
+  'for',
+  'gen',
+  'if',
+  'impl',
+  'in',
+  'let',
+  'loop',
+  'macro',
+  'match',
+  'mod',
+  'move',
+  'mut',
+  'override',
+  'priv',
+  'pub',
+  'ref',
+  'return',
+  'self',
+  'static',
+  'struct',
+  'super',
+  'trait',
+  'true',
+  'try',
+  'type',
+  'typeof',
+  'union',
+  'unsafe',
+  'unsized',
+  'use',
+  'virtual',
+  'where',
+  'while',
+  'yield'
+]);
 
 export async function extractCellsFromMarkdown(source, pagePath, context) {
   const cells = [];
@@ -475,7 +530,8 @@ export function rustFunctionName(id) {
 
 export function rustIdentifier(value) {
   const identifier = value.replace(/[^a-zA-Z0-9_]/gu, '_').replace(/_+/gu, '_');
-  return /^[a-zA-Z_]/u.test(identifier) ? identifier : `cell_${identifier}`;
+  if (!/^[a-zA-Z_]/u.test(identifier)) return `cell_${identifier}`;
+  return rustReservedIdentifiers.has(identifier) ? `cell_${identifier}` : identifier;
 }
 
 function rustReadF64() {

--- a/scripts/doc-runtime-core.mjs
+++ b/scripts/doc-runtime-core.mjs
@@ -102,7 +102,15 @@ export function normalizePackages(value, language, cellId, pagePath) {
     throw new Error(`Rust cell "${cellId}" in ${pagePath} must use crates instead of packages.`);
   }
 
-  return normalizeStringArray(value, 'packages', cellId, pagePath);
+  const packages = normalizeStringArray(value, 'packages', cellId, pagePath);
+  if (packages.length > 0) {
+    throw new Error(
+      `Python cell "${cellId}" in ${pagePath} specifies packages: ${packages.join(', ')}. ` +
+        'Static Pyodide package assets are not currently distributed; remove packages or add package asset copying first.'
+    );
+  }
+
+  return packages;
 }
 
 export function normalizeCrates(value, language, cellId, pagePath, helperCrates) {

--- a/scripts/doc-runtime-core.mjs
+++ b/scripts/doc-runtime-core.mjs
@@ -15,6 +15,8 @@ const supportedLanguages = new Map([
   ['python', 'python'],
   ['py', 'python']
 ]);
+const runModes = ['button', 'reactive', 'autorun', 'hidden'];
+const inputTypes = ['range', 'number', 'integer', 'text', 'textarea', 'checkbox', 'select', 'radio'];
 const rustReservedIdentifiers = new Set([
   'Self',
   'abstract',
@@ -110,16 +112,16 @@ export async function parseCell(rawSource, language, pagePath, context) {
     id: scopedCellId(pagePath, localId),
     language,
     title: String(metadata.title ?? localId),
-    run: normalizeRunMode(metadata.run),
+    run: normalizeRunMode(metadata.run, localId, pagePath),
     source,
     sourceHtml: await context.highlighter.codeToHtml(source, {
       lang: language,
       themes: sourceThemes
     }),
-    inputs: normalizeInputs(metadata.inputs),
+    inputs: normalizeInputs(metadata.inputs, localId, pagePath),
     packages: normalizePackages(metadata.packages, language, metadata.id, pagePath),
     crates: normalizeCrates(metadata.crates, language, metadata.id, pagePath, context.helperCrates),
-    timeoutMs: normalizeTimeout(metadata.timeoutMs),
+    timeoutMs: normalizeTimeout(metadata.timeoutMs, localId, pagePath),
     showSource: metadata.showSource !== false,
     pagePath
   };
@@ -141,13 +143,25 @@ export function splitCellSource(rawSource) {
   return { metadataLines, sourceLines };
 }
 
-export function normalizeRunMode(value) {
-  if (value === 'reactive' || value === 'autorun' || value === 'hidden') return value;
-  return 'button';
+export function normalizeRunMode(value, cellId = 'cell', pagePath = 'page') {
+  if (value == null) return 'button';
+  if (runModes.includes(value)) return value;
+
+  throw new Error(
+    `Interactive cell "${cellId}" in ${pagePath} has invalid run value ${JSON.stringify(value)}. ` +
+      `Allowed values: ${runModes.join(', ')}.`
+  );
 }
 
-export function normalizeTimeout(value) {
-  if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) return 30_000;
+export function normalizeTimeout(value, cellId = 'cell', pagePath = 'page') {
+  if (value == null) return 30_000;
+  if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) {
+    throw new Error(
+      `Interactive cell "${cellId}" in ${pagePath} has invalid timeoutMs value ${JSON.stringify(value)}. ` +
+        'Expected a positive number.'
+    );
+  }
+
   return Math.trunc(value);
 }
 
@@ -206,12 +220,12 @@ export function normalizeStringArray(value, field, cellId, pagePath) {
   return Array.from(values).sort();
 }
 
-export function normalizeInputs(inputs) {
+export function normalizeInputs(inputs, cellId = 'cell', pagePath = 'page') {
   if (!inputs || typeof inputs !== 'object' || Array.isArray(inputs)) return [];
 
   return Object.entries(inputs).map(([name, raw]) => {
     const value = raw && typeof raw === 'object' && !Array.isArray(raw) ? raw : { value: raw };
-    const type = normalizeInputType(value.type);
+    const type = normalizeInputType(value.type, name, cellId, pagePath);
 
     return {
       name,
@@ -227,21 +241,14 @@ export function normalizeInputs(inputs) {
   });
 }
 
-export function normalizeInputType(type) {
-  if (
-    type === 'range' ||
-    type === 'number' ||
-    type === 'integer' ||
-    type === 'text' ||
-    type === 'textarea' ||
-    type === 'checkbox' ||
-    type === 'select' ||
-    type === 'radio'
-  ) {
-    return type;
-  }
+export function normalizeInputType(type, inputName = 'input', cellId = 'cell', pagePath = 'page') {
+  if (type == null) return 'text';
+  if (inputTypes.includes(type)) return type;
 
-  return 'text';
+  throw new Error(
+    `Interactive cell "${cellId}" in ${pagePath} has invalid type ${JSON.stringify(type)} ` +
+      `for input "${inputName}". Allowed values: ${inputTypes.join(', ')}.`
+  );
 }
 
 export function normalizeInputValue(type, value) {

--- a/src/components/doc-runtime/InteractiveCell.tsx
+++ b/src/components/doc-runtime/InteractiveCell.tsx
@@ -106,6 +106,7 @@ function InteractiveCellPanel({
           {cell.inputs.map((input) => (
             <InputControl
               key={input.name}
+              cellId={cell.id}
               input={input}
               value={values[input.name]}
               onChange={(value) => setValues((current) => ({ ...current, [input.name]: value }))}
@@ -140,15 +141,17 @@ function useRuntimeLabels() {
 }
 
 function InputControl({
+  cellId,
   input,
   value,
   onChange
 }: {
+  cellId: string;
   input: InputSpec;
   onChange: (value: string | number | boolean) => void;
   value: string | number | boolean;
 }) {
-  const id = `doc-input-${input.name}`;
+  const id = inputControlId(cellId, input.name);
 
   if (input.type === 'checkbox') {
     return (
@@ -247,6 +250,10 @@ function InputControl({
       />
     </label>
   );
+}
+
+function inputControlId(cellId: string, inputName: string): string {
+  return `doc-input-${cellId}-${inputName}`;
 }
 
 function CellOutput({

--- a/src/components/doc-runtime/InteractiveCell.tsx
+++ b/src/components/doc-runtime/InteractiveCell.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'preact/hooks';
+import { useEffect, useMemo, useRef, useState } from 'preact/hooks';
 import {
   coerceInputValue,
   formatInputValue,
@@ -51,6 +51,7 @@ function InteractiveCellPanel({
   const [error, setError] = useState<string>();
   const [isRunning, setIsRunning] = useState(false);
   const [isSourceVisible, setIsSourceVisible] = useState(cell.showSource);
+  const latestRunId = useRef(0);
 
   const serializedValues = useMemo(() => JSON.stringify(values), [values]);
 
@@ -65,15 +66,24 @@ function InteractiveCellPanel({
   }, [cell.id, runtimeVersion, serializedValues]);
 
   async function run() {
+    const runId = latestRunId.current + 1;
+    latestRunId.current = runId;
     setIsRunning(true);
     setError(undefined);
 
     try {
-      setResult(await runInteractiveCell(cell, values));
+      const nextResult = await runInteractiveCell(cell, values);
+      if (latestRunId.current === runId) {
+        setResult(nextResult);
+      }
     } catch (caught) {
-      setError(caught instanceof Error ? caught.message : String(caught));
+      if (latestRunId.current === runId) {
+        setError(caught instanceof Error ? caught.message : String(caught));
+      }
     } finally {
-      setIsRunning(false);
+      if (latestRunId.current === runId) {
+        setIsRunning(false);
+      }
     }
   }
 

--- a/src/lib/doc-runtime/python-worker.ts
+++ b/src/lib/doc-runtime/python-worker.ts
@@ -12,10 +12,26 @@ const worker = self as unknown as WorkerScope;
 let pyodideReady: Promise<PyodideRuntime> | undefined;
 let loadPyodideReady: Promise<LoadPyodide> | undefined;
 const pyodideModuleUrl = '/pyodide/pyodide.mjs';
+const requestQueue = createSerialRequestQueue(handleRequest);
 
 worker.addEventListener('message', (event) => {
-  void handleRequest(event.data);
+  requestQueue.enqueue(event.data);
 });
+
+export function createSerialRequestQueue<Request>(
+  handle: (request: Request) => Promise<void>
+): { enqueue: (request: Request) => void } {
+  let tail = Promise.resolve();
+
+  return {
+    enqueue(request) {
+      tail = tail
+        .catch(() => undefined)
+        .then(() => handle(request))
+        .catch(() => undefined);
+    }
+  };
+}
 
 async function handleRequest(request: RuntimeWorkerRequest): Promise<void> {
   try {

--- a/tests/unit/components.test.tsx
+++ b/tests/unit/components.test.tsx
@@ -1,6 +1,6 @@
 import { act, cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/preact';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import type { CellManifest, InputSpec } from '../../src/lib/doc-runtime/types';
+import type { CellExecutionResult, CellManifest, InputSpec } from '../../src/lib/doc-runtime/types';
 
 const mocks = vi.hoisted(() => {
   const chart = {
@@ -111,6 +111,17 @@ function makeCell(overrides: Partial<CellManifest> = {}): CellManifest {
     pagePath: 'page.mdx',
     ...overrides
   };
+}
+
+function createDeferredResult() {
+  let resolve!: (value: CellExecutionResult) => void;
+  let reject!: (reason: Error) => void;
+  const promise = new Promise<CellExecutionResult>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+
+  return { promise, reject, resolve };
 }
 
 beforeEach(() => {
@@ -254,6 +265,38 @@ describe('InteractiveCell', () => {
 
     fireEvent.input(screen.getByRole('slider', { name: 'ratio' }), { target: { value: '3' } });
     await waitFor(() => expect(mocks.runInteractiveCell).toHaveBeenCalledTimes(3));
+  });
+
+  it('ignores stale async results from superseded reactive runs', async () => {
+    const pending: Array<ReturnType<typeof createDeferredResult>> = [];
+    mocks.runInteractiveCell.mockImplementation(() => {
+      const deferred = createDeferredResult();
+      pending.push(deferred);
+      return deferred.promise;
+    });
+    mocks.getCell.mockReturnValue(makeCell({
+      run: 'reactive',
+      inputs: [inputs.find((input) => input.name === 'label') as InputSpec]
+    }));
+
+    render(<InteractiveCell cellId="cell-one" />);
+    await waitFor(() => expect(pending).toHaveLength(1));
+
+    fireEvent.input(screen.getByLabelText('label'), { target: { value: 'newer input' } });
+    await waitFor(() => expect(pending).toHaveLength(2));
+
+    await act(async () => {
+      pending[1].resolve({ stdout: 'newer result', stderr: '', value: null, plots: [] });
+      await pending[1].promise;
+    });
+    await waitFor(() => expect(screen.getByTestId('run-output')).toHaveTextContent('newer result'));
+
+    await act(async () => {
+      pending[0].resolve({ stdout: 'older result', stderr: '', value: null, plots: [] });
+      await pending[0].promise;
+    });
+
+    expect(screen.getByTestId('run-output')).toHaveTextContent('newer result');
   });
 
   it('supports cells without inputs and hidden source', () => {

--- a/tests/unit/components.test.tsx
+++ b/tests/unit/components.test.tsx
@@ -299,6 +299,39 @@ describe('InteractiveCell', () => {
     expect(screen.getByTestId('run-output')).toHaveTextContent('newer result');
   });
 
+  it('ignores stale async errors from superseded reactive runs', async () => {
+    const pending: Array<ReturnType<typeof createDeferredResult>> = [];
+    mocks.runInteractiveCell.mockImplementation(() => {
+      const deferred = createDeferredResult();
+      pending.push(deferred);
+      return deferred.promise;
+    });
+    mocks.getCell.mockReturnValue(makeCell({
+      run: 'reactive',
+      inputs: [inputs.find((input) => input.name === 'label') as InputSpec]
+    }));
+
+    render(<InteractiveCell cellId="cell-one" />);
+    await waitFor(() => expect(pending).toHaveLength(1));
+
+    fireEvent.input(screen.getByLabelText('label'), { target: { value: 'newer input' } });
+    await waitFor(() => expect(pending).toHaveLength(2));
+
+    await act(async () => {
+      pending[1].resolve({ stdout: 'newer result', stderr: '', value: null, plots: [] });
+      await pending[1].promise;
+    });
+    await waitFor(() => expect(screen.getByTestId('run-output')).toHaveTextContent('newer result'));
+
+    await act(async () => {
+      pending[0].reject(new Error('older failure'));
+      await pending[0].promise.catch(() => undefined);
+    });
+
+    expect(screen.queryByText('older failure')).not.toBeInTheDocument();
+    expect(screen.getByTestId('run-output')).toHaveTextContent('newer result');
+  });
+
   it('supports cells without inputs and hidden source', () => {
     mocks.getCell.mockReturnValue(makeCell({ inputs: [], showSource: false, run: 'hidden' }));
 

--- a/tests/unit/components.test.tsx
+++ b/tests/unit/components.test.tsx
@@ -1,4 +1,4 @@
-import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/preact';
+import { act, cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/preact';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { CellManifest, InputSpec } from '../../src/lib/doc-runtime/types';
 
@@ -187,6 +187,36 @@ describe('InteractiveCell', () => {
         label: 'next'
       })
     );
+  });
+
+  it('scopes input ids and radio groups per cell', () => {
+    const radioOnly = inputs.filter((input) => input.name === 'style');
+    mocks.getCell.mockImplementation((cellId: string) =>
+      makeCell({ id: cellId, title: cellId, inputs: radioOnly })
+    );
+
+    render(
+      <>
+        <InteractiveCell cellId="cell-one" />
+        <InteractiveCell cellId="cell-two" />
+      </>
+    );
+
+    const first = within(screen.getByTestId('cell-cell-one'));
+    const second = within(screen.getByTestId('cell-cell-two'));
+    const firstCompact = first.getByLabelText('compact') as HTMLInputElement;
+    const firstVerbose = first.getByLabelText('verbose') as HTMLInputElement;
+    const secondCompact = second.getByLabelText('compact') as HTMLInputElement;
+
+    expect(firstCompact.name).toBe('doc-input-cell-one-style');
+    expect(secondCompact.name).toBe('doc-input-cell-two-style');
+    expect(firstCompact).toBeChecked();
+    expect(secondCompact).toBeChecked();
+
+    fireEvent.input(firstVerbose, { target: { value: 'verbose' } });
+
+    expect(firstVerbose).toBeChecked();
+    expect(secondCompact).toBeChecked();
   });
 
   it('shows running and error states', async () => {

--- a/tests/unit/doc-runtime-core.test.mjs
+++ b/tests/unit/doc-runtime-core.test.mjs
@@ -140,18 +140,35 @@ describe('doc runtime core', () => {
     await expect(parseCell('//| id: empty', 'rust', 'page.mdx', { helperCrates, highlighter })).rejects.toThrow(
       'does not contain code'
     );
+    await expect(parseCell('//| id: bad\n//| run: sometimes\nprintln!("ok");', 'rust', 'page.mdx', {
+      helperCrates,
+      highlighter
+    })).rejects.toThrow('Allowed values: button, reactive, autorun, hidden');
+    await expect(parseCell('//| id: bad\n//| timeoutMs: 0\nprintln!("ok");', 'rust', 'page.mdx', {
+      helperCrates,
+      highlighter
+    })).rejects.toThrow('invalid timeoutMs value 0');
+    await expect(parseCell('//| id: bad\n//| inputs:\n//|   mode: { type: knob }\nprintln!("ok");', 'rust', 'page.mdx', {
+      helperCrates,
+      highlighter
+    })).rejects.toThrow('for input "mode". Allowed values');
   });
 
   it('normalizes run modes, timeouts, package lists, and crate lists', () => {
+    expect(normalizeRunMode(undefined)).toBe('button');
+    expect(normalizeRunMode('button')).toBe('button');
     expect(normalizeRunMode('autorun')).toBe('autorun');
     expect(normalizeRunMode('hidden')).toBe('hidden');
     expect(normalizeRunMode('reactive')).toBe('reactive');
-    expect(normalizeRunMode('unknown')).toBe('button');
+    expect(() => normalizeRunMode('unknown', 'cell', 'page')).toThrow(
+      'Allowed values: button, reactive, autorun, hidden'
+    );
 
+    expect(normalizeTimeout(undefined)).toBe(30_000);
     expect(normalizeTimeout(10.8)).toBe(10);
-    expect(normalizeTimeout(0)).toBe(30_000);
-    expect(normalizeTimeout(Number.NaN)).toBe(30_000);
-    expect(normalizeTimeout('bad')).toBe(30_000);
+    expect(() => normalizeTimeout(0, 'cell', 'page')).toThrow('Expected a positive number');
+    expect(() => normalizeTimeout(Number.NaN, 'cell', 'page')).toThrow('Expected a positive number');
+    expect(() => normalizeTimeout('bad', 'cell', 'page')).toThrow('Expected a positive number');
 
     expect(normalizePackages(null, 'python', 'cell', 'page')).toEqual([]);
     expect(normalizePackages([], 'python', 'cell', 'page')).toEqual([]);
@@ -183,7 +200,8 @@ describe('doc runtime core', () => {
     expect(normalizeInputType('checkbox')).toBe('checkbox');
     expect(normalizeInputType('select')).toBe('select');
     expect(normalizeInputType('radio')).toBe('radio');
-    expect(normalizeInputType('unknown')).toBe('text');
+    expect(normalizeInputType(undefined)).toBe('text');
+    expect(() => normalizeInputType('unknown', 'mode', 'cell', 'page')).toThrow('for input "mode"');
 
     expect(normalizeInputValue('checkbox', 1)).toBe(true);
     expect(normalizeInputValue('range', 2)).toBe(2);

--- a/tests/unit/doc-runtime-core.test.mjs
+++ b/tests/unit/doc-runtime-core.test.mjs
@@ -267,6 +267,11 @@ describe('doc runtime core', () => {
         { id: 'bad', pagePath: 'page', inputs: [{ name: 'value-a' }, { name: 'value_a' }] }
       ])
     ).toThrow('both map to Rust binding');
+    expect(() =>
+      assertUniqueRustInputBindings([
+        { id: 'keyword', pagePath: 'page', inputs: [{ name: 'type' }, { name: 'cell-type' }] }
+      ])
+    ).toThrow('both map to Rust binding "cell_type"');
 
     const crates = helperCratesFromManifests([
       { content: '[package]\nname = "b-crate"\n', manifestPath: '/repo/crates/b/Cargo.toml' },
@@ -306,6 +311,9 @@ describe('doc runtime core', () => {
     expect(() => generateRustDependency('missing', helperCrates)).toThrow('unknown Rust crate');
 
     expect(rustIdentifier('1-bad id')).toBe('cell_1_bad_id');
+    expect(rustIdentifier('type')).toBe('cell_type');
+    expect(rustIdentifier('match')).toBe('cell_match');
+    expect(rustIdentifier('crate')).toBe('cell_crate');
     expect(rustFunctionName('cell-id')).toBe('run_cell_id');
     expect(rustFunctionName('page__cell')).toBe('run_page_cell');
     expect(rustReaderName({ type: 'checkbox' })).toBe('read_bool');
@@ -317,6 +325,9 @@ describe('doc runtime core', () => {
 
     expect(generateRustInputBinding({ name: 'value-name', type: 'number' })).toBe(
       'let value_name = read_f64(inputs, "value-name")?;'
+    );
+    expect(generateRustInputBinding({ name: 'type', type: 'text' })).toBe(
+      'let cell_type = read_string(inputs, "type")?;'
     );
 
     const rustCell = {

--- a/tests/unit/doc-runtime-core.test.mjs
+++ b/tests/unit/doc-runtime-core.test.mjs
@@ -154,10 +154,10 @@ describe('doc runtime core', () => {
     expect(normalizeTimeout('bad')).toBe(30_000);
 
     expect(normalizePackages(null, 'python', 'cell', 'page')).toEqual([]);
-    expect(normalizePackages(['numpy', 'numpy', 'pandas'], 'python', 'cell', 'page')).toEqual([
-      'numpy',
-      'pandas'
-    ]);
+    expect(normalizePackages([], 'python', 'cell', 'page')).toEqual([]);
+    expect(() => normalizePackages(['numpy', 'numpy', 'pandas'], 'python', 'cell', 'page')).toThrow(
+      'Static Pyodide package assets are not currently distributed'
+    );
     expect(() => normalizePackages(['numpy'], 'rust', 'cell', 'page')).toThrow('must use crates');
 
     expect(normalizeCrates(null, 'rust', 'cell', 'page', helperCrates)).toEqual([]);

--- a/tests/unit/doc-runtime-service.test.mjs
+++ b/tests/unit/doc-runtime-service.test.mjs
@@ -280,6 +280,24 @@ describe('doc runtime service', () => {
     );
   });
 
+  it('fails clearly when an MDX Python cell specifies unsupported packages', async () => {
+    const fileSystem = createMemoryFileSystem({
+      '/repo/src/content/docs/page.mdx': '```python\n#| id: py\n#| packages: [numpy]\nprint("py")\n```'
+    });
+
+    await expect(
+      collectCells({
+        fileSystem,
+        helperCrates: new Map(),
+        highlighter,
+        paths: createDocRuntimePaths('/repo'),
+        root: '/repo'
+      })
+    ).rejects.toThrow(
+      'Python cell "py" in src/content/docs/page.mdx specifies packages: numpy'
+    );
+  });
+
   it('writes and copies only when content changes', async () => {
     const fileSystem = createMemoryFileSystem({
       '/repo/source.bin': Buffer.from([1, 2, 3]),

--- a/tests/unit/python-worker.test.ts
+++ b/tests/unit/python-worker.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+import { createSerialRequestQueue } from '../../src/lib/doc-runtime/python-worker';
+
+function createDeferred() {
+  let reject!: (reason: Error) => void;
+  let resolve!: () => void;
+  const promise = new Promise<void>((resolvePromise, rejectPromise) => {
+    reject = rejectPromise;
+    resolve = resolvePromise;
+  });
+
+  return { promise, reject, resolve };
+}
+
+async function flushMicrotasks() {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe('python worker request queue', () => {
+  it('processes queued requests one at a time', async () => {
+    const first = createDeferred();
+    const second = createDeferred();
+    const events: string[] = [];
+    const queue = createSerialRequestQueue(async (request: string) => {
+      events.push(`start:${request}`);
+      await (request === 'first' ? first.promise : second.promise);
+      events.push(`finish:${request}`);
+    });
+
+    queue.enqueue('first');
+    queue.enqueue('second');
+    await flushMicrotasks();
+
+    expect(events).toEqual(['start:first']);
+
+    first.resolve();
+    await flushMicrotasks();
+
+    expect(events).toEqual(['start:first', 'finish:first', 'start:second']);
+
+    second.resolve();
+    await flushMicrotasks();
+
+    expect(events).toEqual(['start:first', 'finish:first', 'start:second', 'finish:second']);
+  });
+
+  it('continues draining after a request rejects', async () => {
+    const first = createDeferred();
+    const second = createDeferred();
+    const events: string[] = [];
+    const queue = createSerialRequestQueue(async (request: string) => {
+      events.push(`start:${request}`);
+      await (request === 'first' ? first.promise : second.promise);
+      events.push(`finish:${request}`);
+    });
+
+    queue.enqueue('first');
+    queue.enqueue('second');
+    await flushMicrotasks();
+
+    first.reject(new Error('failed'));
+    await first.promise.catch(() => undefined);
+    await flushMicrotasks();
+
+    expect(events).toEqual(['start:first', 'start:second']);
+
+    second.resolve();
+    await flushMicrotasks();
+
+    expect(events).toEqual(['start:first', 'start:second', 'finish:second']);
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-    "extends": "astro/tsconfigs/strict",
+    "extends": "./node_modules/astro/tsconfigs/strict.json",
     "compilerOptions": {
         "jsx": "react-jsx",
         "jsxImportSource": "preact",


### PR DESCRIPTION
## Summary
- Isolate interactive cell input IDs and radio groups per cell.
- Ignore stale async interactive cell completions.
- Serialize Python worker requests.
- Reject unsupported Python package metadata for static Pyodide assets.
- Make generated Rust identifiers keyword-safe.
- Fail fast on invalid doc runtime authoring metadata.
- Resolve the Astro tsconfig base path for editors/TypeScript servers.

## Validation
- `pnpm test:unit`
- `pnpm test:unit:coverage`
- `pnpm check`
- `pnpm test:wasm`