### PR TITLE
Add chart artifact renderer

### DIFF
--- a/src/components/doc-runtime/ChartOutput.tsx
+++ b/src/components/doc-runtime/ChartOutput.tsx
@@ -1,0 +1,176 @@
+import { BarChart, HeatmapChart, LineChart, ScatterChart } from 'echarts/charts';
+import {
+  DataZoomComponent,
+  GridComponent,
+  LegendComponent,
+  TitleComponent,
+  TooltipComponent,
+  VisualMapComponent
+} from 'echarts/components';
+import * as echarts from 'echarts/core';
+import { CanvasRenderer } from 'echarts/renderers';
+import { useEffect, useRef } from 'preact/hooks';
+import type { ChartSpec } from '../../lib/doc-runtime/types';
+
+echarts.use([
+  BarChart,
+  HeatmapChart,
+  LineChart,
+  ScatterChart,
+  GridComponent,
+  LegendComponent,
+  TitleComponent,
+  TooltipComponent,
+  VisualMapComponent,
+  DataZoomComponent,
+  CanvasRenderer
+]);
+
+interface ChartOutputProps {
+  spec: ChartSpec;
+}
+
+type EChartsInstance = ReturnType<typeof echarts.init>;
+export type EChartsOptions = Record<string, unknown> & {
+  series: readonly Record<string, unknown>[];
+};
+
+const palette = ['#0f766e', '#2563eb', '#9333ea', '#dc2626', '#ca8a04', '#4b5563'];
+
+export default function ChartOutput({ spec }: ChartOutputProps) {
+  const element = useRef<HTMLDivElement>(null);
+  const chart = useRef<EChartsInstance>();
+
+  useEffect(() => {
+    const chartElement = element.current!;
+    const nextChart = echarts.init(chartElement, undefined, { renderer: 'canvas' });
+    chart.current = nextChart;
+
+    const resizeObserver = new ResizeObserver(() => nextChart.resize());
+    resizeObserver.observe(chartElement);
+
+    return () => {
+      resizeObserver.disconnect();
+      nextChart.dispose();
+      chart.current = undefined;
+    };
+  }, []);
+
+  useEffect(() => {
+    chart.current!.setOption(chartSpecToEChartsOptions(spec), true);
+  }, [spec]);
+
+  return <div ref={element} class="doc-plot" data-testid="doc-plot" />;
+}
+
+export function chartSpecToEChartsOptions(spec: ChartSpec): EChartsOptions {
+  const series = chartSeries(spec);
+  const base = {
+    animation: false,
+    color: palette,
+    grid: { left: 56, right: 24, top: spec.title || shouldShowLegend(spec, series) ? 48 : 24, bottom: 56 },
+    tooltip: spec.tooltip === false ? undefined : { trigger: tooltipTrigger(spec) },
+    legend: shouldShowLegend(spec, series) ? { top: 4 } : undefined,
+    title: spec.title ? { text: spec.title, left: 'center', textStyle: { fontSize: 14, fontWeight: 600 } } : undefined,
+    xAxis: xAxis(spec),
+    yAxis: yAxis(spec),
+    dataZoom: spec.dataZoom === false ? undefined : [{ type: 'inside' }],
+    series
+  };
+
+  if (spec.kind === 'heatmap') {
+    return {
+      ...base,
+      dataZoom: undefined,
+      visualMap: { calculable: true, orient: 'horizontal', left: 'center', bottom: 0 }
+    };
+  }
+
+  return base;
+}
+
+function chartSeries(spec: ChartSpec): readonly Record<string, unknown>[] {
+  switch (spec.kind) {
+    case 'line':
+      return spec.series.map((series) => ({
+        type: 'line',
+        name: series.name,
+        showSymbol: false,
+        data: series.points
+      }));
+    case 'scatter':
+      return spec.series.map((series) => ({
+        type: 'scatter',
+        name: series.name,
+        symbolSize: 6,
+        data: series.points
+      }));
+    case 'bar':
+      return spec.series.map((series) => ({
+        type: 'bar',
+        name: series.name,
+        data: series.values
+      }));
+    case 'histogram':
+      return [
+        {
+          type: 'bar',
+          barCategoryGap: '8%',
+          data: spec.bins.map((bin) => bin[2])
+        }
+      ];
+    case 'area':
+      return spec.series.map((series) => ({
+        type: 'line',
+        name: series.name,
+        showSymbol: false,
+        areaStyle: { opacity: 0.18 },
+        data: series.points
+      }));
+    case 'heatmap':
+      return [{ type: 'heatmap', data: spec.data }];
+    default:
+      return [];
+  }
+}
+
+function xAxis(spec: ChartSpec): Record<string, unknown> {
+  if (spec.kind === 'bar') {
+    return categoryAxis(spec.categories, spec.xLabel);
+  }
+
+  if (spec.kind === 'histogram') {
+    return categoryAxis(spec.bins.map((bin) => `${bin[0]}-${bin[1]}`), spec.xLabel);
+  }
+
+  if (spec.kind === 'heatmap' && spec.xCategories) {
+    return categoryAxis(spec.xCategories, spec.xLabel);
+  }
+
+  return valueAxis(spec.xType ?? 'value', spec.xLabel);
+}
+
+function yAxis(spec: ChartSpec): Record<string, unknown> {
+  if (spec.kind === 'heatmap' && spec.yCategories) {
+    return categoryAxis(spec.yCategories, spec.yLabel);
+  }
+
+  return valueAxis(spec.yType ?? 'value', spec.yLabel);
+}
+
+function categoryAxis(data: readonly string[], name?: string): Record<string, unknown> {
+  return { type: 'category', data, name, nameLocation: 'middle', nameGap: 34 };
+}
+
+function valueAxis(type: NonNullable<ChartSpec['xType']>, name?: string): Record<string, unknown> {
+  return { type, name, nameLocation: 'middle', nameGap: 34, scale: true };
+}
+
+function tooltipTrigger(spec: ChartSpec): 'axis' | 'item' {
+  return spec.kind === 'scatter' || spec.kind === 'heatmap' ? 'item' : 'axis';
+}
+
+function shouldShowLegend(spec: ChartSpec, series: readonly Record<string, unknown>[]): boolean {
+  if (spec.legend != null) return spec.legend;
+  return series.filter((item) => typeof item.name === 'string' && item.name.length > 0).length > 1;
+}

