### PR TITLE
Document interactive rich outputs

### DIFF
--- a/src/content/docs/authoring.mdx
+++ b/src/content/docs/authoring.mdx
@@ -54,6 +54,52 @@ println!("next = {next:.6}");
 
 Use `crates` to list optional helper crate package names under `crates/*`. Cells that do not need shared Rust logic should use `crates: []`.
 
+## Emit Rich Outputs
+
+Cells can return multiple typed output artifacts. Plain `print` and `println!` still work, and richer outputs render with shared UI components.
+
+Python cells include display helpers:
+
+- `display(value)` chooses JSON, table, image, HTML, or text output from the value.
+- `display_json(value)` emits JSON.
+- `display_html(html)` emits sandboxed HTML.
+- `display_table(rows_or_dataframe)` emits a table.
+- `display_image(data, mime)` emits SVG, PNG, or JPEG image data.
+
+Python cells that use vendored packages must list them with `packages`. The current vendored rich-output packages are `matplotlib` and `pandas`.
+
+````md
+```python
+#| id: pandas-example
+#| title: Pandas table
+#| packages: [pandas]
+import pandas as pd
+
+scores = pd.DataFrame({"label": ["alpha", "beta"], "score": [3, 5]})
+display(scores, title="Scores")
+```
+````
+
+Rust cells use explicit `emit_*` macros. Supported macros include `emit_text!`, `emit_json!`, `emit_html!`, `emit_svg!`, `emit_png_base64!`, `emit_table!`, `emit_table_with_columns!`, `emit_records_table!`, `emit_line_chart!`, `emit_scatter_chart!`, `emit_bar_chart!`, `emit_histogram!`, `emit_heatmap!`, and the compatibility `emit_line_plot!`.
+
+````md
+```rust
+//| id: rust-output-example
+//| title: Rust rich output
+//| crates: []
+let rows = vec![
+    serde_json::json!({"label": "alpha", "score": 3}),
+    serde_json::json!({"label": "beta", "score": 5}),
+];
+
+emit_json!(&serde_json::json!({"rows": rows.len()}));
+emit_records_table!(&rows);
+emit_bar_chart!(&["alpha", "beta"], &[3, 5]);
+```
+````
+
+Large outputs are limited before they reach the UI thread. Text is capped at about 200 KB, JSON and HTML at about 500 KB, images at about 2 MB, and table previews at 1,000 rows.
+
 ## Add Inputs
 
 Add `inputs` metadata to let the runtime generate form controls. Supported input types are `range`, `number`, `integer`, `text`, `textarea`, `checkbox`, `select`, and `radio`.

