### PR TITLE
chore: prepare rich output release

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -10,7 +10,9 @@ Rust、Python、数式、Mermaid 図、画像、PDF を同じ MDX ノートに�
 
 - Rust セルをビルド時に WebAssembly 化してブラウザで実行
 - Python セルを Pyodide worker で実行
-- ECharts による折れ線グラフ出力
+- テキスト、JSON、表、グラフ、画像、sandboxed HTML の共通リッチ出力
+- pandas の表、matplotlib の図、一般的な MIME bundle に対応した Python リッチ表示
+- 表、複数種類のグラフ、JSON、SVG/PNG 画像、sandboxed HTML を出力する Rust macro
 - KaTeX によるインライン数式とブロック数式
 - Mermaid によるフローチャート、シーケンス図、状態遷移図
 - `public/media` から PNG、JPEG、PDF などを配信

--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ This repository is responsible for producing the static output in `dist/`. Hosti
 
 - Rust cells compiled to WebAssembly at build time and run in the browser
 - Python cells executed in a Pyodide worker
-- Line plot output rendered with ECharts
+- Shared rich output artifacts for text, JSON, tables, charts, images, and sandboxed HTML
+- Python rich display support for pandas tables, matplotlib figures, and common MIME bundles
+- Rust output macros for tables, multiple chart types, JSON, SVG/PNG images, and sandboxed HTML
 - Inline and block math rendered with KaTeX
 - Mermaid flowcharts, sequence diagrams, and state diagrams
 - PNG, JPEG, PDF, and similar files served from `public/media`

--- a/src/components/doc-runtime/OutputRenderer.tsx
+++ b/src/components/doc-runtime/OutputRenderer.tsx
@@ -39,6 +39,7 @@ function ArtifactOutput({ output }: { output: unknown }) {
       return <TableOutput table={output} />;
     case 'image':
       return <ImageOutput output={output} />;
+    /* v8 ignore next -- isOutputArtifact rejects unknown artifact kinds before this switch. */
     default:
       return <UnknownOutput message="Unsupported output artifact." />;
   }

--- a/src/lib/doc-runtime/output-artifacts.ts
+++ b/src/lib/doc-runtime/output-artifacts.ts
@@ -2,12 +2,10 @@ import type {
   ChartArtifact,
   ChartSpec,
   CellExecutionResult,
-  ImageArtifact,
   OutputArtifact,
   OutputLimits,
   PlotSpec,
   RawCellExecutionResult,
-  TableArtifact,
   TableColumn,
   TextArtifact
 } from './types';
@@ -93,6 +91,7 @@ export function isOutputArtifact(value: unknown): value is OutputArtifact {
       return isImageArtifact(value);
     case 'html':
       return typeof value.html === 'string' && value.sandboxed === true;
+    /* v8 ignore next -- artifactKinds rejects unknown artifact kinds before this switch. */
     default:
       return false;
   }
@@ -155,9 +154,7 @@ function hasValidBaseArtifact(value: Record<string, unknown>): boolean {
   );
 }
 
