### PR TITLE
chore: add Nix development environment

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,3 @@
+source_env_if_exists .envrc.local
+watch_file rust-toolchain.toml
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -29,12 +29,14 @@ examples/docs-site/crates/target/
 .codex/
 .serena/
 .agents/
+.direnv/
 .vscode/
 .idea/
 
 # Environment files
 .env
 .env.*
+.envrc.local
 !.env.example
 
 # Logs and package-manager diagnostics

--- a/README.md
+++ b/README.md
@@ -26,13 +26,23 @@ English is the root documentation language. Japanese pages are published under `
 
 ### Requirements
 
-- Node.js and `pnpm`
-- Rust toolchain `1.95.0`
+- Nix with flakes enabled, or equivalent manual tools
+- Node.js 24 and `pnpm` 11.2.2
+- Rust toolchain `1.95.0` with `wasm32-unknown-unknown`
 - `wasm-pack`
 - `cargo-llvm-cov`
-- `wasm32-wasi-ghc` when authoring Haskell cells
+- `wasm32-wasi-ghc` 9.14 when authoring Haskell cells
+- Chromium for Playwright e2e tests
 
-The Rust toolchain and Wasm target are pinned by `rust-toolchain.toml`. Haskell cells use GHC's `wasm32-wasi` backend. When using `ghc-wasm-meta`, keep a normal Node.js runtime first in `PATH` and point Oxiquill at the Haskell compiler directly:
+On NixOS or any Linux system with Nix, use the checked-in flake to enter a shell with Node, pnpm, Rust, `wasm-pack`, `cargo-llvm-cov`, `wasm32-wasi-ghc`, and Chromium already wired up:
+
+```sh
+nix develop
+```
+
+The Nix shell sets `OXIQUILL_NODE`, `OXIQUILL_HASKELL_GHC`, `LLVM_COV`, `LLVM_PROFDATA`, `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1`, and `PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH`. Writable tool caches are kept under the ignored `.cache/` directory.
+
+Without Nix, install equivalent tools manually. Haskell cells use GHC's `wasm32-wasi` backend. When using `ghc-wasm-meta`, keep a normal Node.js runtime first in `PATH` and point Oxiquill at the Haskell compiler directly:
 
 ```sh
 nvm alias default 24.2.0
@@ -43,10 +53,11 @@ Avoid putting ghc-wasm's static Node ahead of the normal Node used by Vite, Vite
 
 ### Setup
 
-Install dependencies:
+Enter the development shell and install dependencies:
 
 ```sh
-pnpm install
+nix develop
+pnpm install --frozen-lockfile
 ```
 
 Start the development server:
@@ -276,13 +287,23 @@ Oxiquill は、MDX で書いた技術ノートを静的サイトとして公開�
 
 ### 前提
 
-- Node.js と `pnpm`
-- Rust toolchain `1.95.0`
+- Nix flakes、または同等の手動 tool
+- Node.js 24 と `pnpm` 11.2.2
+- `wasm32-unknown-unknown` を含む Rust toolchain `1.95.0`
 - `wasm-pack`
 - `cargo-llvm-cov`
-- Haskell セルを書く場合は `wasm32-wasi-ghc`
+- Haskell セルを書く場合は `wasm32-wasi-ghc` 9.14
+- Playwright e2e test 用の Chromium
 
-Rust toolchain と Wasm target は `rust-toolchain.toml` で固定しています。Haskell セルは GHC の `wasm32-wasi` backend を使います。`ghc-wasm-meta` を使う場合は、通常の Node.js runtime を `PATH` の先頭に置いたまま、Oxiquill には Haskell compiler の path を直接指定します。
+NixOS または Nix を使える Linux では、このリポジトリの flake で shell に入ると、Node、pnpm、Rust、`wasm-pack`、`cargo-llvm-cov`、`wasm32-wasi-ghc`、Chromium が設定済みになります。
+
+```sh
+nix develop
+```
+
+Nix shell は `OXIQUILL_NODE`、`OXIQUILL_HASKELL_GHC`、`LLVM_COV`、`LLVM_PROFDATA`、`PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1`、`PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH` を設定します。tool cache は ignore 済みの `.cache/` 配下に置かれます。
+
+Nix を使わない場合は、同等の tool を手動で導入してください。Haskell セルは GHC の `wasm32-wasi` backend を使います。`ghc-wasm-meta` を使う場合は、通常の Node.js runtime を `PATH` の先頭に置いたまま、Oxiquill には Haskell compiler の path を直接指定します。
 
 ```sh
 nvm alias default 24.2.0
@@ -293,10 +314,11 @@ Vite、Vitest、Astro が使う通常の Node より前に ghc-wasm の static N
 
 ### セットアップ
 
-依存関係をインストールします。
+開発 shell に入り、依存関係をインストールします。
 
 ```sh
