### PR TITLE
Render interactive artifacts through output renderer

### DIFF
--- a/src/components/doc-runtime/InteractiveCell.tsx
+++ b/src/components/doc-runtime/InteractiveCell.tsx
@@ -8,6 +8,7 @@ import {
   shouldShowRunButton
 } from '../../lib/doc-runtime/interactive-cell-model';
 import { getCell, getManifestSnapshot, subscribeManifest } from '../../lib/doc-runtime/manifest';
+import { normalizeCellExecutionResult } from '../../lib/doc-runtime/output-artifacts';
 import { runInteractiveCell } from '../../lib/doc-runtime/runtime-client';
 import type {
   CellExecutionResult,
@@ -15,7 +16,7 @@ import type {
   InputSpec,
   InputValues
 } from '../../lib/doc-runtime/types';
-import PlotOutput from './PlotOutput';
+import OutputRenderer from './OutputRenderer';
 
 interface InteractiveCellProps {
   cellId: string;
@@ -289,22 +290,11 @@ function CellOutput({
     );
   }
 
+  const normalizedResult = normalizeCellExecutionResult(result);
+
   return (
     <div class="doc-cell__outputs">
-      {result.stdout ? (
-        <pre class="run-output" data-testid="run-output">
-          <code>{result.stdout}</code>
-        </pre>
-      ) : null}
-      {result.stderr ? <pre class="error-output">{result.stderr}</pre> : null}
-      {result.value != null && result.value !== '' ? (
-        <pre class="run-output" data-testid="value-output">
-          <code>{JSON.stringify(result.value, null, 2)}</code>
-        </pre>
-      ) : null}
-      {result.plots.map((plot, index) => (
-        <PlotOutput key={index} plot={plot} />
-      ))}
+      <OutputRenderer outputs={normalizedResult.outputs} />
     </div>
   );
 }

--- a/src/components/doc-runtime/OutputRenderer.tsx
+++ b/src/components/doc-runtime/OutputRenderer.tsx
@@ -1,0 +1,105 @@
+import { isOutputArtifact } from '../../lib/doc-runtime/output-artifacts';
+import type { ChartArtifact, OutputArtifact, PlotSpec, TextArtifact } from '../../lib/doc-runtime/types';
+import PlotOutput from './PlotOutput';
+
+interface OutputRendererProps {
+  outputs: readonly unknown[];
+}
+
+export default function OutputRenderer({ outputs }: OutputRendererProps) {
+  return (
+    <>
+      {outputs.map((output, index) => (
+        <ArtifactOutput key={artifactKey(output, index)} output={output} />
+      ))}
+    </>
+  );
+}
+
+function ArtifactOutput({ output }: { output: unknown }) {
+  if (!isOutputArtifact(output)) {
+    return <UnknownOutput message="Unsupported output artifact." />;
+  }
+
+  switch (output.kind) {
+    case 'text':
+      return <TextOutput output={output} />;
+    case 'json':
+      return (
+        <pre class="run-output" data-testid="value-output">
+          <code>{JSON.stringify(output.value, null, 2)}</code>
+        </pre>
+      );
+    case 'html':
+      return <HtmlOutput output={output} />;
+    case 'chart':
+      return <ChartOutput output={output} />;
+    case 'table':
+    case 'image':
+      return <UnknownOutput message={`Unsupported ${output.kind} output artifact.`} />;
+    default:
+      return <UnknownOutput message="Unsupported output artifact." />;
+  }
+}
+
+function TextOutput({ output }: { output: TextArtifact }) {
+  const isError = output.stream === 'stderr';
+  const className = isError ? 'error-output' : 'run-output';
+
+  return (
+    <pre class={className} data-testid={isError ? undefined : 'run-output'}>
+      <code>{output.content}</code>
+    </pre>
+  );
+}
+
+function HtmlOutput({ output }: { output: Extract<OutputArtifact, { kind: 'html' }> }) {
+  return (
+    <iframe
+      class="doc-html-output"
+      data-testid="html-output"
+      sandbox=""
+      srcdoc={output.html}
+      title={output.title ?? 'HTML output'}
+    />
+  );
+}
+
+function ChartOutput({ output }: { output: ChartArtifact }) {
+  const plot = legacyPlotFromChart(output);
+
+  if (!plot) {
+    return <UnknownOutput message="Unsupported chart output artifact." />;
+  }
+
+  return <PlotOutput plot={plot} />;
+}
+
+function legacyPlotFromChart(output: ChartArtifact): PlotSpec | undefined {
+  if (output.spec.kind !== 'line' || output.spec.series.length !== 1) return undefined;
+
+  const points = output.spec.series[0]?.points;
+  if (!points?.every((point) => point.every((value) => typeof value === 'number'))) {
+    return undefined;
+  }
+
+  return {
+    kind: 'line',
+    x_label: output.spec.xLabel ?? '',
+    y_label: output.spec.yLabel ?? '',
+    points: points as readonly [number, number][]
+  };
+}
+
+function UnknownOutput({ message }: { message: string }) {
+  return (
+    <p class="error-state" data-testid="artifact-error">
+      {message}
+    </p>
+  );
+}
+
+function artifactKey(output: unknown, index: number): string {
+  if (isOutputArtifact(output) && output.id) return output.id;
+  return String(index);
+}

--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -193,6 +193,14 @@
   background: var(--sl-color-bg);
 }
 
