### PR TITLE
Add Python matplotlib image output support

### DIFF
--- a/src/components/doc-runtime/OutputRenderer.tsx
+++ b/src/components/doc-runtime/OutputRenderer.tsx
@@ -1,5 +1,5 @@
 import { isOutputArtifact } from '../../lib/doc-runtime/output-artifacts';
-import type { OutputArtifact, TextArtifact } from '../../lib/doc-runtime/types';
+import type { ImageArtifact, OutputArtifact, TextArtifact } from '../../lib/doc-runtime/types';
 import ChartOutput from './ChartOutput';
 import TableOutput from './TableOutput';
 
@@ -38,7 +38,7 @@ function ArtifactOutput({ output }: { output: unknown }) {
     case 'table':
       return <TableOutput table={output} />;
     case 'image':
-      return <UnknownOutput message={`Unsupported ${output.kind} output artifact.`} />;
+      return <ImageOutput output={output} />;
     default:
       return <UnknownOutput message="Unsupported output artifact." />;
   }
@@ -52,6 +52,25 @@ function TextOutput({ output }: { output: TextArtifact }) {
     <pre class={className} data-testid={isError ? undefined : 'run-output'}>
       <code>{output.content}</code>
     </pre>
+  );
+}
+
+function ImageOutput({ output }: { output: ImageArtifact }) {
+  return (
+    <figure class="doc-image-output">
+      <img
+        alt={output.alt ?? output.title ?? 'Image output'}
+        data-testid="image-output"
+        src={imageArtifactSource(output)}
+      />
+      {output.title || output.caption ? (
+        <figcaption>
+          {output.title ? <strong>{output.title}</strong> : null}
+          {output.title && output.caption ? ' ' : null}
+          {output.caption}
+        </figcaption>
+      ) : null}
+    </figure>
   );
 }
 
@@ -73,6 +92,14 @@ function UnknownOutput({ message }: { message: string }) {
       {message}
     </p>
   );