--- a/src/components/doc-runtime/OutputRenderer.tsx
+++ b/src/components/doc-runtime/OutputRenderer.tsx
@@ -1,6 +1,6 @@
 import { isOutputArtifact } from '../../lib/doc-runtime/output-artifacts';
-import type { ChartArtifact, OutputArtifact, PlotSpec, TextArtifact } from '../../lib/doc-runtime/types';
-import PlotOutput from './PlotOutput';
+import type { OutputArtifact, TextArtifact } from '../../lib/doc-runtime/types';
+import ChartOutput from './ChartOutput';
 
 interface OutputRendererProps {
   outputs: readonly unknown[];
@@ -33,7 +33,7 @@ function ArtifactOutput({ output }: { output: unknown }) {
     case 'html':
       return <HtmlOutput output={output} />;
     case 'chart':
-      return <ChartOutput output={output} />;
+      return <ChartOutput spec={output.spec} />;
     case 'table':
     case 'image':
       return <UnknownOutput message={`Unsupported ${output.kind} output artifact.`} />;
@@ -63,32 +63,6 @@ function HtmlOutput({ output }: { output: Extract<OutputArtifact, { kind: 'html'
       title={output.title ?? 'HTML output'}
     />
   );
-}
-
-function ChartOutput({ output }: { output: ChartArtifact }) {
-  const plot = legacyPlotFromChart(output);
-
-  if (!plot) {
-    return <UnknownOutput message="Unsupported chart output artifact." />;
-  }
-
-  return <PlotOutput plot={plot} />;
-}
-
-function legacyPlotFromChart(output: ChartArtifact): PlotSpec | undefined {
-  if (output.spec.kind !== 'line' || output.spec.series.length !== 1) return undefined;
-
-  const points = output.spec.series[0]?.points;
-  if (!points?.every((point) => point.every((value) => typeof value === 'number'))) {
-    return undefined;
-  }
-
-  return {
-    kind: 'line',
-    x_label: output.spec.xLabel ?? '',
-    y_label: output.spec.yLabel ?? '',
-    points: points as readonly [number, number][]
-  };
 }
 
 function UnknownOutput({ message }: { message: string }) {

--- a/src/components/doc-runtime/PlotOutput.tsx
+++ b/src/components/doc-runtime/PlotOutput.tsx
@@ -1,58 +1,23 @@
-import { LineChart } from 'echarts/charts';
-import { DataZoomComponent, GridComponent, TooltipComponent } from 'echarts/components';
-import * as echarts from 'echarts/core';
-import { CanvasRenderer } from 'echarts/renderers';
-import { useEffect, useRef } from 'preact/hooks';
-import type { PlotSpec } from '../../lib/doc-runtime/types';
-
-echarts.use([LineChart, GridComponent, TooltipComponent, DataZoomComponent, CanvasRenderer]);
+import type { ChartSpec, PlotSpec } from '../../lib/doc-runtime/types';
+import ChartOutput from './ChartOutput';
 
 interface PlotOutputProps {
   plot: PlotSpec;
 }
 
-type EChartsInstance = ReturnType<typeof echarts.init>;
-
 export default function PlotOutput({ plot }: PlotOutputProps) {
-  const element = useRef<HTMLDivElement>(null);
-  const chart = useRef<EChartsInstance>();
+  return <ChartOutput spec={legacyPlotToChartSpec(plot)} />;
+}
 
-  useEffect(() => {
-    const chartElement = element.current!;
-    const nextChart = echarts.init(chartElement, undefined, { renderer: 'canvas' });
-    chart.current = nextChart;
-
-    const resizeObserver = new ResizeObserver(() => nextChart.resize());
-    resizeObserver.observe(chartElement);
-
-    return () => {
-      resizeObserver.disconnect();
-      nextChart.dispose();
-      chart.current = undefined;
-    };
-  }, []);
-
-  useEffect(() => {
-    chart.current!.setOption(
-      {
-        animation: false,
-        color: ['#0f766e'],
-        grid: { left: 48, right: 18, top: 18, bottom: 48 },
-        tooltip: { trigger: 'axis' },
-        xAxis: { type: 'value', name: plot.x_label },
-        yAxis: { type: 'value', name: plot.y_label },
-        dataZoom: [{ type: 'inside' }],
-        series: [
-          {
-            type: 'line',
-            showSymbol: false,
-            data: plot.points
-          }
-        ]
-      },
-      true
-    );
-  }, [plot]);
-
-  return <div ref={element} class="doc-plot" data-testid="doc-plot" />;
+function legacyPlotToChartSpec(plot: PlotSpec): ChartSpec {
+  return {
+    kind: 'line',
+    xLabel: plot.x_label,
+    yLabel: plot.y_label,
+    xType: 'value',
+    yType: 'value',
+    tooltip: true,
+    dataZoom: true,
+    series: [{ points: plot.points }]
+  };
 }

--- a/tests/unit/components.test.tsx
+++ b/tests/unit/components.test.tsx
@@ -22,11 +22,14 @@ const mocks = vi.hoisted(() => {
   };
 });
 
-vi.mock('echarts/charts', () => ({ LineChart: {} }));
+vi.mock('echarts/charts', () => ({ BarChart: {}, HeatmapChart: {}, LineChart: {}, ScatterChart: {} }));
 vi.mock('echarts/components', () => ({
   DataZoomComponent: {},
   GridComponent: {},
-  TooltipComponent: {}
+  LegendComponent: {},
+  TitleComponent: {},
+  TooltipComponent: {},
+  VisualMapComponent: {}
 }));
 vi.mock('echarts/renderers', () => ({ CanvasRenderer: {} }));
 vi.mock('echarts/core', () => ({
@@ -55,6 +58,7 @@ const { default: InteractiveCell } = await import('../../src/components/doc-runt
 const { default: MermaidDiagram } = await import('../../src/components/doc-runtime/MermaidDiagram');
 const { default: OutputRenderer } = await import('../../src/components/doc-runtime/OutputRenderer');
 const { default: PlotOutput } = await import('../../src/components/doc-runtime/PlotOutput');
+const { chartSpecToEChartsOptions } = await import('../../src/components/doc-runtime/ChartOutput');
 
 class TestResizeObserver {
   static instances: TestResizeObserver[] = [];
@@ -181,8 +185,8 @@ describe('InteractiveCell', () => {
     await waitFor(() =>
       expect(mocks.chart.setOption).toHaveBeenCalledWith(
         expect.objectContaining({
-          xAxis: { type: 'value', name: 'x' },
-          yAxis: { type: 'value', name: 'y' }
+          xAxis: expect.objectContaining({ type: 'value', name: 'x' }),
+          yAxis: expect.objectContaining({ type: 'value', name: 'y' })
         }),
         true
       )
@@ -466,7 +470,7 @@ describe('PlotOutput', () => {
     expect(mocks.chart.resize).toHaveBeenCalled();
     expect(mocks.chart.setOption).toHaveBeenCalledWith(
       expect.objectContaining({
-        color: ['#0f766e'],
+        color: expect.arrayContaining(['#0f766e']),
         series: [expect.objectContaining({ type: 'line', data: [[0, 0.2]] })]
       }),
       true
@@ -474,6 +478,76 @@ describe('PlotOutput', () => {
 
     unmount();
     expect(mocks.chart.dispose).toHaveBeenCalled();
+  });
+});
+
+describe('ChartOutput options', () => {
+  it('maps supported chart specs to ECharts options', () => {
+    expect(chartSpecToEChartsOptions({
+      kind: 'line',
+      xLabel: 'n',
+      yLabel: 'x',
+      series: [{ name: 'a', points: [[0, 1]] }, { name: 'b', points: [[0, 2]] }]
+    })).toMatchObject({
+      legend: { top: 4 },
+      tooltip: { trigger: 'axis' },
+      xAxis: { type: 'value', name: 'n' },
+      yAxis: { type: 'value', name: 'x' },
+      series: [
+        { type: 'line', showSymbol: false, data: [[0, 1]] },
+        { type: 'line', showSymbol: false, data: [[0, 2]] }
+      ]
+    });
+
+    expect(chartSpecToEChartsOptions({
+      kind: 'scatter',
+      tooltip: true,
+      series: [{ points: [[0, 1]] }]
+    })).toMatchObject({
+      tooltip: { trigger: 'item' },
+      series: [{ type: 'scatter', symbolSize: 6, data: [[0, 1]] }]
+    });
+
+    expect(chartSpecToEChartsOptions({
+      kind: 'bar',
+      categories: ['A', 'B'],
+      series: [{ values: [1, null] }]
+    })).toMatchObject({
+      xAxis: { type: 'category', data: ['A', 'B'] },
+      series: [{ type: 'bar', data: [1, null] }]
+    });
+
+    expect(chartSpecToEChartsOptions({
+      kind: 'histogram',
+      bins: [[0, 1, 2], [1, 2, 3]]
+    })).toMatchObject({
+      xAxis: { type: 'category', data: ['0-1', '1-2'] },
+      series: [{ type: 'bar', barCategoryGap: '8%', data: [2, 3] }]
+    });
+
+    expect(chartSpecToEChartsOptions({
+      kind: 'area',
+      dataZoom: false,
+      series: [{ points: [[0, 1]] }]
+    })).toMatchObject({
+      dataZoom: undefined,
+      series: [{ type: 'line', areaStyle: { opacity: 0.18 }, data: [[0, 1]] }]
+    });
+
+    expect(chartSpecToEChartsOptions({
+      kind: 'heatmap',
+      title: 'Heat',
+      xCategories: ['x'],
+      yCategories: ['y'],
+      data: [['x', 'y', 5]]
+    })).toMatchObject({
+      title: { text: 'Heat' },
+      xAxis: { type: 'category', data: ['x'] },
+      yAxis: { type: 'category', data: ['y'] },
+      dataZoom: undefined,
+      visualMap: expect.objectContaining({ calculable: true }),
+      series: [{ type: 'heatmap', data: [['x', 'y', 5]] }]
+    });
   });
 });
 


### PR DESCRIPTION
## Summary
- add ChartOutput for line, scatter, bar, histogram, area, and heatmap specs
- keep PlotOutput as a legacy line-plot compatibility wrapper
- render chart artifacts directly from OutputRenderer

## Validation
- pnpm test:unit
- pnpm check
- pnpm test:e2e