-pnpm install
+nix develop
+pnpm install --frozen-lockfile
 ```
 
 開発サーバーを起動します。

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,135 @@
+{
+  "nodes": {
+    "fenix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "rust-analyzer-src": "rust-analyzer-src"
+      },
+      "locked": {
+        "lastModified": 1780824777,
+        "narHash": "sha256-/D3gjEDezsoa//Kbd+rNQRERl4AS+HYOMChsdD1eus4=",
+        "owner": "nix-community",
+        "repo": "fenix",
+        "rev": "3a556b6fbd42412b6f3f0ea8d35959b1826f86ff",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "fenix",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "ghc-wasm-meta": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1780507186,
+        "narHash": "sha256-qp/sLxsc3mHrXyVRTWn0zmqWMg+60G36zUGLeLhGIHQ=",
+        "owner": "haskell-wasm",
+        "repo": "ghc-wasm-meta",
+        "rev": "ba0c8238314857ef1d5db1f20bb17b96178c9bd3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell-wasm",
+        "repo": "ghc-wasm-meta",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1780383649,
+        "narHash": "sha256-FS3od1iIyWYz68tqZGGc92Po7Ji+G2NEm6+a4s4RI0w=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "595ee2b1a31a50efcb8db3824999abb98ec1d0c9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-26.05-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1780243769,
+        "narHash": "sha256-x5UQuRsH3MqI0U9afaXSNqzTPSeZlRLvFAav2Ux1pNw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "331800de5053fcebacf6813adb5db9c9dca22a0c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "fenix": "fenix",
+        "ghc-wasm-meta": "ghc-wasm-meta",
+        "nixpkgs": "nixpkgs_2"
+      }
+    },
+    "rust-analyzer-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1780758424,
+        "narHash": "sha256-OcXGwiq5ibERT8S9rx5V1bgleguAfwzSQzMePpf8yIE=",
+        "owner": "rust-lang",
+        "repo": "rust-analyzer",
+        "rev": "a9a66c4077fedd375c0f1e61dc39a8f3243ce0ef",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rust-lang",
+        "ref": "nightly",
+        "repo": "rust-analyzer",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,153 @@
+{
+  description = "Oxiquill development environment";
+
+  nixConfig.http2 = false;
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    fenix = {
+      url = "github:nix-community/fenix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    ghc-wasm-meta.url = "github:haskell-wasm/ghc-wasm-meta";
+  };
+
+  outputs =
+    {
+      self,
+      nixpkgs,
+      fenix,
+      ghc-wasm-meta,
+    }:
+    let
+      systems = [ "x86_64-linux" ];
+      forAllSystems = nixpkgs.lib.genAttrs systems;
+      mkToolchain =
+        system:
+        let
+          pkgs = import nixpkgs { inherit system; };
+          rustToolchain = fenix.packages.${system}.fromToolchainFile {
+            file = ./rust-toolchain.toml;
+            sha256 = "sha256-gh/xTkxKHL4eiRXzWv8KP7vfjSk61Iq48x47BEDFgfk=";
+          };
+          nodejs = pkgs.nodejs_24;
+          pnpm = pkgs.pnpm_11.overrideAttrs (_oldAttrs: {
+            version = "11.2.2";
+            src = pkgs.fetchurl {
+              url = "https://registry.npmjs.org/pnpm/-/pnpm-11.2.2.tgz";
+              hash = "sha256-mcS+gx7SMYKYlRQtlnk9vnWvxTeVkzrtg2bmjczh4bg=";
+            };
+          });
+          haskellGhc = ghc-wasm-meta.packages.${system}."wasm32-wasi-ghc-9_14";
+          llvmTools = pkgs.llvmPackages.llvm;
+          chromiumExecutablePath = nixpkgs.lib.getExe pkgs.chromium;
+          nodeExecutablePath = nixpkgs.lib.getExe nodejs;
+          haskellCompilerPath = "${haskellGhc}/bin/wasm32-wasi-ghc";
+          llvmCovPath = "${llvmTools}/bin/llvm-cov";
+          llvmProfdataPath = "${llvmTools}/bin/llvm-profdata";
+          packages = [
+            nodejs
+            pnpm
+            rustToolchain
+            pkgs.wasm-pack
+            pkgs.cargo-llvm-cov
+            llvmTools
+            haskellGhc
+            pkgs.chromium
+          ];
+          cacheHook = ''
+            export XDG_CACHE_HOME="$PWD/.cache/xdg"
+            export npm_config_cache="$PWD/.cache/npm"
+            export npm_config_store_dir="$PWD/.cache/pnpm-store"
+            export PNPM_HOME="$PWD/.cache/pnpm-home"
+            export CARGO_HOME="$PWD/.cache/cargo"
+            export WASM_PACK_CACHE="$PWD/.cache/wasm-pack"
+            mkdir -p "$XDG_CACHE_HOME" "$npm_config_cache" "$npm_config_store_dir" "$PNPM_HOME" "$CARGO_HOME" "$WASM_PACK_CACHE"
+            export PATH="$PNPM_HOME:$PATH"
+          '';
+        in
+        {
+          inherit
+            cacheHook
+            chromiumExecutablePath
+            haskellCompilerPath
+            llvmCovPath
+            llvmProfdataPath
+            nodeExecutablePath
+            packages
+            ;
+        };
+    in
+    {
+      devShells = forAllSystems (
+        system:
+        let
+          toolchain = mkToolchain system;
+          pkgs = import nixpkgs { inherit system; };
+        in
+        {
+          default = pkgs.mkShell {
+            packages = toolchain.packages;
+            OXIQUILL_NODE = toolchain.nodeExecutablePath;
+            OXIQUILL_HASKELL_GHC = toolchain.haskellCompilerPath;
+            LLVM_COV = toolchain.llvmCovPath;
+            LLVM_PROFDATA = toolchain.llvmProfdataPath;
+            PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD = "1";
+            PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH = toolchain.chromiumExecutablePath;
+            shellHook = toolchain.cacheHook;
+          };
+        }
+      );
+
+      checks = forAllSystems (
+        system:
+        let
+          toolchain = mkToolchain system;
+          pkgs = import nixpkgs { inherit system; };
+        in
+        {
+          toolchain = pkgs.runCommand "oxiquill-toolchain-check" {
+            nativeBuildInputs = toolchain.packages;
+            OXIQUILL_NODE = toolchain.nodeExecutablePath;
+            OXIQUILL_HASKELL_GHC = toolchain.haskellCompilerPath;
+            LLVM_COV = toolchain.llvmCovPath;
+            LLVM_PROFDATA = toolchain.llvmProfdataPath;
+            PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD = "1";
+            PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH = toolchain.chromiumExecutablePath;
+          } ''
+            node_version="$(node --version)"
+            case "$node_version" in
+              v24.*) ;;
+              *) echo "expected Node.js 24, got $node_version" >&2; exit 1 ;;
+            esac
+
+            pnpm_version="$(pnpm --version)"
+            if [ "$pnpm_version" != "11.2.2" ]; then
+              echo "expected pnpm 11.2.2, got $pnpm_version" >&2
+              exit 1
+            fi
+
+            rustc_version="$(rustc --version)"
+            case "$rustc_version" in
+              "rustc 1.95.0 "*) ;;
+              *) echo "expected rustc 1.95.0, got $rustc_version" >&2; exit 1 ;;
+            esac
+
+            cargo llvm-cov --version
+            "$LLVM_COV" --version
+            "$LLVM_PROFDATA" --version
+            wasm-pack --version
+            "$OXIQUILL_HASKELL_GHC" --version
+            "$PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH" --version
+
+            mkdir -p "$out"
+            {
+              echo "$node_version"
+              echo "pnpm $pnpm_version"
+              echo "$rustc_version"
+            } > "$out/toolchain.txt"
+          '';
+        }
+      );
+    };
+}

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,5 +1,7 @@
 import { defineConfig } from '@playwright/test';
 
+const chromiumExecutablePath = process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH?.trim();
+
 export default defineConfig({
   testDir: './tests/e2e',
   timeout: 60_000,
@@ -10,6 +12,9 @@ export default defineConfig({
   },
   use: {
     baseURL: 'http://127.0.0.1:4322',
-    trace: 'on-first-retry'
+    trace: 'on-first-retry',
+    ...(chromiumExecutablePath
+      ? { launchOptions: { executablePath: chromiumExecutablePath } }
+      : {})
   }
 });

--- a/tests/e2e/dev-hmr-smoke.mjs
+++ b/tests/e2e/dev-hmr-smoke.mjs
@@ -15,6 +15,7 @@ import { fileURLToPath } from 'node:url';
 const repoRoot = path.resolve(fileURLToPath(new URL('../..', import.meta.url)));
 const tempRoot = mkdtempSync(path.join(os.tmpdir(), 'oxiquill-dev-hmr-'));
 const tempSiteRoot = path.join(tempRoot, 'examples/docs-site');
+const chromiumExecutablePath = process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH?.trim();
 const children = new Set();
 let browser;
 
@@ -53,6 +54,7 @@ try {
   await waitForHttp(`http://127.0.0.1:${port}/features/interactive-cells/`, 60_000);
 
   browser = await chromium.launch({
+    ...(chromiumExecutablePath ? { executablePath: chromiumExecutablePath } : {}),
     args: ['--disable-setuid-sandbox', '--no-sandbox']
   });
   const page = await browser.newPage();


### PR DESCRIPTION
## Summary
- add a flake-based Nix development environment
- add direnv support and ignore local direnv state
- document the Nix workflow and adjust dev-server e2e setup

## Testing
- Not run; PR creation only.