### PR TITLE
Add interactive output artifact contract

### DIFF
--- a/src/lib/doc-runtime/output-artifacts.ts
+++ b/src/lib/doc-runtime/output-artifacts.ts
@@ -1,0 +1,199 @@
+import type {
+  ChartArtifact,
+  ChartSpec,
+  CellExecutionResult,
+  ImageArtifact,
+  OutputArtifact,
+  OutputLimits,
+  PlotSpec,
+  RawCellExecutionResult,
+  TableArtifact,
+  TableColumn,
+  TextArtifact
+} from './types';
+
+export const defaultOutputLimits: OutputLimits = {
+  maxTextBytes: 200_000,
+  maxJsonBytes: 500_000,
+  maxJsonDepth: 32,
+  maxTableRows: 1_000,
+  maxImageBytes: 2_000_000,
+  maxHtmlBytes: 500_000
+};
+
+const artifactKinds = new Set(['text', 'json', 'table', 'chart', 'image', 'html']);
+const artifactStreams = new Set(['stdout', 'stderr', 'display']);
+const tableColumnTypes = new Set([
+  'string',
+  'number',
+  'integer',
+  'boolean',
+  'date',
+  'datetime',
+  'null',
+  'unknown'
+]);
+const chartKinds = new Set(['line', 'scatter', 'bar', 'histogram', 'area', 'heatmap']);
+const imageMimes = new Set(['image/png', 'image/jpeg', 'image/svg+xml']);
+
+export function legacyResultToOutputs(result: RawCellExecutionResult): readonly OutputArtifact[] {
+  return [
+    result.stdout ? [{ kind: 'text', stream: 'stdout', content: result.stdout } satisfies TextArtifact] : [],
+    result.stderr ? [{ kind: 'text', stream: 'stderr', content: result.stderr } satisfies TextArtifact] : [],
+    result.value != null && result.value !== '' ? [{ kind: 'json', value: result.value } satisfies OutputArtifact] : [],
+    ...(result.plots ?? []).map((plot) => [legacyPlotToChartArtifact(plot)])
+  ].flat();
+}
+
+export function outputsToLegacyResult(outputs: readonly OutputArtifact[]): CellExecutionResult {
+  const stdout = joinTextArtifacts(outputs, 'stdout');
+  const stderr = joinTextArtifacts(outputs, 'stderr');
+  const jsonValues = outputs.filter((output) => output.kind === 'json').map((output) => output.value);
+
+  return {
+    stdout,
+    ...(stderr ? { stderr } : {}),
+    ...(jsonValues.length > 0 ? { value: jsonValues.at(-1) } : {}),
+    plots: outputs.flatMap(chartArtifactToLegacyPlot),
+    outputs
+  };
+}
+
+export function normalizeCellExecutionResult(result: RawCellExecutionResult): CellExecutionResult {
+  const explicitOutputs = Array.isArray(result.outputs)
+    ? result.outputs.filter(isOutputArtifact)
+    : [];
+  const outputs = explicitOutputs.length > 0 ? explicitOutputs : legacyResultToOutputs(result);
+  const legacy = outputsToLegacyResult(outputs);
+
+  return {
+    stdout: typeof result.stdout === 'string' ? result.stdout : legacy.stdout,
+    ...(typeof result.stderr === 'string' ? { stderr: result.stderr } : legacy.stderr ? { stderr: legacy.stderr } : {}),
+    ...(Object.hasOwn(result, 'value') ? { value: result.value } : Object.hasOwn(legacy, 'value') ? { value: legacy.value } : {}),
+    plots: Array.isArray(result.plots) ? result.plots : legacy.plots,
+    outputs
+  };
+}
+
+export function isOutputArtifact(value: unknown): value is OutputArtifact {
+  if (!isRecord(value) || !artifactKinds.has(value.kind as string) || !hasValidBaseArtifact(value)) {
+    return false;
+  }
+
+  switch (value.kind) {
+    case 'text':
+      return artifactStreams.has(value.stream as string) && typeof value.content === 'string';
+    case 'json':
+      return Object.hasOwn(value, 'value');
+    case 'table':
+      return isTableArtifact(value);
+    case 'chart':
+      return isChartSpec(value.spec);
+    case 'image':
+      return isImageArtifact(value);
+    case 'html':
+      return typeof value.html === 'string' && value.sandboxed === true;
+    default:
+      return false;
+  }
+}
+
+export function withDefaultOutputLimits(overrides: Partial<OutputLimits> = {}): OutputLimits {
+  return { ...defaultOutputLimits, ...overrides };
+}
+
+function legacyPlotToChartArtifact(plot: PlotSpec): ChartArtifact {
+  return {
+    kind: 'chart',
+    spec: {
+      kind: 'line',
+      xLabel: plot.x_label,
+      yLabel: plot.y_label,
+      xType: 'value',
+      yType: 'value',
+      tooltip: true,
+      dataZoom: true,
+      series: [{ points: plot.points }]
+    }
+  };
+}
+
+function chartArtifactToLegacyPlot(output: OutputArtifact): PlotSpec[] {
+  if (output.kind !== 'chart' || output.spec.kind !== 'line' || output.spec.series.length !== 1) {
+    return [];
+  }
+
+  const points = output.spec.series[0]?.points;
+  if (!points.every((point) => point.every((value) => typeof value === 'number'))) {
+    return [];
+  }
+
+  return [
+    {
+      kind: 'line',
+      x_label: output.spec.xLabel ?? '',
+      y_label: output.spec.yLabel ?? '',
+      points: points as readonly [number, number][]
+    }
+  ];
+}
+
+function joinTextArtifacts(outputs: readonly OutputArtifact[], stream: TextArtifact['stream']): string {
+  return outputs
+    .filter((output): output is TextArtifact => output.kind === 'text' && output.stream === stream)
+    .map((output) => output.content)
+    .filter((content) => content.length > 0)
+    .join('\n');
+}
+
+function hasValidBaseArtifact(value: Record<string, unknown>): boolean {
+  return (
+    optionalString(value.id) &&
+    optionalString(value.title) &&
+    optionalString(value.caption) &&
+    (typeof value.truncated === 'boolean' || value.truncated == null)
+  );
+}
+
+function isTableArtifact(value: unknown): value is TableArtifact {
+  if (!isRecord(value)) return false;
+
+  return (
+    Array.isArray(value.columns) &&
+    value.columns.every(isTableColumn) &&
+    Array.isArray(value.rows) &&
+    value.rows.every(Array.isArray) &&
+    (typeof value.rowCount === 'number' || value.rowCount == null)
+  );
+}
+
+function isTableColumn(value: unknown): value is TableColumn {
+  return (
+    isRecord(value) &&
+    typeof value.key === 'string' &&
+    typeof value.label === 'string' &&
+    (value.type == null || tableColumnTypes.has(value.type as string))
+  );
+}
+
+function isChartSpec(value: unknown): value is ChartSpec {
+  return isRecord(value) && chartKinds.has(value.kind as string);
+}
+
+function isImageArtifact(value: unknown): value is ImageArtifact {
+  if (!isRecord(value)) return false;
+
+  return (
+    imageMimes.has(value.mime as string) &&
+    typeof value.data === 'string' &&
+    optionalString(value.alt)
+  );
+}
+
+function optionalString(value: unknown): boolean {
+  return value == null || typeof value === 'string';
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}