+}
+
+export function imageArtifactSource(output: ImageArtifact): string {
+  if (output.data.startsWith('data:')) return output.data;
+  if (output.mime === 'image/svg+xml') {
+    return `data:${output.mime};charset=utf-8,${encodeURIComponent(output.data)}`;
+  }
+  return `data:${output.mime};base64,${output.data}`;
 }
 
 function artifactKey(output: unknown, index: number): string {

--- a/src/lib/doc-runtime/python-worker.ts
+++ b/src/lib/doc-runtime/python-worker.ts
@@ -21,9 +21,11 @@ const requestQueue = createSerialRequestQueue(handleRequest);
 export const pythonDisplaySupportCode = String.raw`
 import base64
 import builtins
+import io
 import json
 
 __oxiquill_outputs = []
+__oxiquill_displayed_figures = set()
 __oxiquill_table_limit = 1000
 
 def __oxiquill_meta(artifact, title=None, caption=None):
@@ -52,9 +54,77 @@ def __oxiquill_image_data(data):
         return base64.b64encode(data).decode("ascii")
     return str(data)
 
+def __oxiquill_configure_matplotlib():
+    try:
+        import matplotlib
+    except Exception:
+        return False
+    try:
+        matplotlib.use("Agg", force=True)
+    except Exception:
+        pass
+    return True
+
+def __oxiquill_is_matplotlib_figure(value):
+    module = getattr(value.__class__, "__module__", "")
+    return module.startswith("matplotlib.") and callable(getattr(value, "savefig", None))
+
+def __oxiquill_figure_to_image(fig, *, preferred="svg", title=None, caption=None, mark_displayed=False):
+    if mark_displayed:
+        __oxiquill_displayed_figures.add(id(fig))
+    if preferred == "svg":
+        buffer = io.StringIO()
+        fig.savefig(buffer, format="svg", bbox_inches="tight")
+        return __oxiquill_meta(
+            {
+                "kind": "image",
+                "mime": "image/svg+xml",
+                "data": buffer.getvalue(),
+                "alt": "matplotlib figure",
+            },
+            title,
+            caption,
+        )
+    buffer = io.BytesIO()
+    fig.savefig(buffer, format="png", bbox_inches="tight")
+    return __oxiquill_meta(
+        {
+            "kind": "image",
+            "mime": "image/png",
+            "data": base64.b64encode(buffer.getvalue()).decode("ascii"),
+            "alt": "matplotlib figure",
+        },
+        title,
+        caption,
+    )
+
+def __oxiquill_collect_matplotlib_outputs(preferred="svg", close_figures=True):
+    try:
+        import matplotlib.pyplot as plt
+    except Exception:
+        return []
+    outputs = []
+    for number in list(plt.get_fignums()):
+        fig = plt.figure(number)
+        if id(fig) in __oxiquill_displayed_figures:
+            continue
+        try:
+            outputs.append(__oxiquill_figure_to_image(fig, preferred=preferred))
+        except Exception as error:
+            outputs.append({
+                "kind": "text",
+                "stream": "stderr",
+                "content": f"Failed to render matplotlib figure {number}: {error}",
+            })
+    if close_figures:
+        plt.close("all")
+    return outputs
+
 def __oxiquill_artifact(value, title=None, caption=None):
     if value is None or isinstance(value, (str, int, float, bool, list, tuple, dict)):
         return __oxiquill_json_artifact(value, title, caption)
+    if __oxiquill_is_matplotlib_figure(value):
+        return __oxiquill_figure_to_image(value, title=title, caption=caption, mark_displayed=True)
     for method_name, mime in (
         ("_repr_svg_", "image/svg+xml"),
         ("_repr_png_", "image/png"),
@@ -116,6 +186,11 @@ def display_table(value, *, title=None, caption=None):
 
 def __oxiquill_reset_outputs():
     __oxiquill_outputs.clear()
+    __oxiquill_displayed_figures.clear()
+
+def __oxiquill_prepare_cell():
+    __oxiquill_reset_outputs()
+    __oxiquill_configure_matplotlib()
 
 def __oxiquill_take_outputs():
     outputs = list(__oxiquill_outputs)
@@ -156,7 +231,6 @@ async function handleRequest(request: RuntimeWorkerRequest): Promise<void> {
 
     pyodide.setStdout({ batched: (output) => stdout.push(output) });
     pyodide.setStderr({ batched: (output) => stderr.push(output) });
-    pyodide.runPython('__oxiquill_reset_outputs()');
 
     if (request.packages && request.packages.length > 0) {
       await pyodide.loadPackage(Array.from(request.packages));
@@ -164,6 +238,7 @@ async function handleRequest(request: RuntimeWorkerRequest): Promise<void> {
     if (request.source) {
       await pyodide.loadPackagesFromImports(request.source);
     }
+    pyodide.runPython('__oxiquill_prepare_cell()');
 
     const globals = pyodide.toPy(request.inputs);
     let value: unknown = null;
@@ -176,13 +251,16 @@ async function handleRequest(request: RuntimeWorkerRequest): Promise<void> {
     const displayOutputs = toOutputArtifacts(
       toSerializable(pyodide.runPython('__oxiquill_take_outputs()'))
     );
+    const matplotlibOutputs = toOutputArtifacts(
+      toSerializable(pyodide.runPython('__oxiquill_collect_matplotlib_outputs()'))
+    );
 
     const result = createPythonCellResult({
       stdout: stdout.join('\n').trimEnd(),
       stderr: stderr.join('\n').trimEnd(),
       value,
       plots: [],
-      displayOutputs
+      displayOutputs: [...displayOutputs, ...matplotlibOutputs]
     });
 
     worker.postMessage({ requestId: request.requestId, ok: true, result });

--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -201,6 +201,27 @@
   background: var(--sl-color-bg);
 }
 
+.doc-image-output {
+  display: grid;
+  gap: 0.45rem;
+  min-width: 0;
+  margin: 0;
+}
+
+.doc-image-output img {
+  display: block;
+  max-width: 100%;
+  height: auto;
+  border: 1px solid color-mix(in srgb, var(--sl-color-gray-5), transparent 35%);
+  border-radius: 6px;
+  background: var(--sl-color-bg);
+}
+
+.doc-image-output figcaption {
+  color: var(--sl-color-gray-2);
+  font-size: 0.85rem;
+}
+
 .doc-table-output {
   display: grid;
   gap: 0.65rem;

--- a/tests/unit/components.test.tsx
+++ b/tests/unit/components.test.tsx
@@ -56,7 +56,7 @@ vi.mock('../../src/lib/doc-runtime/runtime-client', () => ({
 
 const { default: InteractiveCell } = await import('../../src/components/doc-runtime/InteractiveCell');
 const { default: MermaidDiagram } = await import('../../src/components/doc-runtime/MermaidDiagram');
-const { default: OutputRenderer } = await import('../../src/components/doc-runtime/OutputRenderer');
+const { default: OutputRenderer, imageArtifactSource } = await import('../../src/components/doc-runtime/OutputRenderer');
 const { default: PlotOutput } = await import('../../src/components/doc-runtime/PlotOutput');
 const { chartSpecToEChartsOptions } = await import('../../src/components/doc-runtime/ChartOutput');
 const {
@@ -559,12 +559,12 @@ describe('ChartOutput options', () => {
 });
 
 describe('OutputRenderer', () => {
-  it('renders sandboxed HTML and reports unsupported artifacts', () => {
+  it('renders sandboxed HTML, images, and reports unsupported artifacts', () => {
     render(
       <OutputRenderer
         outputs={[
           { kind: 'html', html: '<strong>safe</strong>', sandboxed: true, title: 'HTML preview' },
-          { kind: 'image', mime: 'image/png', data: 'abc' },
+          { kind: 'image', mime: 'image/png', data: 'abc', alt: 'plot image' },
           { kind: 'unknown' }
         ]}
       />
@@ -573,9 +573,28 @@ describe('OutputRenderer', () => {
     expect(screen.getByTestId('html-output')).toHaveAttribute('sandbox', '');
     expect(screen.getByTestId('html-output')).toHaveAttribute('srcdoc', '<strong>safe</strong>');
     expect(screen.getByTestId('html-output')).toHaveAttribute('title', 'HTML preview');
-    expect(screen.getAllByTestId('artifact-error')).toHaveLength(2);
-    expect(screen.getByText('Unsupported image output artifact.')).toBeVisible();
+    expect(screen.getByTestId('image-output')).toHaveAttribute('src', 'data:image/png;base64,abc');
+    expect(screen.getByTestId('image-output')).toHaveAttribute('alt', 'plot image');
+    expect(screen.getAllByTestId('artifact-error')).toHaveLength(1);
     expect(screen.getByText('Unsupported output artifact.')).toBeVisible();
+  });
+
+  it('builds data URLs for raw SVG and base64 image artifacts', () => {
+    expect(imageArtifactSource({
+      kind: 'image',
+      mime: 'image/svg+xml',
+      data: '<svg><text>plot</text></svg>'
+    })).toBe('data:image/svg+xml;charset=utf-8,%3Csvg%3E%3Ctext%3Eplot%3C%2Ftext%3E%3C%2Fsvg%3E');
+    expect(imageArtifactSource({
+      kind: 'image',
+      mime: 'image/jpeg',
+      data: 'abc'
+    })).toBe('data:image/jpeg;base64,abc');
+    expect(imageArtifactSource({
+      kind: 'image',
+      mime: 'image/png',
+      data: 'data:image/png;base64,existing'
+    })).toBe('data:image/png;base64,existing');
   });
 });
 

--- a/tests/unit/python-worker.test.ts
+++ b/tests/unit/python-worker.test.ts
@@ -86,6 +86,14 @@ describe('python rich display support', () => {
     expect(pythonDisplaySupportCode).toContain('_repr_png_');
   });
 
+  it('configures matplotlib and captures figures as image artifacts', () => {
+    expect(pythonDisplaySupportCode).toContain('def __oxiquill_collect_matplotlib_outputs');
+    expect(pythonDisplaySupportCode).toContain('matplotlib.use("Agg", force=True)');
+    expect(pythonDisplaySupportCode).toContain('fig.savefig(buffer, format="svg"');
+    expect(pythonDisplaySupportCode).toContain('plt.close("all")');
+    expect(pythonDisplaySupportCode).toContain('__oxiquill_displayed_figures.add(id(fig))');
+  });
+
   it('combines stream output, rich display artifacts, and final values deterministically', () => {
     expect(createPythonCellResult({
       stdout: 'printed',
@@ -94,6 +102,7 @@ describe('python rich display support', () => {
       plots: [],
       displayOutputs: [
         { kind: 'html', html: '<strong>display</strong>', sandboxed: true },
+        { kind: 'image', mime: 'image/svg+xml', data: '<svg />', alt: 'plot' },
         { kind: 'text', stream: 'display', content: 'fallback' }
       ]
     })).toEqual({
@@ -105,6 +114,7 @@ describe('python rich display support', () => {
         { kind: 'text', stream: 'stdout', content: 'printed' },
         { kind: 'text', stream: 'stderr', content: 'warned' },
         { kind: 'html', html: '<strong>display</strong>', sandboxed: true },
+        { kind: 'image', mime: 'image/svg+xml', data: '<svg />', alt: 'plot' },
         { kind: 'text', stream: 'display', content: 'fallback' },
         { kind: 'json', value: { ok: true } }
       ]


### PR DESCRIPTION
## Summary
- render image artifacts in interactive cell output
- configure Pyodide matplotlib to use the Agg backend before execution
- collect active matplotlib figures as SVG image artifacts and close them after capture

## Validation
- `pnpm test:unit`
- `pnpm check`
- `pnpm test:e2e`