### PR TITLE
Capture Python rich display artifacts

### DIFF
--- a/src/lib/doc-runtime/python-worker.ts
+++ b/src/lib/doc-runtime/python-worker.ts
@@ -1,4 +1,8 @@
-import type { CellExecutionResult, RuntimeWorkerRequest, RuntimeWorkerResponse } from './types';
+import {
+  isOutputArtifact,
+  legacyResultToOutputs
+} from './output-artifacts';
+import type { CellExecutionResult, OutputArtifact, RuntimeWorkerRequest, RuntimeWorkerResponse } from './types';
 
 type LoadPyodide = typeof import('pyodide').loadPyodide;
 type PyodideRuntime = Awaited<ReturnType<LoadPyodide>>;
@@ -13,6 +17,117 @@ let pyodideReady: Promise<PyodideRuntime> | undefined;
 let loadPyodideReady: Promise<LoadPyodide> | undefined;
 const pyodideModuleUrl = '/pyodide/pyodide.mjs';
 const requestQueue = createSerialRequestQueue(handleRequest);
+
+export const pythonDisplaySupportCode = String.raw`
+import base64
+import builtins
+import json
+
+__oxiquill_outputs = []
+__oxiquill_table_limit = 1000
+
+def __oxiquill_meta(artifact, title=None, caption=None):
+    if title is not None:
+        artifact["title"] = str(title)
+    if caption is not None:
+        artifact["caption"] = str(caption)
+    return artifact
+
+def __oxiquill_jsonable(value):
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, (list, tuple)):
+        return [__oxiquill_jsonable(item) for item in value]
+    if isinstance(value, dict):
+        return {str(key): __oxiquill_jsonable(item) for key, item in value.items()}
+    return str(value)
+
+def __oxiquill_json_artifact(value, title=None, caption=None):
+    json_value = __oxiquill_jsonable(value)
+    json.dumps(json_value)
+    return __oxiquill_meta({"kind": "json", "value": json_value}, title, caption)
+
+def __oxiquill_image_data(data):
+    if isinstance(data, bytes):
+        return base64.b64encode(data).decode("ascii")
+    return str(data)
+
+def __oxiquill_artifact(value, title=None, caption=None):
+    if value is None or isinstance(value, (str, int, float, bool, list, tuple, dict)):
+        return __oxiquill_json_artifact(value, title, caption)
+    for method_name, mime in (
+        ("_repr_svg_", "image/svg+xml"),
+        ("_repr_png_", "image/png"),
+        ("_repr_jpeg_", "image/jpeg"),
+    ):
+        method = getattr(value, method_name, None)
+        if callable(method):
+            data = method()
+            if data:
+                return __oxiquill_meta(
+                    {"kind": "image", "mime": mime, "data": __oxiquill_image_data(data)},
+                    title,
+                    caption,
+                )
+    html_repr = getattr(value, "_repr_html_", None)
+    if callable(html_repr):
+        html = html_repr()
+        if html:
+            return __oxiquill_meta({"kind": "html", "html": str(html), "sandboxed": True}, title, caption)
+    return __oxiquill_meta({"kind": "text", "stream": "display", "content": str(value)}, title, caption)
+
+def display(value, *, title=None, caption=None):
+    __oxiquill_outputs.append(__oxiquill_artifact(value, title, caption))
+
+def display_json(value, *, title=None):
+    __oxiquill_outputs.append(__oxiquill_json_artifact(value, title))
+
+def display_html(html, *, title=None):
+    __oxiquill_outputs.append(__oxiquill_meta({"kind": "html", "html": str(html), "sandboxed": True}, title))
+
+def display_image(data, mime, *, alt=None, title=None):
+    artifact = {"kind": "image", "mime": str(mime), "data": __oxiquill_image_data(data)}
+    if alt is not None:
+        artifact["alt"] = str(alt)
+    __oxiquill_outputs.append(__oxiquill_meta(artifact, title))
+
+def display_table(value, *, title=None, caption=None):
+    rows = list(value)
+    truncated = len(rows) > __oxiquill_table_limit
+    preview = rows[:__oxiquill_table_limit]
+    if preview and isinstance(preview[0], dict):
+        keys = list(preview[0].keys())
+        columns = [{"key": str(key), "label": str(key), "type": "unknown"} for key in keys]
+        table_rows = [[__oxiquill_jsonable(row.get(key)) for key in keys] for row in preview]
+    else:
+        width = max((len(row) if isinstance(row, (list, tuple)) else 1 for row in preview), default=0)
+        columns = [{"key": str(index), "label": str(index + 1), "type": "unknown"} for index in range(width)]
+        table_rows = [
+            [__oxiquill_jsonable(row[index]) if isinstance(row, (list, tuple)) and index < len(row) else None for index in range(width)]
+            for row in preview
+        ]
+    __oxiquill_outputs.append(__oxiquill_meta({
+        "kind": "table",
+        "columns": columns,
+        "rows": table_rows,
+        "rowCount": len(rows),
+        "truncated": truncated,
+    }, title, caption))
+
+def __oxiquill_reset_outputs():
+    __oxiquill_outputs.clear()
+
+def __oxiquill_take_outputs():
+    outputs = list(__oxiquill_outputs)
+    __oxiquill_outputs.clear()
+    return outputs
+
+builtins.display = display
+builtins.display_json = display_json
+builtins.display_html = display_html
+builtins.display_table = display_table
+builtins.display_image = display_image
+`;
 
 worker.addEventListener('message', (event) => {
   requestQueue.enqueue(event.data);
@@ -41,6 +156,7 @@ async function handleRequest(request: RuntimeWorkerRequest): Promise<void> {
 
     pyodide.setStdout({ batched: (output) => stdout.push(output) });
     pyodide.setStderr({ batched: (output) => stderr.push(output) });
+    pyodide.runPython('__oxiquill_reset_outputs()');
 
     if (request.packages && request.packages.length > 0) {
       await pyodide.loadPackage(Array.from(request.packages));
@@ -57,14 +173,17 @@ async function handleRequest(request: RuntimeWorkerRequest): Promise<void> {
     } finally {
       globals.destroy();
     }
+    const displayOutputs = toOutputArtifacts(
+      toSerializable(pyodide.runPython('__oxiquill_take_outputs()'))
+    );
 
-    const result: CellExecutionResult = {
+    const result = createPythonCellResult({
       stdout: stdout.join('\n').trimEnd(),
       stderr: stderr.join('\n').trimEnd(),
       value,
       plots: [],
-      outputs: []
-    };
+      displayOutputs
+    });
 
     worker.postMessage({ requestId: request.requestId, ok: true, result });
   } catch (error) {
@@ -77,7 +196,11 @@ async function handleRequest(request: RuntimeWorkerRequest): Promise<void> {
 }
 
 function ensurePyodide(): Promise<PyodideRuntime> {
-  pyodideReady ??= getLoadPyodide().then((loadPyodide) => loadPyodide({ indexURL: '/pyodide/' }));
+  pyodideReady ??= getLoadPyodide().then(async (loadPyodide) => {
+    const pyodide = await loadPyodide({ indexURL: '/pyodide/' });
+    await pyodide.runPythonAsync(pythonDisplaySupportCode);
+    return pyodide;
+  });
   return pyodideReady;
 }
 
@@ -109,7 +232,7 @@ function toSerializable(value: unknown): unknown {
   if (typeof value === 'object' && value && 'toJs' in value) {
     const proxy = value as { destroy?: () => void; toJs: (options?: unknown) => unknown };
     try {
-      return proxy.toJs();
+      return proxy.toJs({ dict_converter: Object.fromEntries });
     } finally {
       proxy.destroy?.();
     }
@@ -120,4 +243,33 @@ function toSerializable(value: unknown): unknown {
   }
 
   return String(value);
+}
+
+export function createPythonCellResult({
+  displayOutputs,
+  plots,
+  stderr,
+  stdout,
+  value
+}: {
+  displayOutputs: readonly OutputArtifact[];
+  plots: CellExecutionResult['plots'];
+  stderr: string;
+  stdout: string;
+  value: unknown;
+}): CellExecutionResult {
+  const streamOutputs = legacyResultToOutputs({ stdout, stderr, plots: [] });
+  const valueOutputs = legacyResultToOutputs({ value, plots: [] });
+
+  return {
+    stdout,
+    stderr,
+    value,
+    plots,
+    outputs: [...streamOutputs, ...displayOutputs, ...valueOutputs]
+  };
+}
+
+function toOutputArtifacts(value: unknown): readonly OutputArtifact[] {
+  return Array.isArray(value) ? value.filter(isOutputArtifact) : [];
 }

--- a/tests/unit/python-worker.test.ts
+++ b/tests/unit/python-worker.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { createSerialRequestQueue } from '../../src/lib/doc-runtime/python-worker';
+import {
+  createPythonCellResult,
+  createSerialRequestQueue,
+  pythonDisplaySupportCode
+} from '../../src/lib/doc-runtime/python-worker';
 
 function createDeferred() {
   let reject!: (reason: Error) => void;
@@ -71,5 +75,39 @@ describe('python worker request queue', () => {
     await flushMicrotasks();
 
     expect(events).toEqual(['start:first', 'start:second', 'finish:second']);
+  });
+});
+
+describe('python rich display support', () => {
+  it('exposes display helpers in the injected support module', () => {
+    expect(pythonDisplaySupportCode).toContain('builtins.display = display');
+    expect(pythonDisplaySupportCode).toContain('def display_table');
+    expect(pythonDisplaySupportCode).toContain('_repr_html_');
+    expect(pythonDisplaySupportCode).toContain('_repr_png_');
+  });
+
+  it('combines stream output, rich display artifacts, and final values deterministically', () => {
+    expect(createPythonCellResult({
+      stdout: 'printed',
+      stderr: 'warned',
+      value: { ok: true },
+      plots: [],
+      displayOutputs: [
+        { kind: 'html', html: '<strong>display</strong>', sandboxed: true },
+        { kind: 'text', stream: 'display', content: 'fallback' }
+      ]
+    })).toEqual({
+      stdout: 'printed',
+      stderr: 'warned',
+      value: { ok: true },
+      plots: [],
+      outputs: [
+        { kind: 'text', stream: 'stdout', content: 'printed' },
+        { kind: 'text', stream: 'stderr', content: 'warned' },
+        { kind: 'html', html: '<strong>display</strong>', sandboxed: true },
+        { kind: 'text', stream: 'display', content: 'fallback' },
+        { kind: 'json', value: { ok: true } }
+      ]
+    });
   });
 });


### PR DESCRIPTION
## Summary
- inject Python display helpers into Pyodide builtins
- collect display artifacts from Python cells
- include stdout, stderr, rich display artifacts, and final values in a deterministic output sequence

## Validation
- pnpm test:unit
- pnpm check
- pnpm test:e2e