### PR TITLE
ci: deploy site to GitHub Pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,78 @@
+name: Deploy Pages
+
+on:
+  push:
+    branches:
+      - develop
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+env:
+  CARGO_TERM_COLOR: always
+  NODE_VERSION: '24'
+  PNPM_VERSION: '11.2.2'
+  RUST_TOOLCHAIN: '1.95.0'
+  SITE: 'https://kakune.github.io'
+  BASE_PATH: '/oxiquill'
+
+jobs:
+  build:
+    name: Build Pages artifact
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: ${{ env.PNPM_VERSION }}
+          run_install: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+
+      - name: Set up Rust
+        shell: bash
+        run: |
+          rustup toolchain install "$RUST_TOOLCHAIN" --profile minimal --target wasm32-unknown-unknown
+          rustup default "$RUST_TOOLCHAIN"
+
+      - name: Install wasm-pack
+        uses: taiki-e/install-action@wasm-pack
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build static site
+        run: pnpm build
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
+  deploy:
+    name: Deploy to GitHub Pages
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Deploy Pages artifact
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Oxiquill is a static documentation workspace for technical notes written in MDX. It publishes an Astro Starlight site where one page can combine prose, Rust/Wasm cells, Python/Pyodide cells, math, Mermaid diagrams, images, PDFs, and rich output artifacts.
 
-The repository is responsible for producing the static output in `dist/`. Hosting, TLS, domains, and reverse proxies are handled outside this project.
+The repository is responsible for producing the static output in `dist/`. A sample build is published with GitHub Pages at <https://kakune.github.io/oxiquill/>. Production hosting, TLS, domains, and reverse proxies are handled outside this project.
 
 English is the root documentation language. Japanese pages are published under `/ja/`, and the Japanese README is included later in this file.
 
@@ -171,7 +171,7 @@ For docs-only prose changes, `pnpm check` is usually enough. For interactive cel
 
 Oxiquill は、MDX で書いた技術ノートを静的サイトとして公開するためのドキュメントワークスペースです。Astro Starlight を土台にし、1つのページに本文、Rust/Wasm セル、Python/Pyodide セル、数式、Mermaid 図、画像、PDF、リッチ出力をまとめられます。
 
-このリポジトリの責務は、公開用の静的成果物 `dist/` を作るところまでです。配信、TLS、ドメイン、リバースプロキシはこのプロジェクトの外側で扱います。
+このリポジトリの責務は、公開用の静的成果物 `dist/` を作るところまでです。サンプルビルドは GitHub Pages で <https://kakune.github.io/oxiquill/> に公開します。本番配信、TLS、ドメイン、リバースプロキシはこのプロジェクトの外側で扱います。
 
 ドキュメントのroot言語は英語です。日本語ページは `/ja/` 配下で公開します。
 

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -8,9 +8,11 @@ import remarkInteractiveCells from './src/lib/doc-runtime/remark-interactive-cel
 import remarkMermaidDiagrams from './src/lib/doc-runtime/remark-mermaid-diagrams.mjs';
 
 const projectRoot = fileURLToPath(new URL('.', import.meta.url));
+const basePath = process.env.BASE_PATH;
 
 export default defineConfig({
   site: process.env.SITE ?? 'https://oxiquill.local',
+  ...(basePath ? { base: basePath } : {}),
   output: 'static',
   markdown: {
     syntaxHighlight: {


### PR DESCRIPTION
## Summary
- add a GitHub Pages deployment workflow that builds `dist/` from `develop`
- configure Astro to use `BASE_PATH=/oxiquill` for project Pages builds
- document the sample site URL in the English and Japanese README sections

## Sample URL
- https://kakune.github.io/oxiquill/

## Validation
- `SITE=https://kakune.github.io BASE_PATH=/oxiquill pnpm build`
- `pnpm check`
- commit/push hooks also ran unit tests, Rust tests, and Rust clippy

## Follow-up after merge
- In repository Settings > Pages, set Build and deployment Source to GitHub Actions if it is not already selected.