--- a/src/content/docs/interactive-rust.mdx
+++ b/src/content/docs/interactive-rust.mdx
@@ -27,6 +27,36 @@ for point in points.iter().take(5) {
 emit_line_plot!(&points, "n", "x");
 ```
 
+## Rust Rich Outputs
+
+Rust cells can emit the same artifact types that the Python worker returns. Use explicit macros when the output should be something other than stdout.
+
+```rust
+//| id: rust-rich-outputs
+//| title: Rust table, chart, JSON, SVG, and HTML outputs
+//| run: button
+//| crates: []
+let rows = vec![
+    serde_json::json!({"label": "alpha", "score": 3}),
+    serde_json::json!({"label": "beta", "score": 5}),
+    serde_json::json!({"label": "gamma", "score": 4}),
+];
+let columns = vec![
+    serde_json::json!({"key": "label", "label": "Label", "type": "string"}),
+    serde_json::json!({"key": "score", "label": "Score", "type": "integer"}),
+];
+
+emit_json!(&serde_json::json!({"status": "ok", "rows": rows.len()}));
+emit_records_table!(&rows);
+emit_table_with_columns!(&columns, &rows);
+emit_bar_chart!(&["alpha", "beta", "gamma"], &[3, 5, 4]);
+emit_svg!(
+    r##"<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 48"><rect width="160" height="48" fill="#ecfeff"/><circle cx="32" cy="24" r="14" fill="#0f766e"/><rect x="64" y="12" width="72" height="24" rx="4" fill="#2563eb"/></svg>"##,
+    "Simple generated SVG"
+);
+emit_html!(r#"<p><strong>Sandboxed HTML</strong> emitted from Rust.</p>"#);
+```
+
 ## Input UI
 
 Rust cells can use checkboxes, selects, and radio groups with the same metadata format. A cell with `crates: []` does not depend on helper crates.
@@ -100,4 +130,28 @@ else:
 name = label.upper() if enabled else label
 print(f"{name}: {method} = {result}")
 print(f"style = {style}")
+```
+
+## Python Rich Outputs
+
+Python cells can use `display(...)` helpers and common rich-representation methods. Package-backed examples list their Pyodide packages explicitly.
+
+```python
+#| id: python-rich-outputs
+#| title: Python table, matplotlib, HTML, and JSON outputs
+#| run: button
+#| packages: [matplotlib, pandas]
+import pandas as pd
+import matplotlib.pyplot as plt
+
+scores = pd.DataFrame({"label": ["alpha", "beta", "gamma"], "score": [3, 5, 4]})
+
+display(scores, title="Pandas table")
+display_json({"status": "ok", "rows": len(scores)}, title="Summary")
+display_html("<p><strong>Sandboxed HTML</strong> emitted from Python.</p>", title="HTML")
+
+plt.bar(scores["label"], scores["score"])
+_ = plt.title("Scores")
+_ = plt.xlabel("label")
+_ = plt.ylabel("score")
 ```

--- a/src/content/docs/ja/authoring.mdx
+++ b/src/content/docs/ja/authoring.mdx
@@ -54,6 +54,52 @@ println!("next = {next:.6}");
 
 `crates` には `crates/*` にある任意の helper crate の package 名を指定します。共有ロジックを使わないセルは `crates: []` と書きます。
 
+## リッチ出力を出す
+
+セルは複数の型付き出力を返せます。通常の `print` や `println!` はそのまま使え、表、グラフ、画像、HTML などは共通の UI コンポーネントで表示されます。
+
+Python セルでは次の display helper を使えます。
+
+- `display(value)` は値から JSON、表、画像、HTML、テキストのいずれかを選びます。
+- `display_json(value)` は JSON を出力します。
+- `display_html(html)` は sandbox された HTML を出力します。
+- `display_table(rows_or_dataframe)` は表を出力します。
+- `display_image(data, mime)` は SVG、PNG、JPEG 画像を出力します。
+
+vendored package を使う Python セルは `packages` に指定します。リッチ出力で使う主な vendored package は `matplotlib` と `pandas` です。
+
+````md
+```python
+#| id: pandas-example
+#| title: Pandas の表
+#| packages: [pandas]
+import pandas as pd
+
+scores = pd.DataFrame({"label": ["alpha", "beta"], "score": [3, 5]})
+display(scores, title="Scores")
+```
+````
+
+Rust セルでは明示的な `emit_*` macro を使います。`emit_text!`, `emit_json!`, `emit_html!`, `emit_svg!`, `emit_png_base64!`, `emit_table!`, `emit_table_with_columns!`, `emit_records_table!`, `emit_line_chart!`, `emit_scatter_chart!`, `emit_bar_chart!`, `emit_histogram!`, `emit_heatmap!` と、互換用の `emit_line_plot!` を使えます。
+
+````md
+```rust
+//| id: rust-output-example
+//| title: Rust のリッチ出力
+//| crates: []
+let rows = vec![
+    serde_json::json!({"label": "alpha", "score": 3}),
+    serde_json::json!({"label": "beta", "score": 5}),
+];
+
+emit_json!(&serde_json::json!({"rows": rows.len()}));
+emit_records_table!(&rows);
+emit_bar_chart!(&["alpha", "beta"], &[3, 5]);
+```
+````
+
+大きな出力は UI thread に渡る前に制限されます。テキストは約 200 KB、JSON と HTML は約 500 KB、画像は約 2 MB、表のプレビューは 1,000 行までです。
+
 ## 入力を追加する
 
 `inputs` を指定すると、ランタイムがフォーム UI を自動生成します。対応している入力は `range`, `number`, `integer`, `text`, `textarea`, `checkbox`, `select`, `radio` です。

--- a/src/content/docs/ja/interactive-rust.mdx
+++ b/src/content/docs/ja/interactive-rust.mdx
@@ -27,6 +27,36 @@ for point in points.iter().take(5) {
 emit_line_plot!(&points, "n", "x");
 ```
 
+## Rust のリッチ出力
+
+Rust セルは Python worker と同じ種類の artifact を出力できます。stdout 以外の出力にしたい場合は、明示的な macro を使います。
+
+```rust
+//| id: rust-rich-outputs
+//| title: Rust の表、グラフ、JSON、SVG、HTML 出力
+//| run: button
+//| crates: []
+let rows = vec![
+    serde_json::json!({"label": "alpha", "score": 3}),
+    serde_json::json!({"label": "beta", "score": 5}),
+    serde_json::json!({"label": "gamma", "score": 4}),
+];
+let columns = vec![
+    serde_json::json!({"key": "label", "label": "Label", "type": "string"}),
+    serde_json::json!({"key": "score", "label": "Score", "type": "integer"}),
+];
+
+emit_json!(&serde_json::json!({"status": "ok", "rows": rows.len()}));
+emit_records_table!(&rows);
+emit_table_with_columns!(&columns, &rows);
+emit_bar_chart!(&["alpha", "beta", "gamma"], &[3, 5, 4]);
+emit_svg!(
+    r##"<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 48"><rect width="160" height="48" fill="#ecfeff"/><circle cx="32" cy="24" r="14" fill="#0f766e"/><rect x="64" y="12" width="72" height="24" rx="4" fill="#2563eb"/></svg>"##,
+    "Simple generated SVG"
+);
+emit_html!(r#"<p><strong>Sandboxed HTML</strong> emitted from Rust.</p>"#);
+```
+
 ## 入力 UI
 
 Rust セルでもチェックボックス、セレクト、ラジオ入力を同じ記法で使えます。`crates: []` のセルは helper crate に依存しません。
@@ -100,4 +130,28 @@ else:
 name = label.upper() if enabled else label
 print(f"{name}: {method} = {result}")
 print(f"style = {style}")
+```
+
+## Python のリッチ出力
+
+Python セルでは `display(...)` helper と一般的な rich representation を使えます。package が必要な例では Pyodide package を明示します。
+
+```python
+#| id: python-rich-outputs
+#| title: Python の表、matplotlib、HTML、JSON 出力
+#| run: button
+#| packages: [matplotlib, pandas]
+import pandas as pd
+import matplotlib.pyplot as plt
+
+scores = pd.DataFrame({"label": ["alpha", "beta", "gamma"], "score": [3, 5, 4]})
+
+display(scores, title="Pandas table")
+display_json({"status": "ok", "rows": len(scores)}, title="Summary")
+display_html("<p><strong>Sandboxed HTML</strong> emitted from Python.</p>", title="HTML")
+
+plt.bar(scores["label"], scores["score"])
+_ = plt.title("Scores")
+_ = plt.xlabel("label")
+_ = plt.ylabel("score")
 ```


### PR DESCRIPTION
## Summary
- document Python display helpers, Rust output macros, packages, and output limits
- add English and Japanese interactive examples for Rust JSON/table/chart/SVG/HTML output
- add English and Japanese Python examples for pandas, matplotlib, JSON, and sandboxed HTML output

## Validation
- `pnpm wasm:dev`
- `pnpm test:unit`
- `pnpm test:wasm`
- `pnpm test:e2e`
- `pnpm check`