-function isTableArtifact(value: unknown): value is TableArtifact {
-  if (!isRecord(value)) return false;
-
+function isTableArtifact(value: Record<string, unknown>): boolean {
   return (
     Array.isArray(value.columns) &&
     value.columns.every(isTableColumn) &&
@@ -180,9 +177,7 @@ function isChartSpec(value: unknown): value is ChartSpec {
   return isRecord(value) && chartKinds.has(value.kind as string);
 }
 
-function isImageArtifact(value: unknown): value is ImageArtifact {
-  if (!isRecord(value)) return false;
-
+function isImageArtifact(value: Record<string, unknown>): boolean {
   return (
     imageMimes.has(value.mime as string) &&
     typeof value.data === 'string' &&

--- a/tests/unit/components.test.tsx
+++ b/tests/unit/components.test.tsx
@@ -516,6 +516,16 @@ describe('ChartOutput options', () => {
     });
 
     expect(chartSpecToEChartsOptions({
+      kind: 'scatter',
+      legend: false,
+      tooltip: false,
+      series: [{ name: 'hidden', points: [[0, 1]] }]
+    })).toMatchObject({
+      legend: undefined,
+      tooltip: undefined
+    });
+
+    expect(chartSpecToEChartsOptions({
       kind: 'bar',
       categories: ['A', 'B'],
       series: [{ values: [1, null] }]
@@ -555,28 +565,71 @@ describe('ChartOutput options', () => {
       visualMap: expect.objectContaining({ calculable: true }),
       series: [{ type: 'heatmap', data: [['x', 'y', 5]] }]
     });
+
+    expect(chartSpecToEChartsOptions({
+      kind: 'unsupported',
+      series: []
+    } as unknown as Parameters<typeof chartSpecToEChartsOptions>[0])).toMatchObject({
+      series: []
+    });
+
+    expect(chartSpecToEChartsOptions({
+      kind: 'line',
+      legend: true,
+      series: [{ points: [[0, 1]] }]
+    })).toMatchObject({
+      legend: { top: 4 }
+    });
   });
 });
 
 describe('OutputRenderer', () => {
-  it('renders sandboxed HTML, images, and reports unsupported artifacts', () => {
+  it('renders sandboxed HTML, images, tables, and reports unsupported artifacts', () => {
     render(
       <OutputRenderer
         outputs={[
-          { kind: 'html', html: '<strong>safe</strong>', sandboxed: true, title: 'HTML preview' },
+          { id: 'html-preview', kind: 'html', html: '<strong>safe</strong>', sandboxed: true, title: 'HTML preview' },
+          { kind: 'html', html: '<em>default</em>', sandboxed: true },
           { kind: 'image', mime: 'image/png', data: 'abc', alt: 'plot image' },
+          {
+            kind: 'table',
+            columns: [{ key: 'name', label: 'Name', type: 'string' }],
+            rows: [['Ada']]
+          },
           { kind: 'unknown' }
         ]}
       />
     );
 
-    expect(screen.getByTestId('html-output')).toHaveAttribute('sandbox', '');
-    expect(screen.getByTestId('html-output')).toHaveAttribute('srcdoc', '<strong>safe</strong>');
-    expect(screen.getByTestId('html-output')).toHaveAttribute('title', 'HTML preview');
+    const htmlOutputs = screen.getAllByTestId('html-output');
+    expect(htmlOutputs[0]).toHaveAttribute('sandbox', '');
+    expect(htmlOutputs[0]).toHaveAttribute('srcdoc', '<strong>safe</strong>');
+    expect(htmlOutputs[0]).toHaveAttribute('title', 'HTML preview');
+    expect(htmlOutputs[1]).toHaveAttribute('title', 'HTML output');
     expect(screen.getByTestId('image-output')).toHaveAttribute('src', 'data:image/png;base64,abc');
     expect(screen.getByTestId('image-output')).toHaveAttribute('alt', 'plot image');
+    expect(screen.getByTestId('table-output')).toBeVisible();
     expect(screen.getAllByTestId('artifact-error')).toHaveLength(1);
     expect(screen.getByText('Unsupported output artifact.')).toBeVisible();
+  });
+
+  it('renders image fallback text and captions', () => {
+    render(
+      <OutputRenderer
+        outputs={[
+          { kind: 'image', mime: 'image/png', data: 'abc', title: 'Figure one', caption: 'caption' },
+          { kind: 'image', mime: 'image/png', data: 'def', caption: 'caption only' },
+          { kind: 'image', mime: 'image/png', data: 'ghi' }
+        ]}
+      />
+    );
+
+    const images = screen.getAllByTestId('image-output');
+    expect(images[0]).toHaveAttribute('alt', 'Figure one');
+    expect(images[1]).toHaveAttribute('alt', 'Image output');
+    expect(images[2]).toHaveAttribute('alt', 'Image output');
+    expect(screen.getByText('Figure one')).toBeVisible();
+    expect(screen.getByText('caption only')).toBeVisible();
   });
 
   it('builds data URLs for raw SVG and base64 image artifacts', () => {
@@ -615,7 +668,7 @@ describe('TableOutput', () => {
           caption: 'Preview rows',
           columns: [
             { key: 'score', label: 'Score', type: 'integer' },
-            { key: 'label', label: 'Label', type: 'string' },
+            { key: 'label', label: 'Label' },
             { key: 'enabled', label: 'Enabled', type: 'boolean' }
           ],
           rows,
@@ -629,13 +682,22 @@ describe('TableOutput', () => {
     expect(screen.getByText('Scores')).toBeVisible();
     expect(screen.getByText('Preview rows')).toBeVisible();
     expect(screen.getByText('Rows 1-10 of 20 (truncated)')).toBeVisible();
+    expect(screen.getAllByRole('cell')[1]).toHaveAttribute('data-type', 'unknown');
 
+    fireEvent.click(screen.getByRole('button', { name: 'Score' }));
+    expect(screen.getByRole('columnheader', { name: 'Score' })).toHaveAttribute('aria-sort', 'ascending');
+    expect(screen.getAllByRole('cell')[0]).toHaveTextContent('1');
+    fireEvent.click(screen.getByRole('button', { name: 'Score' }));
+    expect(screen.getByRole('columnheader', { name: 'Score' })).toHaveAttribute('aria-sort', 'descending');
+    expect(screen.getAllByRole('cell')[0]).toHaveTextContent('12');
     fireEvent.click(screen.getByRole('button', { name: 'Score' }));
     expect(screen.getByRole('columnheader', { name: 'Score' })).toHaveAttribute('aria-sort', 'ascending');
     expect(screen.getAllByRole('cell')[0]).toHaveTextContent('1');
 
     fireEvent.click(screen.getByTestId('table-next'));
     expect(screen.getByText('Rows 11-12 of 20 (truncated)')).toBeVisible();
+    fireEvent.click(screen.getByTestId('table-prev'));
+    expect(screen.getByText('Rows 1-10 of 20 (truncated)')).toBeVisible();
 
     fireEvent.input(screen.getByTestId('table-page-size'), { target: { value: '25' } });
     expect(screen.getByText('Rows 1-12 of 20 (truncated)')).toBeVisible();
@@ -645,14 +707,33 @@ describe('TableOutput', () => {
     expect(rows[0]).toEqual([12, 'row 1', true]);
   });
 
+  it('renders empty tables with a stable row range', () => {
+    render(
+      <TableOutput
+        table={{
+          kind: 'table',
+          columns: [{ key: 'value', label: 'Value' }],
+          rows: []
+        }}
+      />
+    );
+
+    expect(screen.getByText('Rows 0-0 of 0')).toBeVisible();
+    expect(screen.getByTestId('table-prev')).toBeDisabled();
+    expect(screen.getByTestId('table-next')).toBeDisabled();
+  });
+
   it('sorts and formats table values without mutating rows', () => {
     const rows = [[2, 'b'], [null, 'z'], [1, 'a'], [undefined, 'y']];
 
     expect(sortRows(rows, { columnIndex: 0, direction: 'asc' })).toEqual([[1, 'a'], [2, 'b'], [null, 'z'], [undefined, 'y']]);
     expect(sortRows(rows, { columnIndex: 1, direction: 'desc' })).toEqual([[null, 'z'], [undefined, 'y'], [2, 'b'], [1, 'a']]);
+    expect(sortRows([[1, 'first'], [1, 'second']], { columnIndex: 0, direction: 'desc' })).toEqual([[1, 'first'], [1, 'second']]);
+    expect(sortRows([[true], [false]], { columnIndex: 0, direction: 'asc' })).toEqual([[false], [true]]);
     expect(visibleRows(rows, 1, 2)).toEqual([[1, 'a'], [undefined, 'y']]);
     expect(rows[0]).toEqual([2, 'b']);
     expect(formatTableCell(1234.5678)).toBe('1,234.57');
+    expect(formatTableCell(Number.POSITIVE_INFINITY)).toBe('Infinity');
     expect(formatTableCell(null)).toBe('null');
     expect(formatTableCell(undefined)).toBe('missing');
     expect(formatTableCell({ nested: true })).toBe('{"nested":true}');

--- a/tests/unit/doc-runtime-service.test.mjs
+++ b/tests/unit/doc-runtime-service.test.mjs
@@ -391,17 +391,24 @@ describe('doc runtime service', () => {
     const paths = createDocRuntimePaths('/repo');
     const lockFile = {
       packages: {
-        root: pyodidePackage('root', 'root.whl', 'root bytes', ['dep']),
-        dep: pyodidePackage('dep', 'dep.whl', 'dep bytes')
+        root: pyodidePackage('root', 'root.whl', 'root bytes', ['dep', 'dep', 'leaf']),
+        dep: pyodidePackage('dep', 'dep.whl', 'dep bytes'),
+        leaf: {
+          file_name: 'leaf.whl',
+          name: 'leaf',
+          sha256: hashBytes(Buffer.from('leaf bytes')),
+          version: '1.0.0'
+        }
       }
     };
     const fileSystem = createMemoryFileSystem();
     const fetched = {
       'dep.whl': Buffer.from('dep bytes'),
+      'leaf.whl': Buffer.from('leaf bytes'),
       'root.whl': Buffer.from('root bytes')
     };
 
-    expect(resolveVendoredPyodidePackages(lockFile, ['root']).map((entry) => entry.name)).toEqual(['dep', 'root']);
+    expect(resolveVendoredPyodidePackages(lockFile, ['root']).map((entry) => entry.name)).toEqual(['dep', 'leaf', 'root']);
     await expect(copyVendoredPyodidePackages({
       fetchPackage: async (fileName) => fetched[fileName],
       fileSystem,
@@ -428,6 +435,70 @@ describe('doc runtime service', () => {
       paths,
       roots: ['root']
     })).rejects.toThrow('has sha256');
+
+    const readFailure = createMemoryFileSystem();
+    const originalReadFile = readFailure.readFile;
+    readFailure.readFile = async (filePath) => {
+      if (filePath.endsWith('.whl')) {
+        const error = new Error('permission denied');
+        error.code = 'EACCES';
+        throw error;
+      }
+      return originalReadFile(filePath);
+    };
+    await expect(copyVendoredPyodidePackages({
+      fetchPackage: async (fileName) => fetched[fileName],
+      fileSystem: readFailure,
+      lockFile,
+      paths,
+      roots: ['root']
+    })).rejects.toThrow('permission denied');
+  });
+
+  it('downloads vendored Pyodide packages with the default fetcher', async () => {
+    const paths = createDocRuntimePaths('/repo');
+    const lockFile = {
+      packages: {
+        root: pyodidePackage('root', 'root.whl', 'root bytes')
+      }
+    };
+    const originalFetch = globalThis.fetch;
+    const requestedUrls = [];
+
+    globalThis.fetch = async (url) => {
+      requestedUrls.push(String(url));
+      return {
+        ok: true,
+        arrayBuffer: async () => Buffer.from('root bytes')
+      };
+    };
+    try {
+      await expect(copyVendoredPyodidePackages({
+        fileSystem: createMemoryFileSystem(),
+        lockFile,
+        paths,
+        roots: ['root']
+      })).resolves.toBe(true);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+    expect(requestedUrls).toEqual(['https://cdn.jsdelivr.net/pyodide/v0.29.4/full/root.whl']);
+
+    globalThis.fetch = async () => ({
+      ok: false,
+      status: 503,
+      statusText: 'unavailable'
+    });
+    try {
+      await expect(copyVendoredPyodidePackages({
+        fileSystem: createMemoryFileSystem(),
+        lockFile,
+        paths,
+        roots: ['root']
+      })).rejects.toThrow('503 unavailable');
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
   });
 
   it('syncs generated runtime files and reports changed surfaces', async () => {

--- a/tests/unit/output-artifacts.test.ts
+++ b/tests/unit/output-artifacts.test.ts
@@ -10,6 +10,8 @@ import {
 
 describe('output artifact normalization', () => {
   it('converts legacy cell fields to ordered output artifacts', () => {
+    expect(legacyResultToOutputs({})).toEqual([]);
+
     const outputs = legacyResultToOutputs({
       stdout: 'printed',
       stderr: 'warned',
@@ -60,6 +62,26 @@ describe('output artifact normalization', () => {
       value: { answer: 42 },
       plots: [{ kind: 'line', x_label: 'x', y_label: 'y', points: [[1, 2]] }]
     });
+
+    expect(outputsToLegacyResult([
+      {
+        kind: 'chart',
+        spec: {
+          kind: 'line',
+          series: [{ points: [[1, 'not numeric']] }]
+        }
+      }
+    ])).toMatchObject({ plots: [] });
+
+    expect(outputsToLegacyResult([
+      {
+        kind: 'chart',
+        spec: {
+          kind: 'line',
+          series: [{ points: [[1, 2]] }]
+        }
+      }
+    ])).toMatchObject({ plots: [{ kind: 'line', x_label: '', y_label: '', points: [[1, 2]] }] });
   });
 
   it('normalizes legacy-only and outputs-only worker results', () => {
@@ -78,6 +100,29 @@ describe('output artifact normalization', () => {
       value: ['new'],
       plots: [],
       outputs: [{ kind: 'json', value: ['new'] }]
+    });
+
+    expect(
+      normalizeCellExecutionResult({
+        outputs: [{ kind: 'text', stream: 'stderr', content: 'from outputs' }]
+      })
+    ).toEqual({
+      stdout: '',
+      stderr: 'from outputs',
+      plots: [],
+      outputs: [{ kind: 'text', stream: 'stderr', content: 'from outputs' }]
+    });
+
+    expect(
+      normalizeCellExecutionResult({
+        stderr: 'explicit',
+        outputs: [{ kind: 'text', stream: 'stderr', content: 'from outputs' }]
+      })
+    ).toEqual({
+      stdout: '',
+      stderr: 'explicit',
+      plots: [],
+      outputs: [{ kind: 'text', stream: 'stderr', content: 'from outputs' }]
     });
   });
 


### PR DESCRIPTION
## Summary
- Update README feature lists for shared rich outputs, Python rich display, and Rust output macros.
- Harden artifact rendering and normalization coverage around unreachable branches, fallbacks, Pyodide package resolution, tables, charts, images, and sandboxed HTML.
- Keep the runtime artifact validators simple by removing redundant internal record checks after the public guard.

## Validation
- `pnpm test:unit:coverage`
- `pnpm check`
- `pnpm lint:rust`
- `pnpm test`