### PR TITLE
feat: add collapsible desktop sidebar

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -49,6 +49,9 @@ export default defineConfig({
         }
       },
       customCss: ['katex/dist/katex.min.css', './src/styles/custom.css'],
+      components: {
+        PageFrame: './src/components/starlight/PageFrame.astro'
+      },
       sidebar: [
         {
           label: 'Overview',

--- a/src/components/starlight/PageFrame.astro
+++ b/src/components/starlight/PageFrame.astro
@@ -1,0 +1,314 @@
+---
+import MobileMenuToggle from '@astrojs/starlight/components/MobileMenuToggle.astro';
+import { Icon } from '@astrojs/starlight/components';
+
+const { hasSidebar, dir, lang } = Astro.locals.starlightRoute;
+const isRtl = dir === 'rtl';
+const labels =
+	lang === 'ja'
+		? {
+				collapse: 'サイドバーを折りたたむ',
+				expand: 'サイドバーを展開する',
+			}
+		: {
+				collapse: 'Collapse sidebar',
+				expand: 'Expand sidebar',
+			};
+const collapseIcon = isRtl ? 'right-arrow' : 'left-arrow';
+const expandIcon = isRtl ? 'left-arrow' : 'right-arrow';
+---
+
+{
+	hasSidebar && (
+		<script is:inline>
+			{`
+				(() => {
+					try {
+						if (
+							matchMedia('(min-width: 50rem)').matches &&
+							sessionStorage.getItem('oxiquill-sidebar-collapsed') === 'true'
+						) {
+							document.documentElement.setAttribute('data-sidebar-collapsed', '');
+							document.documentElement.style.setProperty('--sl-content-inline-start', '0rem');
+							document.documentElement.style.setProperty(
+								'--sl-content-width',
+								'calc(var(--oq-sidebar-base-content-width) + var(--sl-sidebar-width))'
+							);
+						}
+					} catch {}
+				})();
+			`}
+		</script>
+	)
+}
+
+<div class="page sl-flex">
+	<header class="header"><slot name="header" /></header>
+	{
+		hasSidebar && (
+			<nav class="sidebar print:hidden" aria-label={Astro.locals.t('sidebarNav.accessibleLabel')}>
+				<MobileMenuToggle />
+				<div id="starlight__sidebar" class="sidebar-pane">
+					<div class="sidebar-content sl-flex">
+						<slot name="sidebar" />
+					</div>
+				</div>
+				<starlight-sidebar-toggle
+					class="print:hidden"
+					data-collapse-label={labels.collapse}
+					data-expand-label={labels.expand}
+				>
+					<button
+						type="button"
+						class="sidebar-toggle-button sl-flex"
+						aria-controls="starlight__sidebar"
+						aria-expanded="true"
+						aria-label={labels.collapse}
+						title={labels.collapse}
+					>
+						<span class="collapse-sidebar" aria-hidden="true">
+							<Icon name={collapseIcon} size="1rem" />
+						</span>
+						<span class="expand-sidebar" aria-hidden="true">
+							<Icon name={expandIcon} size="1rem" />
+						</span>
+					</button>
+				</starlight-sidebar-toggle>
+			</nav>
+		)
+	}
+	<div class="main-frame"><slot /></div>
+</div>
+
+<script>
+	const storageKey = 'oxiquill-sidebar-collapsed';
+	const desktopQuery = matchMedia('(min-width: 50rem)');
+
+	class StarlightSidebarToggle extends HTMLElement {
+		button = this.querySelector('button')!;
+		sidebar = document.getElementById(this.button.getAttribute('aria-controls') || '');
+		collapseLabel = this.dataset.collapseLabel || 'Collapse sidebar';
+		expandLabel = this.dataset.expandLabel || 'Expand sidebar';
+
+		connectedCallback() {
+			this.button.addEventListener('click', this.toggleCollapsed);
+			desktopQuery.addEventListener('change', this.applyStoredState);
+			this.applyStoredState();
+		}
+
+		disconnectedCallback() {
+			this.button.removeEventListener('click', this.toggleCollapsed);
+			desktopQuery.removeEventListener('change', this.applyStoredState);
+		}
+
+		applyStoredState = () => {
+			this.setCollapsed(this.getStoredCollapsed());
+		};
+
+		toggleCollapsed = () => {
+			if (!desktopQuery.matches) return;
+			const nextCollapsed = !document.documentElement.hasAttribute('data-sidebar-collapsed');
+			this.storeCollapsed(nextCollapsed);
+			this.setCollapsed(nextCollapsed);
+		};
+
+		getStoredCollapsed(): boolean {
+			try {
+				return sessionStorage.getItem(storageKey) === 'true';
+			} catch {
+				return false;
+			}
+		}
+
+		storeCollapsed(collapsed: boolean) {
+			try {
+				if (collapsed) {
+					sessionStorage.setItem(storageKey, 'true');
+				} else {
+					sessionStorage.removeItem(storageKey);
+				}
+			} catch {}
+		}
+
+		setCollapsed(collapsed: boolean) {
+			const active = desktopQuery.matches && collapsed;
+			const label = active ? this.expandLabel : this.collapseLabel;
+			document.documentElement.toggleAttribute('data-sidebar-collapsed', active);
+			if (active) {
+				document.documentElement.style.setProperty('--sl-content-inline-start', '0rem');
+				document.documentElement.style.setProperty(
+					'--sl-content-width',
+					'calc(var(--oq-sidebar-base-content-width) + var(--sl-sidebar-width))'
+				);
+			} else {
+				document.documentElement.style.removeProperty('--sl-content-inline-start');
+				document.documentElement.style.removeProperty('--sl-content-width');
+			}
+			this.button.setAttribute('aria-expanded', String(!active));
+			this.button.setAttribute('aria-label', label);
+			this.button.title = label;
+			if (this.sidebar) {
+				if (active) {
+					this.sidebar.setAttribute('aria-hidden', 'true');
+				} else {
+					this.sidebar.removeAttribute('aria-hidden');
+				}
+				this.sidebar.toggleAttribute('inert', active);
+			}
+		}
+	}
+
+	if (!customElements.get('starlight-sidebar-toggle')) {
+		customElements.define('starlight-sidebar-toggle', StarlightSidebarToggle);
+	}
+</script>
+
+<style>
+	:global(:root) {
+		--oq-sidebar-base-content-width: 45rem;
+	}
+
+	@media (min-width: 50rem) {
+		:global([data-sidebar-collapsed]) {
+			--sl-content-inline-start: 0rem;
+			--sl-content-width: calc(var(--oq-sidebar-base-content-width) + var(--sl-sidebar-width));
+		}
+	}
+</style>
+
+<style>
+	@layer starlight.core {
+		.page {
+			flex-direction: column;
+			min-height: 100vh;
+		}
+
+		.header {
+			z-index: var(--sl-z-index-navbar);
+			position: fixed;
+			inset-inline-start: 0;
+			inset-block-start: 0;
+			width: 100%;
+			height: var(--sl-nav-height);
+			border-bottom: 1px solid var(--sl-color-hairline-shade);
+			padding: var(--sl-nav-pad-y) var(--sl-nav-pad-x);
+			padding-inline-end: var(--sl-nav-pad-x);
+			background-color: var(--sl-color-bg-nav);
+		}
+
+		:global([data-has-sidebar]) .header {
+			padding-inline-end: calc(
+				var(--sl-nav-gap) + var(--sl-nav-pad-x) + var(--sl-menu-button-size)
+			);
+		}
+
+		.sidebar-pane {
+			visibility: var(--sl-sidebar-visibility, hidden);
+			position: fixed;
+			z-index: var(--sl-z-index-menu);
+			inset-block: var(--sl-nav-height) 0;
+			inset-inline-start: 0;
+			width: 100%;
+			background-color: var(--sl-color-black);
+			overflow-y: auto;
+			scrollbar-gutter: stable;
+		}
+
+		:global([aria-expanded='true']) ~ .sidebar-pane {
+			--sl-sidebar-visibility: visible;
+		}
+
+		.sidebar-content {
+			height: 100%;
+			min-height: max-content;
+			padding: 1rem var(--sl-sidebar-pad-x) 0;
+			flex-direction: column;
+			gap: 1rem;
+		}
+
+		@media (min-width: 50rem) {
+			.sidebar-content::after {
+				content: '';
+				padding-bottom: 1px;
+			}
+		}
+
+		.main-frame {
+			padding-top: calc(var(--sl-nav-height) + var(--sl-mobile-toc-height));
+			padding-inline-start: var(--sl-content-inline-start);
+		}
+
+		starlight-sidebar-toggle {
+			display: none;
+		}
+
+		.sidebar-toggle-button {
+			align-items: center;
+			justify-content: center;
+			border: 1px solid var(--sl-color-hairline-shade);
+			border-radius: 50%;
+			width: 2rem;
+			height: 2rem;
+			padding: 0;
+			background-color: var(--sl-color-bg-nav);
+			color: var(--sl-color-text);
+			box-shadow: var(--sl-shadow-sm);
+			cursor: pointer;
+		}
+
+		.sidebar-toggle-button:hover {
+			border-color: var(--sl-color-gray-4);
+			background-color: var(--sl-color-gray-6);
+		}
+
+		.sidebar-toggle-button:focus-visible {
+			outline: 2px solid var(--sl-color-accent);
+			outline-offset: 2px;
+		}
+
+		.sidebar-toggle-button[aria-expanded='true'] .expand-sidebar,
+		.sidebar-toggle-button[aria-expanded='false'] .collapse-sidebar {
+			display: none;
+		}
+
+		@media (min-width: 50rem) {
+			:global([data-has-sidebar]) .header {
+				padding-inline-end: var(--sl-nav-pad-x);
+			}
+
+			.sidebar-pane {
+				--sl-sidebar-visibility: visible;
+				width: var(--sl-sidebar-width);
+				background-color: var(--sl-color-bg-sidebar);
+				border-inline-end: 1px solid var(--sl-color-hairline-shade);
+			}
+
+			starlight-sidebar-toggle {
+				display: block;
+			}
+
+			.sidebar-toggle-button {
+				position: fixed;
+				z-index: var(--sl-z-index-navbar);
+				inset-block-start: calc(var(--sl-nav-height) + 0.75rem);
+				inset-inline-start: calc(var(--sl-sidebar-width) - 1rem);
+				transition:
+					background-color 0.15s ease,
+					border-color 0.15s ease,
+					inset-inline-start 0.15s ease;
+			}
+
+			:global([data-sidebar-collapsed]) .sidebar-pane {
+				visibility: hidden;
+				width: 0;
+				border-inline-end: 0;
+				overflow: hidden;
+				pointer-events: none;
+			}
+
+			:global([data-sidebar-collapsed]) .sidebar-toggle-button {
+				inset-inline-start: var(--sl-nav-pad-x);
+			}
+		}
+	}
+</style>

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,1 +1,2 @@
 /// <reference types="astro/client" />
+/// <reference types="@astrojs/starlight/locals" />

--- a/tests/e2e/interactive.spec.ts
+++ b/tests/e2e/interactive.spec.ts
@@ -1,6 +1,74 @@
 import { expect, test } from '@playwright/test';
 import type { Locator } from '@playwright/test';
 
+test('desktop sidebar toggle collapses, expands, and persists across navigation', async ({ page }) => {
+  await page.setViewportSize({ width: 1280, height: 900 });
+  await page.goto('/features/math/');
+
+  const sidebar = page.locator('#starlight__sidebar');
+  const mainFrame = page.locator('.main-frame');
+  const contentContainer = page.locator('.content-panel .sl-container').first();
+  const toggle = page.locator('starlight-sidebar-toggle button');
+
+  await expect(toggle).toBeVisible();
+  await expect(toggle).toHaveAttribute('aria-label', 'Collapse sidebar');
+  await expect(sidebar).toBeVisible();
+  const expandedContentWidth = await elementWidth(contentContainer);
+  expect(await sidebarPadding(mainFrame)).toBeGreaterThan(100);
+
+  await toggle.click();
+
+  await expect(page.locator('html')).toHaveAttribute('data-sidebar-collapsed', '');
+  await expect(toggle).toHaveAttribute('aria-expanded', 'false');
+  await expect(toggle).toHaveAttribute('aria-label', 'Expand sidebar');
+  await expect(sidebar).toHaveAttribute('aria-hidden', 'true');
+  await expect(sidebar).toHaveAttribute('inert', '');
+  await expect(sidebar).not.toBeVisible();
+  await expect.poll(() => sidebarPadding(mainFrame)).toBeLessThan(1);
+  await expect.poll(() => elementWidth(contentContainer)).toBeGreaterThan(expandedContentWidth + 100);
+  expect(await page.evaluate(() => sessionStorage.getItem('oxiquill-sidebar-collapsed'))).toBe('true');
+
+  await page.goto('/features/diagrams/');
+
+  const persistedToggle = page.locator('starlight-sidebar-toggle button');
+  await expect(page.locator('html')).toHaveAttribute('data-sidebar-collapsed', '');
+  await expect(persistedToggle).toBeVisible();
+  await expect(persistedToggle).toHaveAttribute('aria-label', 'Expand sidebar');
+  await expect(page.locator('#starlight__sidebar')).not.toBeVisible();
+
+  await persistedToggle.click();
+
+  await expect(page.locator('html')).not.toHaveAttribute('data-sidebar-collapsed', '');
+  await expect(persistedToggle).toHaveAttribute('aria-expanded', 'true');
+  await expect(persistedToggle).toHaveAttribute('aria-label', 'Collapse sidebar');
+  await expect(page.locator('#starlight__sidebar')).toBeVisible();
+  expect(await page.evaluate(() => sessionStorage.getItem('oxiquill-sidebar-collapsed'))).toBeNull();
+});
+
+test('desktop sidebar preference does not affect the mobile menu', async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 800 });
+  await page.goto('/features/math/');
+  await page.evaluate(() => sessionStorage.setItem('oxiquill-sidebar-collapsed', 'true'));
+  await page.reload();
+
+  const sidebar = page.locator('#starlight__sidebar');
+  const mobileMenu = page.getByRole('button', { name: 'Menu' });
+
+  await expect(page.locator('html')).not.toHaveAttribute('data-sidebar-collapsed', '');
+  await expect(page.getByRole('button', { name: /sidebar/i })).toHaveCount(0);
+  await expect(mobileMenu).toBeVisible();
+  await expect(sidebar).not.toBeVisible();
+
+  await mobileMenu.click();
+  await expect(sidebar).toBeVisible();
+  await expect(page.locator('body')).toHaveAttribute('data-mobile-menu-expanded', '');
+
+  await mobileMenu.click();
+  await expect(sidebar).not.toBeVisible();
+  await expect(page.locator('body')).not.toHaveAttribute('data-mobile-menu-expanded', '');
+  expect(await page.evaluate(() => sessionStorage.getItem('oxiquill-sidebar-collapsed'))).toBe('true');
+});
+
 test('Rust cells run from MDX code fences and redraw plots', async ({ page }) => {
   await page.goto('/samples/logistic-map/');
 
@@ -163,6 +231,14 @@ test('localized pages and media examples are available', async ({ page }) => {
     page.getByTestId('cell-ja__features__interactive-cells__rust-controls').getByRole('button', { name: 'コードを隠す' })
   ).toBeVisible();
 });
+
+async function sidebarPadding(mainFrame: Locator): Promise<number> {
+  return mainFrame.evaluate((element) => parseFloat(getComputedStyle(element).paddingInlineStart));
+}
+
+async function elementWidth(locator: Locator): Promise<number> {
+  return locator.evaluate((element) => element.getBoundingClientRect().width);
+}
 
 async function canvasStats(canvas: Locator): Promise<{
   height: number;


### PR DESCRIPTION
## Summary
- add a Starlight PageFrame override with a desktop-only sidebar collapse/expand toggle
- persist the desktop sidebar state across navigation while preserving the mobile menu behavior
- widen the main content area when the sidebar is collapsed

## Validation
- pnpm check
- pnpm build
- pnpm exec playwright test tests/e2e/interactive.spec.ts -g "sidebar"
- pnpm test:unit
- push hooks also ran check, unit tests, Rust tests, and Rust clippy