### PR TITLE
Fix Pages artifact upload path

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: dist
+          path: examples/docs-site/dist
 
   deploy:
     name: Deploy to GitHub Pages


### PR DESCRIPTION
## Summary
- Point the Pages artifact upload at `examples/docs-site/dist`, where the docs-site build writes Astro output.

## Validation
- `pnpm build`
- pre-push hook: `pnpm --dir examples/docs-site check`
- pre-push hook: `vitest run`
- pre-push hook: `pnpm --dir examples/docs-site test:rust`
- pre-push hook: `pnpm --dir examples/docs-site lint:rust`