### PR TITLE
Fix Mermaid dark mode contrast

### DIFF
--- a/src/components/doc-runtime/MermaidDiagram.tsx
+++ b/src/components/doc-runtime/MermaidDiagram.tsx
@@ -1,4 +1,4 @@
-import mermaid from 'mermaid';
+import mermaid, { type MermaidConfig } from 'mermaid';
 import { useEffect, useMemo, useRef, useState } from 'preact/hooks';
 
 interface MermaidDiagramProps {
@@ -7,14 +7,31 @@ interface MermaidDiagramProps {
 }
 
 type RenderState = 'idle' | 'rendering' | 'ready' | 'error';
+type MermaidColorScheme = 'light' | 'dark';
 
-let hasInitializedMermaid = false;
+let configuredMermaidColorScheme: MermaidColorScheme | undefined;
 
 export default function MermaidDiagram({ diagramId, source }: MermaidDiagramProps) {
   const container = useRef<HTMLDivElement>(null);
   const [error, setError] = useState<string>();
   const [state, setState] = useState<RenderState>('idle');
+  const [colorScheme, setColorScheme] = useState<MermaidColorScheme>(() => getMermaidColorScheme());
   const renderId = useMemo(() => `doc-${diagramId}`, [diagramId]);
+
+  useEffect(() => {
+    setColorScheme(getMermaidColorScheme());
+
+    if (typeof MutationObserver === 'undefined') return undefined;
+
+    const observer = new MutationObserver(() => {
+      setColorScheme(getMermaidColorScheme());
+    });
+    observer.observe(document.documentElement, { attributes: true, attributeFilter: ['data-theme'] });
+
+    return () => {
+      observer.disconnect();
+    };
+  }, []);
 
   useEffect(() => {
     const element = container.current!;
@@ -27,7 +44,7 @@ export default function MermaidDiagram({ diagramId, source }: MermaidDiagramProp
       element.replaceChildren();
 
       try {
-        initializeMermaid();
+        initializeMermaid(colorScheme);
         const { svg, bindFunctions } = await mermaid.render(renderId, source);
         if (cancelled) return;
 
@@ -50,7 +67,7 @@ export default function MermaidDiagram({ diagramId, source }: MermaidDiagramProp
       cancelled = true;
       element.replaceChildren();
     };
-  }, [renderId, source]);
+  }, [colorScheme, renderId, source]);
 
   return (
     <figure class="mermaid-diagram" data-state={state} data-testid="mermaid-diagram">
@@ -64,23 +81,105 @@ export default function MermaidDiagram({ diagramId, source }: MermaidDiagramProp
   );
 }
 
-function initializeMermaid(): void {
-  if (hasInitializedMermaid) return;
+function getMermaidColorScheme(): MermaidColorScheme {
+  if (typeof document === 'undefined') return 'light';
+
+  return document.documentElement.dataset.theme === 'dark' ? 'dark' : 'light';
+}
+
+function initializeMermaid(colorScheme: MermaidColorScheme): void {
+  if (configuredMermaidColorScheme === colorScheme) return;
 
   mermaid.initialize({
     startOnLoad: false,
     securityLevel: 'strict',
     theme: 'base',
-    themeVariables: {
-      fontFamily: 'system-ui, sans-serif',
-      primaryColor: '#f8fafc',
-      primaryTextColor: '#111827',
-      primaryBorderColor: '#64748b',
-      lineColor: '#0f766e',
-      secondaryColor: '#ecfeff',
-      tertiaryColor: '#f1f5f9'
-    }
+    themeVariables: mermaidThemeVariables[colorScheme]
   });
 
-  hasInitializedMermaid = true;
+  configuredMermaidColorScheme = colorScheme;
 }
+
+const mermaidFontFamily = 'system-ui, sans-serif';
+
+const mermaidThemeVariables = {
+  light: {
+    fontFamily: mermaidFontFamily,
+    primaryColor: '#f8fafc',
+    primaryTextColor: '#111827',
+    primaryBorderColor: '#64748b',
+    lineColor: '#0f766e',
+    secondaryColor: '#ecfeff',
+    secondaryTextColor: '#111827',
+    secondaryBorderColor: '#0891b2',
+    tertiaryColor: '#f1f5f9',
+    tertiaryTextColor: '#111827',
+    tertiaryBorderColor: '#94a3b8',
+    textColor: '#111827',
+    arrowheadColor: '#0f766e',
+    edgeLabelBackground: '#f8fafc',
+    nodeTextColor: '#111827',
+    clusterBkg: '#f8fafc',
+    clusterBorder: '#94a3b8',
+    titleColor: '#111827',
+    actorBorder: '#64748b',
+    actorBkg: '#f8fafc',
+    actorTextColor: '#111827',
+    actorLineColor: '#0f766e',
+    signalColor: '#0f766e',
+    signalTextColor: '#111827',
+    noteBkgColor: '#fef9c3',
+    noteTextColor: '#111827',
+    noteBorderColor: '#ca8a04',
+    stateBkg: '#f8fafc',
+    stateBorder: '#64748b',
+    stateLabelColor: '#111827',
+    transitionColor: '#0f766e',
+    transitionLabelColor: '#111827'
+  },
+  dark: {
+    fontFamily: mermaidFontFamily,
+    background: '#0f172a',
+    primaryColor: '#1e293b',
+    primaryTextColor: '#f8fafc',
+    primaryBorderColor: '#94a3b8',
+    lineColor: '#67e8f9',
+    secondaryColor: '#164e63',
+    secondaryTextColor: '#f8fafc',
+    secondaryBorderColor: '#67e8f9',
+    tertiaryColor: '#334155',
+    tertiaryTextColor: '#f8fafc',
+    tertiaryBorderColor: '#cbd5e1',
+    textColor: '#f8fafc',
+    mainBkg: '#1e293b',
+    nodeBkg: '#1e293b',
+    nodeBorder: '#94a3b8',
+    nodeTextColor: '#f8fafc',
+    arrowheadColor: '#67e8f9',
+    edgeLabelBackground: '#0f172a',
+    labelTextColor: '#f8fafc',
+    labelBoxBkgColor: '#1e293b',
+    labelBoxBorderColor: '#94a3b8',
+    clusterBkg: '#111827',
+    clusterBorder: '#94a3b8',
+    titleColor: '#f8fafc',
+    actorBorder: '#94a3b8',
+    actorBkg: '#1e293b',
+    actorTextColor: '#f8fafc',
+    actorLineColor: '#67e8f9',
+    signalColor: '#e2e8f0',
+    signalTextColor: '#f8fafc',
+    noteBkgColor: '#1f2937',
+    noteTextColor: '#f8fafc',
+    noteBorderColor: '#facc15',
+    stateBkg: '#1e293b',
+    stateBorder: '#94a3b8',
+    stateLabelColor: '#f8fafc',
+    transitionColor: '#67e8f9',
+    transitionLabelColor: '#f8fafc',
+    labelBackgroundColor: '#0f172a',
+    compositeBackground: '#111827',
+    compositeBorder: '#94a3b8',
+    compositeTitleBackground: '#1e293b'
+  }
+} satisfies Record<MermaidColorScheme, MermaidConfig['themeVariables']>;

--- a/tests/e2e/interactive.spec.ts
+++ b/tests/e2e/interactive.spec.ts
@@ -130,6 +130,14 @@ test('theme note and Mermaid examples are available without author-side TSX impo
   await expect(diagrams.first().locator('svg')).toBeVisible();
   await expect(diagrams.nth(1).locator('svg')).toBeVisible();
   await expect(diagrams.nth(2).locator('svg')).toBeVisible();
+
+  await page.evaluate(() => {
+    document.documentElement.dataset.theme = 'dark';
+  });
+
+  await expect(diagrams.first().locator('svg')).toBeVisible();
+  await expect(diagrams.nth(1).locator('svg')).toBeVisible();
+  await expect(diagrams.nth(2).locator('svg')).toBeVisible();
 });
 
 test('localized pages and media examples are available', async ({ page }) => {

--- a/tests/unit/components.test.tsx
+++ b/tests/unit/components.test.tsx
@@ -141,6 +141,7 @@ beforeEach(() => {
   mocks.manifestListeners = [];
   TestResizeObserver.instances = [];
   document.documentElement.lang = 'en';
+  document.documentElement.removeAttribute('data-theme');
   globalThis.ResizeObserver = TestResizeObserver as unknown as typeof ResizeObserver;
 });
 
@@ -407,10 +408,68 @@ describe('MermaidDiagram', () => {
     await waitFor(() => expect(screen.getByTestId('mermaid-diagram')).toHaveAttribute('data-state', 'ready'));
     expect(screen.getByText('diagram')).toBeVisible();
     expect(mocks.mermaidInitialize).toHaveBeenCalledTimes(1);
+    expect(mocks.mermaidInitialize).toHaveBeenCalledWith(
+      expect.objectContaining({
+        themeVariables: expect.objectContaining({
+          lineColor: '#0f766e',
+          primaryTextColor: '#111827'
+        })
+      })
+    );
 
     rerender(<MermaidDiagram diagramId="one" source="flowchart LR\nA-->C" />);
     await waitFor(() => expect(mocks.mermaidRender).toHaveBeenCalledTimes(2));
     expect(mocks.mermaidInitialize).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses a readable dark Mermaid palette when Starlight is in dark mode', async () => {
+    document.documentElement.dataset.theme = 'dark';
+    mocks.mermaidRender.mockResolvedValue({
+      svg: '<svg><text>dark diagram</text></svg>'
+    });
+
+    render(<MermaidDiagram diagramId="dark" source="flowchart LR\nA-->B" />);
+
+    await waitFor(() => expect(screen.getByText('dark diagram')).toBeVisible());
+    expect(mocks.mermaidInitialize).toHaveBeenCalledWith(
+      expect.objectContaining({
+        themeVariables: expect.objectContaining({
+          background: '#0f172a',
+          lineColor: '#67e8f9',
+          primaryTextColor: '#f8fafc'
+        })
+      })
+    );
+  });
+
+  it('rerenders Mermaid SVG when Starlight theme changes', async () => {
+    mocks.mermaidRender.mockResolvedValue({
+      svg: '<svg><text>theme diagram</text></svg>'
+    });
+
+    render(<MermaidDiagram diagramId="theme" source="flowchart LR\nA-->B" />);
+
+    await waitFor(() => expect(mocks.mermaidRender).toHaveBeenCalledTimes(1));
+    expect(mocks.mermaidInitialize).toHaveBeenCalledWith(
+      expect.objectContaining({
+        themeVariables: expect.objectContaining({
+          primaryTextColor: '#111827'
+        })
+      })
+    );
+
+    act(() => {
+      document.documentElement.dataset.theme = 'dark';
+    });
+
+    await waitFor(() => expect(mocks.mermaidRender).toHaveBeenCalledTimes(2));
+    expect(mocks.mermaidInitialize).toHaveBeenCalledWith(
+      expect.objectContaining({
+        themeVariables: expect.objectContaining({
+          primaryTextColor: '#f8fafc'
+        })
+      })
+    );
   });
 
   it('renders Mermaid SVG when no bind function is returned', async () => {


### PR DESCRIPTION
## Summary
- add light/dark Mermaid theme variables keyed off Starlight's root `data-theme`
- rerender Mermaid diagrams when the site theme changes
- cover default, dark, and live theme-switch rendering in unit tests
- extend the Mermaid e2e path to force dark mode and verify diagrams still render

## Validation
- `pnpm test:unit`
- `pnpm check`
- `pnpm build`
- `pnpm exec playwright test tests/e2e/interactive.spec.ts -g "theme note"`