### PR TITLE
chore: adopt a main-only development workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,11 +2,11 @@ name: CI
 
 on:
   pull_request:
+    branches:
+      - main
   push:
     branches:
-      - develop
       - main
-      - 'release/**'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -3,7 +3,7 @@ name: Deploy Pages
 on:
   push:
     branches:
-      - develop
+      - main
   workflow_dispatch:
 
 permissions:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,13 +7,12 @@
 ## Branch Strategy
 
 - Do development work on topic branches such as `feat/...`, `fix/...`, `chore/...`, or `docs/...`.
-- Submit topic branch changes to `develop` by pull request. Do not push directly to `develop` or `main`.
+- Submit every topic branch, Dependabot update, and release preparation branch to `main` by pull request. Do not push directly to `main`.
 - Keep commits small and separated by logical meaning.
-- Pull requests to `main` must come only from release branches, for example `release/v0.1.1`.
-- After a release branch is merged into `main`, merge that same release branch into `develop` so `develop` stays in sync.
-- Use squash merge when merging into `develop`.
-- Use merge commits when merging into `main`.
-- Branch rules prohibit all other merge methods.
+- Keep pull requests up to date with `main`, pass every required check, and resolve review conversations before merging.
+- Use squash merge for every pull request into `main`; branch rules prohibit other merge methods.
+- Delete merged topic branches. GitHub deletes them automatically unless a protection rule retains them.
+- Prepare releases on `release/vX.Y.Z` branches created from the latest `main`. Squash-merge the release pull request into `main`, tag the resulting `main` commit, and retain the protected release branch without further updates.
 
 ## Project Shape
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to Oxiquill
 
-Contributions are welcome through focused pull requests against `develop`. Create a topic branch, follow the validation guidance in `AGENTS.md`, and keep generated output out of commits.
+Contributions are welcome through focused pull requests against `main`. Create a topic branch, follow the validation guidance in `AGENTS.md`, and keep generated output out of commits. Pull requests are squash-merged after the required checks pass and review conversations are resolved.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ See the [licensing guide](./examples/docs-site/content/docs/guides/licensing.mdx
 
 ### Contributing
 
-Contributions are welcome. Please open issues for bug reports, questions, and proposals, and send focused pull requests for fixes or documentation improvements. Contributions are accepted under the inbound dual-license terms in [CONTRIBUTING.md](./CONTRIBUTING.md).
+Contributions are welcome. Please open issues for bug reports, questions, and proposals, and send focused pull requests to `main` from topic branches for fixes or documentation improvements. Pull requests are squash-merged after the required checks pass. Contributions are accepted under the inbound dual-license terms in [CONTRIBUTING.md](./CONTRIBUTING.md).
 
 ### Troubleshooting
 
@@ -523,7 +523,7 @@ Oxiquill は [MIT License](./LICENSE-MIT) または [Apache License, Version 2.0
 
 ### コントリビューション
 
-バグ報告、質問、提案は issue で歓迎します。小さな修正やドキュメント改善の pull request も歓迎します。Contribution は [CONTRIBUTING.md](./CONTRIBUTING.md) の inbound dual-license 条項に基づいて受け入れます。
+バグ報告、質問、提案は issue で歓迎します。修正やドキュメント改善は topic branch から `main` への小さな pull request として送ってください。必須 check が成功した pull request は squash merge します。Contribution は [CONTRIBUTING.md](./CONTRIBUTING.md) の inbound dual-license 条項に基づいて受け入れます。
 
 ### トラブルシュート
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,6 +1,8 @@
 # Releasing Oxiquill
 
-Releases are prepared on `release/vX.Y.Z` branches. Update and validate the version there, merge the release branch into `main` with a merge commit, tag that `main` commit as `vX.Y.Z`, and publish a GitHub Release for the tag. Merge the same release branch back into `develop` afterward.
+Create `release/vX.Y.Z` from the latest `main`, then update and validate the version there. Open a pull request to `main` and squash-merge it after every required check passes and review conversations are resolved. Tag the resulting `main` commit as `vX.Y.Z` and publish a GitHub Release for that tag. Do not tag the release-branch commit: squash merge creates a different commit, and the publication workflow requires the tag to be contained in `main`.
+
+Retain the protected release branch after merging as a record of the release preparation. Do not update, force-push, or delete it after the pull request is merged. Other merged topic branches are deleted automatically.
 
 The `.github/workflows/npm-publish.yml` workflow rejects prerelease versions, prerelease GitHub Releases, mismatched tags, and tags that are not contained in `main`. It runs repository validation, checks the npm tarball, and builds a fresh consumer from that tarball before publishing `packages/oxiquill`.
 
@@ -12,4 +14,4 @@ npm Trusted Publishing cannot be configured until the package exists. For the fi
 
 Configure npm Trusted Publishing for repository `kakune/oxiquill` and workflow filename `npm-publish.yml`. The workflow grants `id-token: write`, runs on a GitHub-hosted runner, and invokes npm directly, so npm can exchange the GitHub OIDC identity for a short-lived publishing credential and attach provenance.
 
-Do not retain `NPM_TOKEN` after bootstrap. Do not publish from a topic branch, from `develop`, or by manually running `npm publish` on a workstation.
+Do not retain `NPM_TOKEN` after bootstrap. Do not publish from a topic or release branch, or by manually running `npm publish` on a workstation. Publish only from a GitHub Release tag that points to a commit contained in `main`.


### PR DESCRIPTION
## Summary

- route topic, Dependabot, and release pull requests directly to main
- switch CI and Pages branch triggers from develop to main
- document squash merging and retained protected release branches

## Validation

- pnpm check