### PR TITLE
Render table output artifacts

### DIFF
--- a/src/components/doc-runtime/OutputRenderer.tsx
+++ b/src/components/doc-runtime/OutputRenderer.tsx
@@ -1,6 +1,7 @@
 import { isOutputArtifact } from '../../lib/doc-runtime/output-artifacts';
 import type { OutputArtifact, TextArtifact } from '../../lib/doc-runtime/types';
 import ChartOutput from './ChartOutput';
+import TableOutput from './TableOutput';
 
 interface OutputRendererProps {
   outputs: readonly unknown[];
@@ -35,6 +36,7 @@ function ArtifactOutput({ output }: { output: unknown }) {
     case 'chart':
       return <ChartOutput spec={output.spec} />;
     case 'table':
+      return <TableOutput table={output} />;
     case 'image':
       return <UnknownOutput message={`Unsupported ${output.kind} output artifact.`} />;
     default:

--- a/src/components/doc-runtime/TableOutput.tsx
+++ b/src/components/doc-runtime/TableOutput.tsx
@@ -1,0 +1,172 @@
+import { useMemo, useState } from 'preact/hooks';
+import type { TableArtifact, TableColumn } from '../../lib/doc-runtime/types';
+
+interface TableOutputProps {
+  table: TableArtifact;
+}
+
+type SortDirection = 'asc' | 'desc';
+type SortState = {
+  columnIndex: number;
+  direction: SortDirection;
+};
+
+const pageSizes = [10, 25, 50, 100] as const;
+
+export default function TableOutput({ table }: TableOutputProps) {
+  const [pageSize, setPageSize] = useState<(typeof pageSizes)[number]>(pageSizes[0]);
+  const [page, setPage] = useState(0);
+  const [sort, setSort] = useState<SortState>();
+  const sortedRows = useMemo(() => sortRows(table.rows, sort), [table.rows, sort]);
+  const pageCount = Math.max(1, Math.ceil(sortedRows.length / pageSize));
+  const safePage = Math.min(page, pageCount - 1);
+  const currentRows = visibleRows(sortedRows, safePage, pageSize);
+  const firstRow = sortedRows.length === 0 ? 0 : safePage * pageSize + 1;
+  const lastRow = Math.min(sortedRows.length, (safePage + 1) * pageSize);
+
+  function updateSort(columnIndex: number): void {
+    setPage(0);
+    setSort((current) => {
+      if (!current || current.columnIndex !== columnIndex) return { columnIndex, direction: 'asc' };
+      return { columnIndex, direction: current.direction === 'asc' ? 'desc' : 'asc' };
+    });
+  }
+
+  async function copyVisibleCsv(): Promise<void> {
+    await globalThis.navigator.clipboard?.writeText(tableToCsv(table.columns, currentRows));
+  }
+
+  return (
+    <section class="doc-table-output" data-testid="table-output">
+      {table.caption ? <p class="doc-table-output__caption">{table.caption}</p> : null}
+      <div class="doc-table-output__scroller">
+        <table>
+          {table.title ? <caption>{table.title}</caption> : null}
+          <thead>
+            <tr>
+              {table.columns.map((column, columnIndex) => (
+                <th key={column.key} scope="col" aria-sort={ariaSort(sort, columnIndex)}>
+                  <button type="button" onClick={() => updateSort(columnIndex)}>
+                    {column.label}
+                  </button>
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {currentRows.map((row, rowIndex) => (
+              <tr key={`${safePage}:${rowIndex}`}>
+                {table.columns.map((column, columnIndex) => (
+                  <td key={column.key} data-type={column.type ?? 'unknown'}>
+                    {formatTableCell(row[columnIndex])}
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      <div class="doc-table-output__footer">
+        <p>
+          Rows {firstRow}-{lastRow} of {table.rowCount ?? sortedRows.length}
+          {table.truncated ? ' (truncated)' : ''}
+        </p>
+        <div class="doc-table-output__controls">
+          <label>
+            <span>Rows</span>
+            <select
+              data-testid="table-page-size"
+              value={String(pageSize)}
+              onInput={(event) => {
+                setPage(0);
+                setPageSize(Number(event.currentTarget.value) as (typeof pageSizes)[number]);
+              }}
+            >
+              {pageSizes.map((size) => (
+                <option key={size} value={size}>
+                  {size}
+                </option>
+              ))}
+            </select>
+          </label>
+          <button type="button" data-testid="table-copy-csv" onClick={copyVisibleCsv}>
+            Copy CSV
+          </button>
+          <button
+            type="button"
+            data-testid="table-prev"
+            disabled={safePage === 0}
+            onClick={() => setPage((current) => Math.max(0, current - 1))}
+          >
+            Prev
+          </button>
+          <button
+            type="button"
+            data-testid="table-next"
+            disabled={safePage >= pageCount - 1}
+            onClick={() => setPage((current) => Math.min(pageCount - 1, current + 1))}
+          >
+            Next
+          </button>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export function sortRows(rows: readonly unknown[][], sort?: SortState): readonly unknown[][] {
+  if (!sort) return rows;
+
+  return rows
+    .map((row, index) => ({ index, row }))
+    .sort((left, right) => {
+      const compared = compareCellValues(left.row[sort.columnIndex], right.row[sort.columnIndex]);
+      return sort.direction === 'asc' ? compared || left.index - right.index : -compared || left.index - right.index;
+    })
+    .map(({ row }) => row);
+}
+
+export function visibleRows(rows: readonly unknown[][], page: number, pageSize: number): readonly unknown[][] {
+  return rows.slice(page * pageSize, (page + 1) * pageSize);
+}
+
+export function tableToCsv(columns: readonly TableColumn[], rows: readonly unknown[][]): string {
+  return [
+    columns.map((column) => csvCell(column.label)).join(','),
+    ...rows.map((row) => columns.map((_, index) => csvCell(row[index])).join(','))
+  ].join('\n');
+}
+
+export function formatTableCell(value: unknown): string {
+  if (value === null) return 'null';
+  if (value === undefined) return 'missing';
+  if (typeof value === 'number') {
+    return Number.isFinite(value)
+      ? new Intl.NumberFormat('en-US', { maximumSignificantDigits: 6 }).format(value)
+      : String(value);
+  }
+  if (typeof value === 'boolean') return value ? 'true' : 'false';
+  if (typeof value === 'string') return value;
+  return JSON.stringify(value);
+}
+
+function compareCellValues(left: unknown, right: unknown): number {
+  if (left == null && right == null) return 0;
+  if (left == null) return 1;
+  if (right == null) return -1;
+  if (typeof left === 'number' && typeof right === 'number') return left - right;
+  if (typeof left === 'boolean' && typeof right === 'boolean') return Number(left) - Number(right);
+  return String(left).localeCompare(String(right));
+}
+
+function csvCell(value: unknown): string {
+  if (value == null) return '';
+
+  const text = typeof value === 'object' ? JSON.stringify(value) : String(value);
+  return /[",\n\r]/u.test(text) ? `"${text.replace(/"/gu, '""')}"` : text;
+}
+
+function ariaSort(sort: SortState | undefined, columnIndex: number): 'ascending' | 'descending' | 'none' {
+  if (!sort || sort.columnIndex !== columnIndex) return 'none';
+  return sort.direction === 'asc' ? 'ascending' : 'descending';
+}

--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -201,6 +201,107 @@
   background: var(--sl-color-bg);
 }
 
+.doc-table-output {
+  display: grid;
+  gap: 0.65rem;
+  min-width: 0;
+}
+
+.doc-table-output__caption,
+.doc-table-output__footer p {
+  margin: 0;
+  color: var(--sl-color-gray-2);
+  font-size: 0.85rem;
+}
+
+.doc-table-output__scroller {
+  max-height: 28rem;
+  overflow: auto;
+  border: 1px solid color-mix(in srgb, var(--sl-color-gray-5), transparent 35%);
+  border-radius: 6px;
+  background: var(--sl-color-bg);
+}
+
+.doc-table-output table {
+  width: 100%;
+  min-width: 36rem;
+  border-collapse: collapse;
+  font-size: 0.9rem;
+}
+
+.doc-table-output caption {
+  padding: 0.65rem 0.75rem;
+  text-align: left;
+  font-weight: 650;
+}
+
+.doc-table-output th,
+.doc-table-output td {
+  padding: 0.55rem 0.75rem;
+  border-bottom: 1px solid color-mix(in srgb, var(--sl-color-gray-5), transparent 55%);
+  text-align: left;
+  vertical-align: top;
+}
+
+.doc-table-output th {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  background: var(--sl-color-bg);
+}
+
+.doc-table-output th button {
+  width: 100%;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  font-weight: 650;
+  text-align: inherit;
+  cursor: pointer;
+}
+
+.doc-table-output td[data-type='number'],
+.doc-table-output td[data-type='integer'] {
+  font-variant-numeric: tabular-nums;
+  text-align: right;
+}
+
+.doc-table-output__footer,
+.doc-table-output__controls {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.6rem;
+  flex-wrap: wrap;
+}
+
+.doc-table-output__controls label {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.doc-table-output__controls button,
+.doc-table-output__controls select {
+  min-height: 2rem;
+  border: 1px solid var(--rn-panel-border);
+  border-radius: 6px;
+  background: var(--sl-color-bg);
+  color: var(--sl-color-text);
+  font: inherit;
+}
+
+.doc-table-output__controls button {
+  padding: 0 0.65rem;
+  cursor: pointer;
+}
+
+.doc-table-output__controls button:disabled {
+  cursor: not-allowed;
+  opacity: 0.62;
+}
+
 .mermaid-diagram {
   display: grid;
   gap: 0.75rem;

--- a/tests/unit/components.test.tsx
+++ b/tests/unit/components.test.tsx
@@ -59,6 +59,13 @@ const { default: MermaidDiagram } = await import('../../src/components/doc-runti
 const { default: OutputRenderer } = await import('../../src/components/doc-runtime/OutputRenderer');
 const { default: PlotOutput } = await import('../../src/components/doc-runtime/PlotOutput');
 const { chartSpecToEChartsOptions } = await import('../../src/components/doc-runtime/ChartOutput');
+const {
+  default: TableOutput,
+  formatTableCell,
+  sortRows,
+  tableToCsv,
+  visibleRows
+} = await import('../../src/components/doc-runtime/TableOutput');
 
 class TestResizeObserver {
   static instances: TestResizeObserver[] = [];
@@ -557,7 +564,7 @@ describe('OutputRenderer', () => {
       <OutputRenderer
         outputs={[
           { kind: 'html', html: '<strong>safe</strong>', sandboxed: true, title: 'HTML preview' },
-          { kind: 'table', columns: [{ key: 'x', label: 'x' }], rows: [[1]] },
+          { kind: 'image', mime: 'image/png', data: 'abc' },
           { kind: 'unknown' }
         ]}
       />
@@ -567,7 +574,84 @@ describe('OutputRenderer', () => {
     expect(screen.getByTestId('html-output')).toHaveAttribute('srcdoc', '<strong>safe</strong>');
     expect(screen.getByTestId('html-output')).toHaveAttribute('title', 'HTML preview');
     expect(screen.getAllByTestId('artifact-error')).toHaveLength(2);
-    expect(screen.getByText('Unsupported table output artifact.')).toBeVisible();
+    expect(screen.getByText('Unsupported image output artifact.')).toBeVisible();
     expect(screen.getByText('Unsupported output artifact.')).toBeVisible();
+  });
+});
+
+describe('TableOutput', () => {
+  it('renders table artifacts with sorting, pagination, and CSV copy', async () => {
+    const writeText = vi.fn();
+    Object.defineProperty(globalThis.navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText }
+    });
+    const rows = Array.from({ length: 12 }, (_, index) => [12 - index, `row ${index + 1}`, index % 2 === 0]);
+
+    render(
+      <TableOutput
+        table={{
+          kind: 'table',
+          title: 'Scores',
+          caption: 'Preview rows',
+          columns: [
+            { key: 'score', label: 'Score', type: 'integer' },
+            { key: 'label', label: 'Label', type: 'string' },
+            { key: 'enabled', label: 'Enabled', type: 'boolean' }
+          ],
+          rows,
+          rowCount: 20,
+          truncated: true
+        }}
+      />
+    );
+
+    expect(screen.getByTestId('table-output')).toBeVisible();
+    expect(screen.getByText('Scores')).toBeVisible();
+    expect(screen.getByText('Preview rows')).toBeVisible();
+    expect(screen.getByText('Rows 1-10 of 20 (truncated)')).toBeVisible();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Score' }));
+    expect(screen.getByRole('columnheader', { name: 'Score' })).toHaveAttribute('aria-sort', 'ascending');
+    expect(screen.getAllByRole('cell')[0]).toHaveTextContent('1');
+
+    fireEvent.click(screen.getByTestId('table-next'));
+    expect(screen.getByText('Rows 11-12 of 20 (truncated)')).toBeVisible();
+
+    fireEvent.input(screen.getByTestId('table-page-size'), { target: { value: '25' } });
+    expect(screen.getByText('Rows 1-12 of 20 (truncated)')).toBeVisible();
+
+    fireEvent.click(screen.getByTestId('table-copy-csv'));
+    await waitFor(() => expect(writeText).toHaveBeenCalledWith(expect.stringContaining('Score,Label,Enabled')));
+    expect(rows[0]).toEqual([12, 'row 1', true]);
+  });
+
+  it('sorts and formats table values without mutating rows', () => {
+    const rows = [[2, 'b'], [null, 'z'], [1, 'a'], [undefined, 'y']];
+
+    expect(sortRows(rows, { columnIndex: 0, direction: 'asc' })).toEqual([[1, 'a'], [2, 'b'], [null, 'z'], [undefined, 'y']]);
+    expect(sortRows(rows, { columnIndex: 1, direction: 'desc' })).toEqual([[null, 'z'], [undefined, 'y'], [2, 'b'], [1, 'a']]);
+    expect(visibleRows(rows, 1, 2)).toEqual([[1, 'a'], [undefined, 'y']]);
+    expect(rows[0]).toEqual([2, 'b']);
+    expect(formatTableCell(1234.5678)).toBe('1,234.57');
+    expect(formatTableCell(null)).toBe('null');
+    expect(formatTableCell(undefined)).toBe('missing');
+    expect(formatTableCell({ nested: true })).toBe('{"nested":true}');
+  });
+
+  it('copies visible table data as escaped CSV', () => {
+    expect(
+      tableToCsv(
+        [
+          { key: 'a', label: 'A' },
+          { key: 'b', label: 'B' }
+        ],
+        [
+          ['comma,value', 'quote "value"'],
+          ['line\nbreak', null],
+          [true, { nested: true }]
+        ]
+      )
+    ).toBe('A,B\n"comma,value","quote ""value"""\n"line\nbreak",\ntrue,"{""nested"":true}"');
   });
 });


### PR DESCRIPTION
## Summary
- add TableOutput for accessible artifact table rendering
- support sorting, pagination, row count/truncation display, and CSV copy
- wire table artifacts into OutputRenderer

## Validation
- pnpm test:unit
- pnpm check