### PR TITLE
Sync release v0.1.0 back to develop

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,10 @@ For docs-only prose changes, `pnpm check` is usually enough. For interactive cel
 
 `test:unit:coverage` requires 85% statement, branch, function, and line coverage for handwritten TypeScript, Preact, and Node runtime code, excluding generated output. `test:rust:coverage` requires 85% line/function/region coverage for optional helper crates under `crates/` through `cargo-llvm-cov`. If no helper crates exist, Rust helper commands skip cleanly.
 
+### Contributing
+
+Contributions are welcome. Please open issues for bug reports, questions, and proposals, and send focused pull requests for fixes or documentation improvements.
+
 ### Troubleshooting
 
 - If a Rust cell helper crate cannot be found, match the cell `crates` value to the `package.name` in `crates/*/Cargo.toml`.
@@ -324,6 +328,10 @@ pnpm doc:rust
 docs-only の本文変更では、通常 `pnpm check` で十分です。実行可能セルの metadata、生成 Rust/Wasm の動作、ブラウザ上の表示例を変更した場合は、必要に応じて `pnpm wasm:dev`、`pnpm test:wasm`、`pnpm test:e2e` も実行します。
 
 `test:unit:coverage` は Vitest の V8 coverage を使い、生成物を除いた手書きの TypeScript、Preact、Node runtime code に statement/branch/function/line 85% coverage を要求します。`test:rust:coverage` は `cargo-llvm-cov` で `crates/` 配下の任意の helper crate に line/function/region 85% を要求します。helper crate がない場合、Rust helper 用 command は正常終了で skip します。
+
+### コントリビューション
+
+バグ報告、質問、提案は issue で歓迎します。小さな修正やドキュメント改善の pull request も歓迎します。
 
 ### トラブルシュート
 


### PR DESCRIPTION
## Summary
- Sync the `release/v0.1.0` branch back into `develop` after the release was merged into `main`.
- Brings over the README contribution notes added for the v0.1.0 release.

## Notes
- PR #33 merged `release/v0.1.0` into `main`.
- This PR follows the repository release flow by bringing the same release branch back into `develop`.