--- a/src/lib/doc-runtime/python-worker.ts
+++ b/src/lib/doc-runtime/python-worker.ts
@@ -62,7 +62,8 @@ async function handleRequest(request: RuntimeWorkerRequest): Promise<void> {
       stdout: stdout.join('\n').trimEnd(),
       stderr: stderr.join('\n').trimEnd(),
       value,
-      plots: []
+      plots: [],
+      outputs: []
     };
 
     worker.postMessage({ requestId: request.requestId, ok: true, result });

--- a/src/lib/doc-runtime/runtime-client.ts
+++ b/src/lib/doc-runtime/runtime-client.ts
@@ -6,6 +6,7 @@ import type {
   RuntimeWorkerRequest,
   RuntimeWorkerResponse
 } from './types';
+import { normalizeCellExecutionResult } from './output-artifacts';
 
 type PendingRequest = {
   reject: (reason: Error) => void;
@@ -74,7 +75,7 @@ export function createInteractiveCellRunner(dependencies: RuntimeClientDependenc
       dependencies.clearTimeout(request.timeout);
 
       if (event.data.ok) {
-        request.resolve(event.data.result);
+        request.resolve(normalizeCellExecutionResult(event.data.result));
       } else {
         request.reject(new Error(event.data.error));
       }

--- a/src/lib/doc-runtime/types.ts
+++ b/src/lib/doc-runtime/types.ts
@@ -53,11 +53,160 @@ export interface LinePlotSpec {
 
 export type PlotSpec = LinePlotSpec;
 
+export type ArtifactStream = 'stdout' | 'stderr' | 'display';
+export type TableColumnType =
+  | 'string'
+  | 'number'
+  | 'integer'
+  | 'boolean'
+  | 'date'
+  | 'datetime'
+  | 'null'
+  | 'unknown';
+export type ChartAxisType = 'value' | 'category' | 'time' | 'log';
+export type ChartSpec =
+  | LineChartSpec
+  | ScatterChartSpec
+  | BarChartSpec
+  | HistogramChartSpec
+  | AreaChartSpec
+  | HeatmapChartSpec;
+export type OutputArtifact =
+  | TextArtifact
+  | JsonArtifact
+  | TableArtifact
+  | ChartArtifact
+  | ImageArtifact
+  | HtmlArtifact;
+
+export interface BaseArtifact {
+  id?: string;
+  title?: string;
+  caption?: string;
+}
+
+export interface TextArtifact extends BaseArtifact {
+  kind: 'text';
+  stream: ArtifactStream;
+  content: string;
+  truncated?: boolean;
+}
+
+export interface JsonArtifact extends BaseArtifact {
+  kind: 'json';
+  value: unknown;
+  truncated?: boolean;
+}
+
+export interface TableArtifact extends BaseArtifact {
+  kind: 'table';
+  columns: readonly TableColumn[];
+  rows: readonly unknown[][];
+  rowCount?: number;
+  truncated?: boolean;
+}
+
+export interface TableColumn {
+  key: string;
+  label: string;
+  type?: TableColumnType;
+}
+
+export interface ChartArtifact extends BaseArtifact {
+  kind: 'chart';
+  spec: ChartSpec;
+}
+
+export interface ImageArtifact extends BaseArtifact {
+  kind: 'image';
+  mime: 'image/png' | 'image/jpeg' | 'image/svg+xml';
+  data: string;
+  alt?: string;
+}
+
+export interface HtmlArtifact extends BaseArtifact {
+  kind: 'html';
+  html: string;
+  sandboxed: true;
+}
+
+export interface BaseChartSpec {
+  title?: string;
+  xLabel?: string;
+  yLabel?: string;
+  xType?: ChartAxisType;
+  yType?: ChartAxisType;
+  legend?: boolean;
+  tooltip?: boolean;
+  dataZoom?: boolean;
+}
+
+export interface XyChartSeries {
+  name?: string;
+  points: readonly (readonly [number | string, number | string])[];
+}
+
+export interface LineChartSpec extends BaseChartSpec {
+  kind: 'line';
+  series: readonly XyChartSeries[];
+}
+
+export interface ScatterChartSpec extends BaseChartSpec {
+  kind: 'scatter';
+  series: readonly XyChartSeries[];
+}
+
+export interface BarChartSeries {
+  name?: string;
+  values: readonly (number | null)[];
+}
+
+export interface BarChartSpec extends BaseChartSpec {
+  kind: 'bar';
+  categories: readonly string[];
+  series: readonly BarChartSeries[];
+}
+
+export interface HistogramChartSpec extends BaseChartSpec {
+  kind: 'histogram';
+  bins: readonly (readonly [number, number, number])[];
+}
+
+export interface AreaChartSpec extends BaseChartSpec {
+  kind: 'area';
+  series: readonly XyChartSeries[];
+}
+
+export interface HeatmapChartSpec extends BaseChartSpec {
+  kind: 'heatmap';
+  xCategories?: readonly string[];
+  yCategories?: readonly string[];
+  data: readonly (readonly [number | string, number | string, number])[];
+}
+
+export interface OutputLimits {
+  maxTextBytes: number;
+  maxJsonBytes: number;
+  maxJsonDepth: number;
+  maxTableRows: number;
+  maxImageBytes: number;
+  maxHtmlBytes: number;
+}
+
+export interface RawCellExecutionResult {
+  stdout?: string;
+  stderr?: string;
+  value?: unknown;
+  plots?: readonly PlotSpec[];
+  outputs?: readonly OutputArtifact[];
+}
+
 export interface CellExecutionResult {
   stdout: string;
   stderr?: string;
   value?: unknown;
   plots: readonly PlotSpec[];
+  outputs: readonly OutputArtifact[];
 }
 
 export interface RuntimeWorkerRequest {
@@ -72,7 +221,7 @@ export type RuntimeWorkerResponse =
   | {
       requestId: number;
       ok: true;
-      result: CellExecutionResult;
+      result: RawCellExecutionResult;
     }
   | {
       requestId: number;

--- a/tests/unit/components.test.tsx
+++ b/tests/unit/components.test.tsx
@@ -286,13 +286,13 @@ describe('InteractiveCell', () => {
     await waitFor(() => expect(pending).toHaveLength(2));
 
     await act(async () => {
-      pending[1].resolve({ stdout: 'newer result', stderr: '', value: null, plots: [] });
+      pending[1].resolve({ stdout: 'newer result', stderr: '', value: null, plots: [], outputs: [] });
       await pending[1].promise;
     });
     await waitFor(() => expect(screen.getByTestId('run-output')).toHaveTextContent('newer result'));
 
     await act(async () => {
-      pending[0].resolve({ stdout: 'older result', stderr: '', value: null, plots: [] });
+      pending[0].resolve({ stdout: 'older result', stderr: '', value: null, plots: [], outputs: [] });
       await pending[0].promise;
     });
 
@@ -318,7 +318,7 @@ describe('InteractiveCell', () => {
     await waitFor(() => expect(pending).toHaveLength(2));
 
     await act(async () => {
-      pending[1].resolve({ stdout: 'newer result', stderr: '', value: null, plots: [] });
+      pending[1].resolve({ stdout: 'newer result', stderr: '', value: null, plots: [], outputs: [] });
       await pending[1].promise;
     });
     await waitFor(() => expect(screen.getByTestId('run-output')).toHaveTextContent('newer result'));

--- a/tests/unit/output-artifacts.test.ts
+++ b/tests/unit/output-artifacts.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from 'vitest';
+import {
+  defaultOutputLimits,
+  isOutputArtifact,
+  legacyResultToOutputs,
+  normalizeCellExecutionResult,
+  outputsToLegacyResult,
+  withDefaultOutputLimits
+} from '../../src/lib/doc-runtime/output-artifacts';
+
+describe('output artifact normalization', () => {
+  it('converts legacy cell fields to ordered output artifacts', () => {
+    const outputs = legacyResultToOutputs({
+      stdout: 'printed',
+      stderr: 'warned',
+      value: { ok: true },
+      plots: [{ kind: 'line', x_label: 'n', y_label: 'x', points: [[0, 0.2]] }]
+    });
+
+    expect(outputs).toEqual([
+      { kind: 'text', stream: 'stdout', content: 'printed' },
+      { kind: 'text', stream: 'stderr', content: 'warned' },
+      { kind: 'json', value: { ok: true } },
+      {
+        kind: 'chart',
+        spec: {
+          kind: 'line',
+          xLabel: 'n',
+          yLabel: 'x',
+          xType: 'value',
+          yType: 'value',
+          tooltip: true,
+          dataZoom: true,
+          series: [{ points: [[0, 0.2]] }]
+        }
+      }
+    ]);
+  });
+
+  it('derives legacy aliases from output artifacts', () => {
+    const result = outputsToLegacyResult([
+      { kind: 'text', stream: 'stdout', content: 'first' },
+      { kind: 'text', stream: 'stdout', content: 'second' },
+      { kind: 'text', stream: 'stderr', content: 'warning' },
+      { kind: 'json', value: { answer: 42 } },
+      {
+        kind: 'chart',
+        spec: {
+          kind: 'line',
+          xLabel: 'x',
+          yLabel: 'y',
+          series: [{ points: [[1, 2]] }]
+        }
+      }
+    ]);
+
+    expect(result).toMatchObject({
+      stdout: 'first\nsecond',
+      stderr: 'warning',
+      value: { answer: 42 },
+      plots: [{ kind: 'line', x_label: 'x', y_label: 'y', points: [[1, 2]] }]
+    });
+  });
+
+  it('normalizes legacy-only and outputs-only worker results', () => {
+    expect(normalizeCellExecutionResult({ stdout: 'old', plots: [] })).toEqual({
+      stdout: 'old',
+      plots: [],
+      outputs: [{ kind: 'text', stream: 'stdout', content: 'old' }]
+    });
+
+    expect(
+      normalizeCellExecutionResult({
+        outputs: [{ kind: 'json', value: ['new'] }]
+      })
+    ).toEqual({
+      stdout: '',
+      value: ['new'],
+      plots: [],
+      outputs: [{ kind: 'json', value: ['new'] }]
+    });
+  });
+
+  it('keeps explicit legacy aliases when outputs are already present', () => {
+    expect(
+      normalizeCellExecutionResult({
+        stdout: 'alias',
+        value: null,
+        plots: [{ kind: 'line', x_label: 'old-x', y_label: 'old-y', points: [[0, 0]] }],
+        outputs: [{ kind: 'json', value: { from: 'outputs' } }]
+      })
+    ).toEqual({
+      stdout: 'alias',
+      value: null,
+      plots: [{ kind: 'line', x_label: 'old-x', y_label: 'old-y', points: [[0, 0]] }],
+      outputs: [{ kind: 'json', value: { from: 'outputs' } }]
+    });
+  });
+
+  it('validates supported artifact shapes', () => {
+    expect(isOutputArtifact({ kind: 'text', stream: 'display', content: 'hello' })).toBe(true);
+    expect(isOutputArtifact({ kind: 'json', value: null })).toBe(true);
+    expect(isOutputArtifact({
+      kind: 'table',
+      columns: [{ key: 'count', label: 'Count', type: 'integer' }],
+      rows: [[1]],
+      rowCount: 1
+    })).toBe(true);
+    expect(isOutputArtifact({ kind: 'chart', spec: { kind: 'scatter', series: [] } })).toBe(true);
+    expect(isOutputArtifact({ kind: 'image', mime: 'image/svg+xml', data: '<svg />', alt: 'plot' })).toBe(true);
+    expect(isOutputArtifact({ kind: 'html', html: '<strong>x</strong>', sandboxed: true })).toBe(true);
+
+    expect(isOutputArtifact({ kind: 'text', stream: 'debug', content: 'hello' })).toBe(false);
+    expect(isOutputArtifact({ kind: 'json' })).toBe(false);
+    expect(isOutputArtifact({ kind: 'table', columns: [{ key: 'x', label: 'x', type: 'wide' }], rows: [] })).toBe(false);
+    expect(isOutputArtifact({ kind: 'chart', spec: { kind: 'pie' } })).toBe(false);
+    expect(isOutputArtifact({ kind: 'image', mime: 'image/gif', data: '' })).toBe(false);
+    expect(isOutputArtifact({ kind: 'html', html: '<script></script>', sandboxed: false })).toBe(false);
+    expect(isOutputArtifact({ kind: 'missing' })).toBe(false);
+  });
+
+  it('exposes overridable default output limits', () => {
+    expect(defaultOutputLimits).toEqual({
+      maxTextBytes: 200_000,
+      maxJsonBytes: 500_000,
+      maxJsonDepth: 32,
+      maxTableRows: 1_000,
+      maxImageBytes: 2_000_000,
+      maxHtmlBytes: 500_000
+    });
+    expect(withDefaultOutputLimits({ maxTableRows: 10 })).toEqual({
+      ...defaultOutputLimits,
+      maxTableRows: 10
+    });
+  });
+});

--- a/tests/unit/runtime-client.test.ts
+++ b/tests/unit/runtime-client.test.ts
@@ -47,7 +47,8 @@ class FakeWorker {
 
 const result: CellExecutionResult = {
   stdout: 'ok',
-  plots: []
+  plots: [],
+  outputs: [{ kind: 'text', stream: 'stdout', content: 'ok' }]
 };
 
 type DefaultFakeWorker = FakeWorker & {
@@ -138,6 +139,39 @@ describe('runtime client', () => {
     workers[0].emitMessage({ requestId: 1, ok: true, result });
 
     await expect(promise).resolves.toEqual(result);
+  });
+
+  it('normalizes legacy worker responses before resolving', async () => {
+    const { runner, workers } = makeRunner();
+    const promise = runner.runInteractiveCell(makeCell('python'), {});
+
+    workers[0].emitMessage({
+      requestId: 1,
+      ok: true,
+      result: {
+        stdout: 'legacy stdout',
+        value: { answer: 42 },
+        plots: [{ kind: 'line', x_label: 'x', y_label: 'y', points: [[0, 1]] }]
+      }
+    });
+
+    await expect(promise).resolves.toMatchObject({
+      stdout: 'legacy stdout',
+      value: { answer: 42 },
+      plots: [{ kind: 'line', x_label: 'x', y_label: 'y', points: [[0, 1]] }],
+      outputs: [
+        { kind: 'text', stream: 'stdout', content: 'legacy stdout' },
+        { kind: 'json', value: { answer: 42 } },
+        {
+          kind: 'chart',
+          spec: expect.objectContaining({
+            kind: 'line',
+            xLabel: 'x',
+            yLabel: 'y'
+          })
+        }
+      ]
+    });
   });
 
   it('sends Rust requests without Python-only fields and reuses workers', async () => {


### PR DESCRIPTION
## Summary
- add the shared OutputArtifact union, chart/table/media artifact types, and output limits
- add normalization helpers between legacy cell results and artifact outputs
- normalize worker responses in the runtime client while preserving legacy fields

## Validation
- pnpm test:unit
- pnpm check