+.doc-html-output {
+  width: 100%;
+  min-height: 12rem;
+  border: 1px solid color-mix(in srgb, var(--sl-color-gray-5), transparent 35%);
+  border-radius: 6px;
+  background: var(--sl-color-bg);
+}
+
 .mermaid-diagram {
   display: grid;
   gap: 0.75rem;

--- a/tests/unit/components.test.tsx
+++ b/tests/unit/components.test.tsx
@@ -53,6 +53,7 @@ vi.mock('../../src/lib/doc-runtime/runtime-client', () => ({
 
 const { default: InteractiveCell } = await import('../../src/components/doc-runtime/InteractiveCell');
 const { default: MermaidDiagram } = await import('../../src/components/doc-runtime/MermaidDiagram');
+const { default: OutputRenderer } = await import('../../src/components/doc-runtime/OutputRenderer');
 const { default: PlotOutput } = await import('../../src/components/doc-runtime/PlotOutput');
 
 class TestResizeObserver {
@@ -473,5 +474,26 @@ describe('PlotOutput', () => {
 
     unmount();
     expect(mocks.chart.dispose).toHaveBeenCalled();
+  });
+});
+
+describe('OutputRenderer', () => {
+  it('renders sandboxed HTML and reports unsupported artifacts', () => {
+    render(
+      <OutputRenderer
+        outputs={[
+          { kind: 'html', html: '<strong>safe</strong>', sandboxed: true, title: 'HTML preview' },
+          { kind: 'table', columns: [{ key: 'x', label: 'x' }], rows: [[1]] },
+          { kind: 'unknown' }
+        ]}
+      />
+    );
+
+    expect(screen.getByTestId('html-output')).toHaveAttribute('sandbox', '');
+    expect(screen.getByTestId('html-output')).toHaveAttribute('srcdoc', '<strong>safe</strong>');
+    expect(screen.getByTestId('html-output')).toHaveAttribute('title', 'HTML preview');
+    expect(screen.getAllByTestId('artifact-error')).toHaveLength(2);
+    expect(screen.getByText('Unsupported table output artifact.')).toBeVisible();
+    expect(screen.getByText('Unsupported output artifact.')).toBeVisible();
   });
 });


### PR DESCRIPTION
## Summary
- add OutputRenderer for normalized artifact rendering
- switch InteractiveCell output rendering to the artifact path
- render text, JSON, sandboxed HTML, legacy line charts, and unsupported artifact errors

## Validation
- pnpm test:unit
- pnpm check