### PR TITLE
Validate, bound, and isolate rich output artifacts

### DIFF
--- a/examples/docs-site/content/docs/features/rich-output.mdx
+++ b/examples/docs-site/content/docs/features/rich-output.mdx
@@ -16,7 +16,20 @@ Oxiquill renders these output kinds:
 - Images from SVG, PNG, or JPEG data.
 - Sandboxed HTML in an iframe.
 
-Large outputs are limited before they reach the UI thread. Text is capped at about 200 KB, JSON and HTML at about 500 KB, images at about 2 MB, and table previews at 1,000 rows.
+Oxiquill validates every artifact before rendering it and applies these runtime limits:
+
+- 100 artifacts per run.
+- 1 MiB of UTF-8 data per text, formatted JSON, or HTML artifact.
+- 10,000 rows and 100 columns per table.
+- 100,000 data points, bins, or cells per chart.
+- 10 MiB of decoded data per image.
+- 16 MiB of validated output data across one run.
+
+Text, JSON, and table artifacts are truncated at safe boundaries and marked as truncated. Oversized charts, images, and HTML artifacts display an artifact-local error instead. Invalid output or a renderer failure also stays local to that artifact, so valid sibling outputs remain usable.
+
+JSON formatting is cycle-aware. Cycles use a `[Circular -> path]` marker, BigInt values use `{ "$bigint": "value" }`, and excessively nested or oversized subtrees use a `[Truncated]` marker. Tables use the same safe formatting for structured cells. Image data must match its declared SVG, PNG, or JPEG MIME type, and PNG/JPEG payloads must be valid base64 with the matching file signature.
+
+HTML always renders in an iframe with an empty `sandbox` attribute. Oxiquill does not grant script or same-origin permission. Table CSV controls report successful copies as well as conversion, permission, and clipboard failures.
 
 ## Python Display Helpers
 

--- a/examples/docs-site/content/docs/ja/features/rich-output.mdx
+++ b/examples/docs-site/content/docs/ja/features/rich-output.mdx
@@ -16,7 +16,20 @@ Oxiquill は次の出力を表示します。
 - SVG、PNG、JPEG data から作る image。
 - iframe 内の sandboxed HTML。
 
-大きな出力は UI thread に届く前に制限されます。text は約 200 KB、JSON と HTML は約 500 KB、image は約 2 MB、table preview は 1,000 row までです。
+Oxiquill は各 artifact を render 前に検証し、次の runtime 上限を適用します。
+
+- 1 run あたり100 artifact。
+- text、format 済み JSON、HTML は1 artifact あたり UTF-8 で1 MiB。
+- table は10,000 row、100 column。
+- chart は data point、bin、cell の合計が100,000。
+- image は decode 後の data が10 MiB。
+- 1 run 全体で検証済み output data が16 MiB。
+
+Text、JSON、table artifact は安全な境界で切り詰められ、truncated と表示されます。上限を超えた chart、image、HTML は、その artifact だけの error を表示します。不正な output や renderer failure も artifact 内に分離されるため、正常な sibling output は引き続き利用できます。
+
+JSON formatting は cycle を扱えます。Cycle は `[Circular -> path]` marker、BigInt は `{ "$bigint": "value" }`、深すぎる、または大きすぎる subtree は `[Truncated]` marker で表します。Table の structured cell も同じ安全な formatting を使います。Image data は宣言した SVG、PNG、JPEG MIME type と一致する必要があり、PNG/JPEG payload は対応する file signature を持つ正しい base64 でなければなりません。
+
+HTML は常に空の `sandbox` attribute を持つ iframe 内で render されます。Script permission と same-origin permission は付与されません。Table の CSV control は copy 成功に加え、conversion、permission、clipboard の失敗も表示します。
 
 ## Python display helper
 

--- a/packages/oxiquill/src/components/doc-runtime/ArtifactErrorBoundary.tsx
+++ b/packages/oxiquill/src/components/doc-runtime/ArtifactErrorBoundary.tsx
@@ -1,0 +1,43 @@
+import { Component, type ComponentChildren } from 'preact';
+
+interface ArtifactErrorBoundaryProps {
+  children: ComponentChildren;
+  index: number;
+  resetKey: object;
+}
+
+interface ArtifactErrorBoundaryState {
+  error?: string;
+}
+
+export default class ArtifactErrorBoundary extends Component<
+  ArtifactErrorBoundaryProps,
+  ArtifactErrorBoundaryState
+> {
+  state: ArtifactErrorBoundaryState = {};
+
+  componentDidCatch(error: unknown): void {
+    this.setState({ error: error instanceof Error ? error.message : String(error) });
+  }
+
+  componentDidUpdate(previousProps: ArtifactErrorBoundaryProps): void {
+    if (previousProps.resetKey !== this.props.resetKey && this.state.error) {
+      this.setState({ error: undefined });
+    }
+  }
+
+  render({ children, index }: ArtifactErrorBoundaryProps, { error }: ArtifactErrorBoundaryState) {
+    if (error) {
+      return <ArtifactError message={`Artifact ${index + 1} failed to render: ${error}`} />;
+    }
+    return children;
+  }
+}
+
+export function ArtifactError({ message }: { message: string }) {
+  return (
+    <p class="error-state" data-testid="artifact-error" role="alert">
+      {message}
+    </p>
+  );
+}

--- a/packages/oxiquill/src/components/doc-runtime/CellOutput.tsx
+++ b/packages/oxiquill/src/components/doc-runtime/CellOutput.tsx
@@ -2,7 +2,10 @@ import {
   idleOutputMessage,
   labelsForLanguage
 } from '../../lib/doc-runtime/interactive-cell-model';
-import { normalizeCellExecutionResult } from '../../lib/doc-runtime/output-artifacts';
+import {
+  normalizeCellExecutionResult,
+  type NormalizedCellExecutionResult
+} from '../../lib/doc-runtime/output-artifacts';
 import type {
   CellExecutionResult,
   CellManifest
@@ -21,7 +24,7 @@ export function CellOutput({
   error?: string;
   isRunning: boolean;
   labels: RuntimeLabels;
-  result?: CellExecutionResult;
+  result?: CellExecutionResult | NormalizedCellExecutionResult;
   runMode: CellManifest['run'];
 }) {
   if (error) return <p class="error-state">{error}</p>;
@@ -34,11 +37,13 @@ export function CellOutput({
     );
   }
 
-  const normalizedResult = normalizeCellExecutionResult(result);
+  const outputResults = 'outputResults' in result
+    ? result.outputResults
+    : normalizeCellExecutionResult(result).outputResults;
 
   return (
     <div class="doc-cell__outputs">
-      <OutputRenderer outputs={normalizedResult.outputs} />
+      <OutputRenderer outputs={outputResults} />
     </div>
   );
 }

--- a/packages/oxiquill/src/components/doc-runtime/OutputRenderer.tsx
+++ b/packages/oxiquill/src/components/doc-runtime/OutputRenderer.tsx
@@ -1,47 +1,53 @@
-import { isOutputArtifact } from '../../lib/doc-runtime/output-artifacts';
-import type { ImageArtifact, OutputArtifact, TextArtifact } from '../../lib/doc-runtime/types';
+import type {
+  ValidatedArtifactResult,
+  ValidatedImageArtifact,
+  ValidatedJsonArtifact,
+  ValidatedOutputArtifact
+} from '../../lib/doc-runtime/output-artifact-validation';
+import type { ComponentChildren } from 'preact';
+import type { TextArtifact } from '../../lib/doc-runtime/types';
+import ArtifactErrorBoundary, { ArtifactError } from './ArtifactErrorBoundary';
 import ChartOutput from './ChartOutput';
 import TableOutput from './TableOutput';
 
 interface OutputRendererProps {
-  outputs: readonly unknown[];
+  outputs: readonly ValidatedArtifactResult[];
 }
 
 export default function OutputRenderer({ outputs }: OutputRendererProps) {
   return (
     <>
       {outputs.map((output, index) => (
-        <ArtifactOutput key={artifactKey(output, index)} output={output} />
+        <ArtifactErrorBoundary
+          key={artifactKey(output, index)}
+          index={output.index}
+          resetKey={output}
+        >
+          <ArtifactOutput output={output} />
+        </ArtifactErrorBoundary>
       ))}
     </>
   );
 }
 
-function ArtifactOutput({ output }: { output: unknown }) {
-  if (!isOutputArtifact(output)) {
-    return <UnknownOutput message="Unsupported output artifact." />;
+function ArtifactOutput({ output }: { output: ValidatedArtifactResult }) {
+  if (output.status === 'error') {
+    return <ArtifactError message={`Artifact ${output.index + 1}: ${output.message}`} />;
   }
 
-  switch (output.kind) {
+  switch (output.artifact.kind) {
     case 'text':
-      return <TextOutput output={output} />;
+      return <TextOutput output={output.artifact} />;
     case 'json':
-      return (
-        <pre class="run-output" data-testid="value-output">
-          <code>{JSON.stringify(output.value, null, 2)}</code>
-        </pre>
-      );
+      return <JsonOutput output={output.artifact} />;
     case 'html':
-      return <HtmlOutput output={output} />;
+      return <HtmlOutput output={output.artifact} />;
     case 'chart':
-      return <ChartOutput spec={output.spec} />;
+      return <ChartOutput spec={output.artifact.spec} />;
     case 'table':
-      return <TableOutput table={output} />;
+      return <TableOutput table={output.artifact} />;
     case 'image':
-      return <ImageOutput output={output} />;
-    /* v8 ignore next -- isOutputArtifact rejects unknown artifact kinds before this switch. */
-    default:
-      return <UnknownOutput message="Unsupported output artifact." />;
+      return <ImageOutput output={output.artifact} />;
   }
 }
 
@@ -49,14 +55,22 @@ function TextOutput({ output }: { output: TextArtifact }) {
   const isError = output.stream === 'stderr';
   const className = isError ? 'error-output' : 'run-output';
 
-  return (
+  return <OutputWithTruncation truncated={output.truncated}>
     <pre class={className} data-testid={isError ? undefined : 'run-output'}>
       <code>{output.content}</code>
     </pre>
-  );
+  </OutputWithTruncation>;
 }
 
-function ImageOutput({ output }: { output: ImageArtifact }) {
+function JsonOutput({ output }: { output: ValidatedJsonArtifact }) {
+  return <OutputWithTruncation truncated={output.truncated}>
+    <pre class="run-output" data-testid="value-output">
+      <code>{output.formattedValue}</code>
+    </pre>
+  </OutputWithTruncation>;
+}
+
+function ImageOutput({ output }: { output: ValidatedImageArtifact }) {
   return (
     <figure class="doc-image-output">
       <img
@@ -75,7 +89,7 @@ function ImageOutput({ output }: { output: ImageArtifact }) {
   );
 }
 
-function HtmlOutput({ output }: { output: Extract<OutputArtifact, { kind: 'html' }> }) {
+function HtmlOutput({ output }: { output: Extract<ValidatedOutputArtifact, { kind: 'html' }> }) {
   return (
     <iframe
       class="doc-html-output"
@@ -87,23 +101,21 @@ function HtmlOutput({ output }: { output: Extract<OutputArtifact, { kind: 'html'
   );
 }
 
-function UnknownOutput({ message }: { message: string }) {
+function OutputWithTruncation({ children, truncated }: { children: ComponentChildren; truncated?: boolean }) {
   return (
-    <p class="error-state" data-testid="artifact-error">
-      {message}
-    </p>
+    <div class="doc-output-artifact">
+      {children}
+      {truncated ? <p class="doc-output-artifact__notice" data-testid="artifact-truncated">Output truncated.</p> : null}
+    </div>
   );
 }
 
-export function imageArtifactSource(output: ImageArtifact): string {
-  if (output.data.startsWith('data:')) return output.data;
-  if (output.mime === 'image/svg+xml') {
-    return `data:${output.mime};charset=utf-8,${encodeURIComponent(output.data)}`;
-  }
-  return `data:${output.mime};base64,${output.data}`;
+export function imageArtifactSource(output: ValidatedImageArtifact): string {
+  return output.source;
 }
 
-function artifactKey(output: unknown, index: number): string {
-  if (isOutputArtifact(output) && output.id) return output.id;
-  return String(index);
+function artifactKey(output: ValidatedArtifactResult, index: number): string {
+  return output.status === 'valid' && output.artifact.id
+    ? `${output.artifact.id}:${index}`
+    : String(index);
 }

--- a/packages/oxiquill/src/components/doc-runtime/TableOutput.tsx
+++ b/packages/oxiquill/src/components/doc-runtime/TableOutput.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'preact/hooks';
+import { useEffect, useMemo, useState } from 'preact/hooks';
 import type { TableArtifact, TableColumn } from '../../lib/doc-runtime/types';
 
 interface TableOutputProps {
@@ -11,18 +11,30 @@ type SortState = {
   direction: SortDirection;
 };
 
+export type TableCsvResult =
+  | { ok: true; csv: string }
+  | { ok: false; error: string };
+
+type CopyStatus = {
+  kind: 'success' | 'error';
+  message: string;
+};
+
 const pageSizes = [10, 25, 50, 100] as const;
 
 export default function TableOutput({ table }: TableOutputProps) {
   const [pageSize, setPageSize] = useState<(typeof pageSizes)[number]>(pageSizes[0]);
   const [page, setPage] = useState(0);
   const [sort, setSort] = useState<SortState>();
+  const [copyStatus, setCopyStatus] = useState<CopyStatus>();
   const sortedRows = useMemo(() => sortRows(table.rows, sort), [table.rows, sort]);
   const pageCount = Math.max(1, Math.ceil(sortedRows.length / pageSize));
   const safePage = Math.min(page, pageCount - 1);
   const currentRows = visibleRows(sortedRows, safePage, pageSize);
   const firstRow = sortedRows.length === 0 ? 0 : safePage * pageSize + 1;
   const lastRow = Math.min(sortedRows.length, (safePage + 1) * pageSize);
+
+  useEffect(() => setCopyStatus(undefined), [table]);
 
   function updateSort(columnIndex: number): void {
     setPage(0);
@@ -33,7 +45,25 @@ export default function TableOutput({ table }: TableOutputProps) {
   }
 
   async function copyVisibleCsv(): Promise<void> {
-    await globalThis.navigator.clipboard?.writeText(tableToCsv(table.columns, currentRows));
+    const converted = tableToCsv(table.columns, currentRows);
+    if (!converted.ok) {
+      setCopyStatus({ kind: 'error', message: `Unable to copy CSV: ${converted.error}` });
+      return;
+    }
+    try {
+      const clipboard = globalThis.navigator.clipboard;
+      if (!clipboard) {
+        setCopyStatus({ kind: 'error', message: 'Unable to copy CSV: Clipboard access is unavailable.' });
+        return;
+      }
+      await clipboard.writeText(converted.csv);
+      setCopyStatus({ kind: 'success', message: 'Copied visible rows as CSV.' });
+    } catch (error) {
+      setCopyStatus({
+        kind: 'error',
+        message: `Unable to copy CSV: ${error instanceof Error ? error.message : String(error)}`
+      });
+    }
   }
 
   return (
@@ -110,6 +140,15 @@ export default function TableOutput({ table }: TableOutputProps) {
           </button>
         </div>
       </div>
+      {copyStatus ? (
+        <p
+          class={copyStatus.kind === 'error' ? 'error-state' : 'doc-table-output__status'}
+          data-testid="table-copy-status"
+          role={copyStatus.kind === 'error' ? 'alert' : 'status'}
+        >
+          {copyStatus.message}
+        </p>
+      ) : null}
     </section>
   );
 }
@@ -130,11 +169,23 @@ export function visibleRows(rows: readonly unknown[][], page: number, pageSize: 
   return rows.slice(page * pageSize, (page + 1) * pageSize);
 }
 
-export function tableToCsv(columns: readonly TableColumn[], rows: readonly unknown[][]): string {
-  return [
-    columns.map((column) => csvCell(column.label)).join(','),
-    ...rows.map((row) => columns.map((_, index) => csvCell(row[index])).join(','))
-  ].join('\n');
+export function tableToCsv(columns: readonly TableColumn[], rows: readonly unknown[][]): TableCsvResult {
+  try {
+    return {
+      ok: true,
+      csv: [
+        columns.map((column) => csvCell(column.label)).join(','),
+        ...rows.map((row, rowIndex) => {
+          if (row.length !== columns.length) {
+            throw new Error(`Row ${rowIndex + 1} has ${row.length} cells; expected ${columns.length}.`);
+          }
+          return columns.map((_, index) => csvCell(row[index])).join(',');
+        })
+      ].join('\n')
+    };
+  } catch (error) {
+    return { ok: false, error: error instanceof Error ? error.message : String(error) };
+  }
 }
 
 export function formatTableCell(value: unknown): string {
@@ -147,7 +198,7 @@ export function formatTableCell(value: unknown): string {
   }
   if (typeof value === 'boolean') return value ? 'true' : 'false';
   if (typeof value === 'string') return value;
-  return JSON.stringify(value);
+  throw new Error(`Unsupported validated table cell type: ${typeof value}.`);
 }
 
 function compareCellValues(left: unknown, right: unknown): number {
@@ -161,8 +212,13 @@ function compareCellValues(left: unknown, right: unknown): number {
 
 function csvCell(value: unknown): string {
   if (value == null) return '';
-
-  const text = typeof value === 'object' ? JSON.stringify(value) : String(value);
+  if (!['string', 'number', 'boolean'].includes(typeof value)) {
+    throw new Error(`Unsupported validated table cell type: ${typeof value}.`);
+  }
+  if (typeof value === 'number' && !Number.isFinite(value)) {
+    throw new Error('Validated table cells must contain finite numbers.');
+  }
+  const text = String(value);
   return /[",\n\r]/u.test(text) ? `"${text.replace(/"/gu, '""')}"` : text;
 }
 

--- a/packages/oxiquill/src/components/doc-runtime/useInteractiveCellRun.ts
+++ b/packages/oxiquill/src/components/doc-runtime/useInteractiveCellRun.ts
@@ -1,8 +1,8 @@
 import { useEffect, useMemo, useRef, useState } from 'preact/hooks';
 import { initialValues } from '../../lib/doc-runtime/interactive-cell-model';
 import { runInteractiveCell } from '../../lib/doc-runtime/runtime-client';
+import type { NormalizedCellExecutionResult } from '../../lib/doc-runtime/output-artifacts';
 import type {
-  CellExecutionResult,
   CellManifest,
   InputValues
 } from '../../lib/doc-runtime/types';
@@ -11,7 +11,7 @@ type InputValue = InputValues[string];
 
 export function useInteractiveCellRun(cell: CellManifest, runtimeVersion: string) {
   const [values, setValues] = useState<InputValues>(() => initialValues(cell.inputs));
-  const [result, setResult] = useState<CellExecutionResult>();
+  const [result, setResult] = useState<NormalizedCellExecutionResult>();
   const [error, setError] = useState<string>();
   const [isRunning, setIsRunning] = useState(false);
   const latestRunId = useRef(0);

--- a/packages/oxiquill/src/generator/doc-runtime/rust-codegen/macros.mjs
+++ b/packages/oxiquill/src/generator/doc-runtime/rust-codegen/macros.mjs
@@ -56,7 +56,7 @@ function generateJsonMacro() {
         ($value:expr) => {{
             let artifact = json_artifact(
                 serde_json::to_value(&$value).map_err(|error| error.to_string())?,
-            )?;
+            );
             __outputs.borrow_mut().push(OutputArtifact::Json(artifact));
         }};
     }`;
@@ -65,7 +65,7 @@ function generateJsonMacro() {
 function generateHtmlMacro() {
   return `    macro_rules! emit_html {
         ($html:expr) => {{
-            let artifact = html_artifact(($html).to_string())?;
+            let artifact = html_artifact(($html).to_string());
             __outputs.borrow_mut().push(OutputArtifact::Html(artifact));
         }};
     }`;
@@ -74,7 +74,7 @@ function generateHtmlMacro() {
 function generateImageSvgMacro() {
   return `    macro_rules! emit_image_svg {
         ($svg:expr) => {{
-            let artifact = image_artifact("image/svg+xml", ($svg).to_string(), None)?;
+            let artifact = image_artifact("image/svg+xml", ($svg).to_string(), None);
             __outputs.borrow_mut().push(OutputArtifact::Image(artifact));
         }};
         ($svg:expr, $alt:expr) => {{
@@ -82,7 +82,7 @@ function generateImageSvgMacro() {
                 "image/svg+xml",
                 ($svg).to_string(),
                 Some(($alt).to_string()),
-            )?;
+            );
             __outputs.borrow_mut().push(OutputArtifact::Image(artifact));
         }};
     }`;
@@ -91,7 +91,7 @@ function generateImageSvgMacro() {
 function generateImagePngMacro() {
   return `    macro_rules! emit_image_png {
         ($base64:expr) => {{
-            let artifact = image_artifact("image/png", ($base64).to_string(), None)?;
+            let artifact = image_artifact("image/png", ($base64).to_string(), None);
             __outputs.borrow_mut().push(OutputArtifact::Image(artifact));
         }};
         ($base64:expr, $alt:expr) => {{
@@ -99,7 +99,7 @@ function generateImagePngMacro() {
                 "image/png",
                 ($base64).to_string(),
                 Some(($alt).to_string()),
-            )?;
+            );
             __outputs.borrow_mut().push(OutputArtifact::Image(artifact));
         }};
     }`;

--- a/packages/oxiquill/src/generator/doc-runtime/rust-codegen/output-types.mjs
+++ b/packages/oxiquill/src/generator/doc-runtime/rust-codegen/output-types.mjs
@@ -65,12 +65,8 @@ struct JsonArtifact {
     value: Value,
 }
 
-fn json_artifact(value: Value) -> Result<JsonArtifact, String> {
-    let byte_count = serde_json::to_string(&value)
-        .map_err(|error| error.to_string())?
-        .len();
-    ensure_output_size("JSON output", byte_count, 500_000)?;
-    Ok(JsonArtifact { value })
+fn json_artifact(value: Value) -> JsonArtifact {
+    JsonArtifact { value }
 }
 ` : ''}
 ${capabilities.html ? `#[derive(Debug, Serialize)]
@@ -79,12 +75,11 @@ struct HtmlArtifact {
     sandboxed: bool,
 }
 
-fn html_artifact(html: String) -> Result<HtmlArtifact, String> {
-    ensure_output_size("HTML output", html.len(), 500_000)?;
-    Ok(HtmlArtifact {
+fn html_artifact(html: String) -> HtmlArtifact {
+    HtmlArtifact {
         html,
         sandboxed: true,
-    })
+    }
 }
 ` : ''}
 ${capabilities.image ? `#[derive(Debug, Serialize)]
@@ -99,21 +94,8 @@ fn image_artifact(
     mime: &'static str,
     data: String,
     alt: Option<String>,
-) -> Result<ImageArtifact, String> {
-    ensure_output_size("image output", data.len(), 2_000_000)?;
-    Ok(ImageArtifact { mime, data, alt })
-}
-` : ''}
-${capabilities.json || capabilities.html || capabilities.image ? `fn ensure_output_size(
-    label: &str,
-    byte_count: usize,
-    limit: usize,
-) -> Result<(), String> {
-    if byte_count > limit {
-        Err(format!("{label} is {byte_count} bytes, exceeding the {limit} byte limit"))
-    } else {
-        Ok(())
-    }
+) -> ImageArtifact {
+    ImageArtifact { mime, data, alt }
 }
 ` : ''}
 ${capabilities.table ? generateRustTableTypes() : ''}
@@ -180,8 +162,8 @@ fn table_artifact_from_value(value: Value) -> Result<TableArtifact, String> {
         _ => return Err("emit_table! expects a serializable array".to_owned()),
     };
     let row_count = rows.len();
-    let truncated = row_count > 1_000;
-    let preview: Vec<Value> = rows.into_iter().take(1_000).collect();
+    let truncated = row_count > 10_000;
+    let preview: Vec<Value> = rows.into_iter().take(10_000).collect();
     let columns = infer_table_columns(&preview);
     let table_rows = table_rows_for_columns(preview, &columns);
     Ok(TableArtifact {
@@ -199,8 +181,8 @@ fn table_artifact_with_columns(columns: Value, rows: Value) -> Result<TableArtif
         _ => return Err("emit_table_with_columns! expects rows to serialize as an array".to_owned()),
     };
     let row_count = rows.len();
-    let truncated = row_count > 1_000;
-    let preview: Vec<Value> = rows.into_iter().take(1_000).collect();
+    let truncated = row_count > 10_000;
+    let preview: Vec<Value> = rows.into_iter().take(10_000).collect();
     let table_rows = table_rows_for_columns(preview, &columns);
     Ok(TableArtifact {
         columns,

--- a/packages/oxiquill/src/lib/doc-runtime/output-artifact-validation.ts
+++ b/packages/oxiquill/src/lib/doc-runtime/output-artifact-validation.ts
@@ -1,0 +1,1017 @@
+import type {
+  ArtifactStream,
+  ChartAxisType,
+  ChartSpec,
+  HtmlArtifact,
+  ImageArtifact,
+  JsonArtifact,
+  OutputArtifact,
+  TableArtifact,
+  TableColumn,
+  TableColumnType,
+  TextArtifact
+} from './types';
+
+export const outputArtifactLimits = Object.freeze({
+  artifactsPerRun: 100,
+  bytesPerTextJsonOrHtml: 1024 * 1024,
+  chartDataItems: 100_000,
+  columnsPerTable: 100,
+  decodedBytesPerImage: 10 * 1024 * 1024,
+  rowsPerTable: 10_000,
+  validatedBytesPerRun: 16 * 1024 * 1024
+});
+
+export interface ValidatedJsonArtifact extends JsonArtifact {
+  formattedValue: string;
+}
+
+export interface ValidatedImageArtifact extends ImageArtifact {
+  source: string;
+}
+
+export type ValidatedOutputArtifact =
+  | TextArtifact
+  | ValidatedJsonArtifact
+  | TableArtifact
+  | Extract<OutputArtifact, { kind: 'chart' }>
+  | ValidatedImageArtifact
+  | HtmlArtifact;
+
+export type ValidatedArtifactResult =
+  | {
+      status: 'valid';
+      artifact: ValidatedOutputArtifact;
+      byteLength: number;
+      index: number;
+    }
+  | {
+      status: 'error';
+      message: string;
+      index: number;
+    };
+
+type ValidationSuccess = {
+  artifact: ValidatedOutputArtifact;
+  byteLength: number;
+};
+
+type JsonFormatResult = {
+  formatted: string;
+  safeValue: unknown;
+  truncated: boolean;
+};
+
+type BaseArtifact = {
+  caption?: string;
+  id?: string;
+  title?: string;
+  byteLength: number;
+};
+
+type JsonContainer = unknown[] | Record<string, unknown>;
+type JsonVisitTask = {
+  assign: (value: unknown) => void;
+  depth: number;
+  input: unknown;
+  kind: 'visit';
+  path: string;
+};
+type JsonArrayTask = {
+  depth: number;
+  index: number;
+  input: unknown[];
+  kind: 'array';
+  output: unknown[];
+  path: string;
+};
+type JsonObjectTask = {
+  depth: number;
+  index: number;
+  input: Record<string, unknown>;
+  keys: string[];
+  kind: 'object';
+  output: Record<string, unknown>;
+  path: string;
+};
+type JsonTask = JsonVisitTask | JsonArrayTask | JsonObjectTask;
+
+const artifactStreams = new Set<ArtifactStream>(['stdout', 'stderr', 'display']);
+const chartAxisTypes = new Set<ChartAxisType>(['value', 'category', 'time', 'log']);
+const imageMimes = new Set<ImageArtifact['mime']>(['image/png', 'image/jpeg', 'image/svg+xml']);
+const tableColumnTypes = new Set<TableColumnType>([
+  'string',
+  'number',
+  'integer',
+  'boolean',
+  'date',
+  'datetime',
+  'null',
+  'unknown'
+]);
+const utf8Encoder = new TextEncoder();
+const utf8Decoder = new TextDecoder('utf-8', { fatal: true });
+const maximumJsonNestingDepth = 100;
+
+class ArtifactValidationError extends Error {}
+
+export function validateOutputArtifacts(outputs: readonly unknown[]): readonly ValidatedArtifactResult[] {
+  const results: ValidatedArtifactResult[] = [];
+  let validatedBytes = 0;
+  const artifactCount = Math.min(outputs.length, outputArtifactLimits.artifactsPerRun);
+
+  for (let index = 0; index < artifactCount; index += 1) {
+    try {
+      const validated = validateOutputArtifact(
+        outputs[index],
+        outputArtifactLimits.validatedBytesPerRun - validatedBytes
+      );
+      validatedBytes += validated.byteLength;
+      results.push({ status: 'valid', ...validated, index });
+    } catch (error) {
+      results.push({
+        status: 'error',
+        message: error instanceof Error ? error.message : String(error),
+        index
+      });
+    }
+  }
+
+  if (outputs.length > outputArtifactLimits.artifactsPerRun) {
+    results.push({
+      status: 'error',
+      message: `Artifact limit exceeded: received ${outputs.length}, maximum ${outputArtifactLimits.artifactsPerRun}.`,
+      index: outputArtifactLimits.artifactsPerRun
+    });
+  }
+
+  return results;
+}
+
+function validateOutputArtifact(value: unknown, remainingBytes: number): ValidationSuccess {
+  const record = plainRecord(value, 'Artifact');
+  const kind = requiredString(record, 'kind', 'Artifact');
+
+  switch (kind) {
+    case 'text':
+      return validateTextArtifact(record, remainingBytes);
+    case 'json':
+      return validateJsonArtifact(record, remainingBytes);
+    case 'table':
+      return validateTableArtifact(record, remainingBytes);
+    case 'chart':
+      return validateChartArtifact(record, remainingBytes);
+    case 'image':
+      return validateImageArtifact(record, remainingBytes);
+    case 'html':
+      return validateHtmlArtifact(record, remainingBytes);
+    default:
+      throw new ArtifactValidationError(`Unsupported artifact kind ${quoted(kind)}.`);
+  }
+}
+
+function validateTextArtifact(record: Record<string, unknown>, remainingBytes: number): ValidationSuccess {
+  const base = validateBaseArtifact(record);
+  const stream = requiredString(record, 'stream', 'Text artifact');
+  if (!artifactStreams.has(stream as ArtifactStream)) {
+    throw new ArtifactValidationError(`Text artifact stream ${quoted(stream)} is not supported.`);
+  }
+  const content = requiredString(record, 'content', 'Text artifact');
+  const producerTruncated = optionalBoolean(record, 'truncated', 'Text artifact') ?? false;
+  const contentBudget = contentByteBudget(base.byteLength, remainingBytes);
+  const bounded = truncateUtf8(content, Math.min(outputArtifactLimits.bytesPerTextJsonOrHtml, contentBudget));
+
+  return {
+    artifact: {
+      ...artifactMetadata(base),
+      kind: 'text',
+      stream: stream as ArtifactStream,
+      content: bounded.value,
+      ...(producerTruncated || bounded.truncated ? { truncated: true } : {})
+    },
+    byteLength: base.byteLength + bounded.byteLength
+  };
+}
+
+function validateJsonArtifact(record: Record<string, unknown>, remainingBytes: number): ValidationSuccess {
+  const base = validateBaseArtifact(record);
+  const value = requiredOwnValue(record, 'value', 'JSON artifact');
+  const producerTruncated = optionalBoolean(record, 'truncated', 'JSON artifact') ?? false;
+  const valueBudget = Math.min(
+    outputArtifactLimits.bytesPerTextJsonOrHtml,
+    contentByteBudget(base.byteLength, remainingBytes)
+  );
+  const formatted = safeJsonFormat(value, valueBudget, 'JSON artifact value');
+  const byteLength = utf8ByteLength(formatted.formatted);
+
+  return {
+    artifact: {
+      ...artifactMetadata(base),
+      kind: 'json',
+      value: formatted.safeValue,
+      formattedValue: formatted.formatted,
+      ...(producerTruncated || formatted.truncated ? { truncated: true } : {})
+    },
+    byteLength: base.byteLength + byteLength
+  };
+}
+
+function validateTableArtifact(record: Record<string, unknown>, remainingBytes: number): ValidationSuccess {
+  const base = validateBaseArtifact(record);
+  const producerTruncated = optionalBoolean(record, 'truncated', 'Table artifact') ?? false;
+  const rawColumns = plainArray(requiredOwnValue(record, 'columns', 'Table artifact'), 'Table artifact columns');
+  const rawRows = plainArray(requiredOwnValue(record, 'rows', 'Table artifact'), 'Table artifact rows');
+  const rowCount = optionalNonNegativeInteger(record, 'rowCount', 'Table artifact') ?? rawRows.length;
+  if (rowCount < rawRows.length) {
+    throw new ArtifactValidationError('Table artifact rowCount cannot be smaller than rows.length.');
+  }
+
+  const retainedColumnCount = Math.min(rawColumns.length, outputArtifactLimits.columnsPerTable);
+  const columns = rawColumns.slice(0, retainedColumnCount).map((column, index) => validateTableColumn(column, index));
+  if (new Set(columns.map((column) => column.key)).size !== columns.length) {
+    throw new ArtifactValidationError('Table artifact column keys must be unique.');
+  }
+
+  let byteLength = base.byteLength + columns.reduce(
+    (total, column) => total + utf8ByteLength(column.key) + utf8ByteLength(column.label),
+    0
+  );
+  if (byteLength > remainingBytes) {
+    throw new ArtifactValidationError('Table artifact metadata exceeds the remaining 16 MiB run limit.');
+  }
+
+  const rows: unknown[][] = [];
+  const retainedRowCount = Math.min(rawRows.length, outputArtifactLimits.rowsPerTable);
+  let truncated = producerTruncated || rawColumns.length > retainedColumnCount || rawRows.length > retainedRowCount;
+
+  for (let rowIndex = 0; rowIndex < retainedRowCount; rowIndex += 1) {
+    const rawRow = plainArray(rawRows[rowIndex], `Table artifact row ${rowIndex + 1}`);
+    if (rawRow.length !== rawColumns.length) {
+      throw new ArtifactValidationError(
+        `Table artifact row ${rowIndex + 1} has ${rawRow.length} cells; expected ${rawColumns.length}.`
+      );
+    }
+
+    const row: unknown[] = [];
+    let rowWasTruncated = false;
+    for (let columnIndex = 0; columnIndex < retainedColumnCount; columnIndex += 1) {
+      const cellBudget = Math.max(0, remainingBytes - byteLength);
+      const cell = validateTableCell(rawRow[columnIndex], cellBudget, rowIndex, columnIndex);
+      row.push(cell.value);
+      byteLength += cell.byteLength;
+      rowWasTruncated ||= cell.truncated;
+    }
+    rows.push(row);
+    if (rowWasTruncated || byteLength >= remainingBytes) {
+      truncated = true;
+      break;
+    }
+  }
+
+  if (rows.length < retainedRowCount) truncated = true;
+
+  return {
+    artifact: {
+      ...artifactMetadata(base),
+      kind: 'table',
+      columns,
+      rows,
+      rowCount,
+      ...(truncated ? { truncated: true } : {})
+    },
+    byteLength
+  };
+}
+
+function validateChartArtifact(record: Record<string, unknown>, remainingBytes: number): ValidationSuccess {
+  rejectTruncated(record, 'Chart artifact');
+  const base = validateBaseArtifact(record);
+  const spec = validateChartSpec(requiredOwnValue(record, 'spec', 'Chart artifact'));
+  const byteLength = base.byteLength + payloadByteLength(spec);
+  if (byteLength > remainingBytes) {
+    throw new ArtifactValidationError('Chart artifact exceeds the remaining 16 MiB run limit.');
+  }
+  return {
+    artifact: { ...artifactMetadata(base), kind: 'chart', spec },
+    byteLength
+  };
+}
+
+function validateImageArtifact(record: Record<string, unknown>, remainingBytes: number): ValidationSuccess {
+  rejectTruncated(record, 'Image artifact');
+  const base = validateBaseArtifact(record);
+  const mime = requiredString(record, 'mime', 'Image artifact');
+  if (!imageMimes.has(mime as ImageArtifact['mime'])) {
+    throw new ArtifactValidationError(`Image artifact MIME type ${quoted(mime)} is not supported.`);
+  }
+  const data = requiredString(record, 'data', 'Image artifact');
+  const alt = optionalString(record, 'alt', 'Image artifact');
+  const validated = mime === 'image/svg+xml'
+    ? validateSvgImage(data)
+    : validateBase64Image(data, mime as 'image/png' | 'image/jpeg');
+  if (validated.decodedBytes > outputArtifactLimits.decodedBytesPerImage) {
+    throw new ArtifactValidationError(
+      `Image artifact is ${validated.decodedBytes} decoded bytes; maximum is ${outputArtifactLimits.decodedBytesPerImage}.`
+    );
+  }
+  const byteLength = base.byteLength + validated.decodedBytes + (alt ? utf8ByteLength(alt) : 0);
+  if (byteLength > remainingBytes) {
+    throw new ArtifactValidationError('Image artifact exceeds the remaining 16 MiB run limit.');
+  }
+
+  return {
+    artifact: {
+      ...artifactMetadata(base),
+      kind: 'image',
+      mime: mime as ImageArtifact['mime'],
+      data: validated.data,
+      source: validated.source,
+      ...(alt == null ? {} : { alt })
+    },
+    byteLength
+  };
+}
+
+function validateHtmlArtifact(record: Record<string, unknown>, remainingBytes: number): ValidationSuccess {
+  rejectTruncated(record, 'HTML artifact');
+  const base = validateBaseArtifact(record);
+  const html = requiredString(record, 'html', 'HTML artifact');
+  if (requiredOwnValue(record, 'sandboxed', 'HTML artifact') !== true) {
+    throw new ArtifactValidationError('HTML artifact sandboxed must be true.');
+  }
+  const htmlBytes = utf8ByteLength(html);
+  if (htmlBytes > outputArtifactLimits.bytesPerTextJsonOrHtml) {
+    throw new ArtifactValidationError(
+      `HTML artifact is ${htmlBytes} bytes; maximum is ${outputArtifactLimits.bytesPerTextJsonOrHtml}.`
+    );
+  }
+  const byteLength = base.byteLength + htmlBytes;
+  if (byteLength > remainingBytes) {
+    throw new ArtifactValidationError('HTML artifact exceeds the remaining 16 MiB run limit.');
+  }
+  return {
+    artifact: { ...artifactMetadata(base), kind: 'html', html, sandboxed: true },
+    byteLength
+  };
+}
+
+function validateBaseArtifact(record: Record<string, unknown>): BaseArtifact {
+  const id = optionalString(record, 'id', 'Artifact');
+  const title = optionalString(record, 'title', 'Artifact');
+  const caption = optionalString(record, 'caption', 'Artifact');
+  return {
+    ...(id == null ? {} : { id }),
+    ...(title == null ? {} : { title }),
+    ...(caption == null ? {} : { caption }),
+    byteLength: [id, title, caption]
+      .filter((value): value is string => value != null)
+      .reduce((total, value) => total + utf8ByteLength(value), 0)
+  };
+}
+
+function artifactMetadata(base: BaseArtifact): Pick<OutputArtifact, 'id' | 'title' | 'caption'> {
+  return {
+    ...(base.id == null ? {} : { id: base.id }),
+    ...(base.title == null ? {} : { title: base.title }),
+    ...(base.caption == null ? {} : { caption: base.caption })
+  };
+}
+
+function validateTableColumn(value: unknown, index: number): TableColumn {
+  const record = plainRecord(value, `Table artifact column ${index + 1}`);
+  const type = optionalString(record, 'type', `Table artifact column ${index + 1}`);
+  if (type != null && !tableColumnTypes.has(type as TableColumnType)) {
+    throw new ArtifactValidationError(
+      `Table artifact column ${index + 1} type ${quoted(type)} is not supported.`
+    );
+  }
+  return {
+    key: requiredString(record, 'key', `Table artifact column ${index + 1}`),
+    label: requiredString(record, 'label', `Table artifact column ${index + 1}`),
+    ...(type == null ? {} : { type: type as TableColumnType })
+  };
+}
+
+function validateTableCell(
+  value: unknown,
+  maxBytes: number,
+  rowIndex: number,
+  columnIndex: number
+): { value: unknown; byteLength: number; truncated: boolean } {
+  if (value == null) {
+    return maxBytes >= 1
+      ? { value: value ?? null, byteLength: 1, truncated: false }
+      : { value: '', byteLength: 0, truncated: true };
+  }
+  if (typeof value === 'boolean') {
+    return maxBytes >= 1
+      ? { value, byteLength: 1, truncated: false }
+      : { value: '', byteLength: 0, truncated: true };
+  }
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) {
+      throw new ArtifactValidationError(
+        `Table artifact cell ${rowIndex + 1}:${columnIndex + 1} must contain a finite number.`
+      );
+    }
+    return maxBytes >= 8
+      ? { value, byteLength: 8, truncated: false }
+      : { value: '', byteLength: 0, truncated: true };
+  }
+  if (typeof value === 'string') {
+    const bounded = truncateUtf8(value, maxBytes);
+    return { value: bounded.value, byteLength: bounded.byteLength, truncated: bounded.truncated };
+  }
+  const formatted = safeJsonFormat(
+    value,
+    maxBytes,
+    `Table artifact cell ${rowIndex + 1}:${columnIndex + 1}`
+  );
+  return {
+    value: formatted.formatted,
+    byteLength: utf8ByteLength(formatted.formatted),
+    truncated: formatted.truncated
+  };
+}
+
+function validateChartSpec(value: unknown): ChartSpec {
+  const record = plainRecord(value, 'Chart spec');
+  const kind = requiredString(record, 'kind', 'Chart spec');
+  const base = validateBaseChartSpec(record);
+
+  switch (kind) {
+    case 'line':
+    case 'scatter':
+    case 'area':
+      return { ...base, kind, series: validateXySeries(requiredOwnValue(record, 'series', `${kind} chart`)) };
+    case 'bar': {
+      const categories = stringArray(requiredOwnValue(record, 'categories', 'Bar chart'), 'Bar chart categories');
+      if (categories.length > outputArtifactLimits.chartDataItems) {
+        throw chartLimitError(categories.length);
+      }
+      const rawSeries = plainArray(requiredOwnValue(record, 'series', 'Bar chart'), 'Bar chart series');
+      if (rawSeries.length > outputArtifactLimits.chartDataItems) throw chartLimitError(rawSeries.length);
+      let dataItems = 0;
+      const series = rawSeries.map((seriesValue, seriesIndex) => {
+        const seriesRecord = plainRecord(seriesValue, `Bar chart series ${seriesIndex + 1}`);
+        const values = plainArray(
+          requiredOwnValue(seriesRecord, 'values', `Bar chart series ${seriesIndex + 1}`),
+          `Bar chart series ${seriesIndex + 1} values`
+        );
+        if (dataItems + values.length > outputArtifactLimits.chartDataItems) {
+          throw chartLimitError(dataItems + values.length);
+        }
+        const validatedValues = values.map((item, valueIndex) => {
+          if (item === null) return null;
+          return finiteNumber(item, `Bar chart series ${seriesIndex + 1} value ${valueIndex + 1}`);
+        });
+        if (validatedValues.length !== categories.length) {
+          throw new ArtifactValidationError(
+            `Bar chart series ${seriesIndex + 1} has ${validatedValues.length} values; expected ${categories.length}.`
+          );
+        }
+        dataItems += validatedValues.length;
+        const name = optionalString(seriesRecord, 'name', `Bar chart series ${seriesIndex + 1}`);
+        return { ...(name == null ? {} : { name }), values: validatedValues };
+      });
+      return { ...base, kind, categories, series };
+    }
+    case 'histogram': {
+      const rawBins = plainArray(requiredOwnValue(record, 'bins', 'Histogram chart'), 'Histogram chart bins');
+      if (rawBins.length > outputArtifactLimits.chartDataItems) throw chartLimitError(rawBins.length);
+      const bins = rawBins.map((bin, binIndex) => {
+        const tuple = fixedTuple(bin, 3, `Histogram chart bin ${binIndex + 1}`);
+        return [
+          finiteNumber(tuple[0], `Histogram chart bin ${binIndex + 1} lower bound`),
+          finiteNumber(tuple[1], `Histogram chart bin ${binIndex + 1} upper bound`),
+          finiteNumber(tuple[2], `Histogram chart bin ${binIndex + 1} count`)
+        ] as const;
+      });
+      return { ...base, kind, bins };
+    }
+    case 'heatmap': {
+      const rawData = plainArray(requiredOwnValue(record, 'data', 'Heatmap chart'), 'Heatmap chart data');
+      if (rawData.length > outputArtifactLimits.chartDataItems) throw chartLimitError(rawData.length);
+      const data = rawData.map((cell, cellIndex) => {
+        const tuple = fixedTuple(cell, 3, `Heatmap chart cell ${cellIndex + 1}`);
+        return [
+          chartCoordinate(tuple[0], `Heatmap chart cell ${cellIndex + 1} x coordinate`),
+          chartCoordinate(tuple[1], `Heatmap chart cell ${cellIndex + 1} y coordinate`),
+          finiteNumber(tuple[2], `Heatmap chart cell ${cellIndex + 1} value`)
+        ] as const;
+      });
+      const xCategories = optionalStringArray(record, 'xCategories', 'Heatmap chart');
+      const yCategories = optionalStringArray(record, 'yCategories', 'Heatmap chart');
+      return {
+        ...base,
+        kind,
+        ...(xCategories == null ? {} : { xCategories }),
+        ...(yCategories == null ? {} : { yCategories }),
+        data
+      };
+    }
+    default:
+      throw new ArtifactValidationError(`Chart kind ${quoted(kind)} is not supported.`);
+  }
+}
+
+function validateBaseChartSpec(record: Record<string, unknown>): Omit<ChartSpec, 'kind'> {
+  const title = optionalString(record, 'title', 'Chart spec');
+  const xLabel = optionalString(record, 'xLabel', 'Chart spec');
+  const yLabel = optionalString(record, 'yLabel', 'Chart spec');
+  const xType = optionalString(record, 'xType', 'Chart spec');
+  const yType = optionalString(record, 'yType', 'Chart spec');
+  if (xType != null && !chartAxisTypes.has(xType as ChartAxisType)) {
+    throw new ArtifactValidationError(`Chart xType ${quoted(xType)} is not supported.`);
+  }
+  if (yType != null && !chartAxisTypes.has(yType as ChartAxisType)) {
+    throw new ArtifactValidationError(`Chart yType ${quoted(yType)} is not supported.`);
+  }
+  const legend = optionalBoolean(record, 'legend', 'Chart spec');
+  const tooltip = optionalBoolean(record, 'tooltip', 'Chart spec');
+  const dataZoom = optionalBoolean(record, 'dataZoom', 'Chart spec');
+  return {
+    ...(title == null ? {} : { title }),
+    ...(xLabel == null ? {} : { xLabel }),
+    ...(yLabel == null ? {} : { yLabel }),
+    ...(xType == null ? {} : { xType: xType as ChartAxisType }),
+    ...(yType == null ? {} : { yType: yType as ChartAxisType }),
+    ...(legend == null ? {} : { legend }),
+    ...(tooltip == null ? {} : { tooltip }),
+    ...(dataZoom == null ? {} : { dataZoom })
+  } as Omit<ChartSpec, 'kind'>;
+}
+
+function validateXySeries(value: unknown): Extract<ChartSpec, { kind: 'line' }>['series'] {
+  const rawSeries = plainArray(value, 'XY chart series');
+  if (rawSeries.length > outputArtifactLimits.chartDataItems) throw chartLimitError(rawSeries.length);
+  let dataItems = 0;
+  return rawSeries.map((seriesValue, seriesIndex) => {
+    const record = plainRecord(seriesValue, `XY chart series ${seriesIndex + 1}`);
+    const rawPoints = plainArray(
+      requiredOwnValue(record, 'points', `XY chart series ${seriesIndex + 1}`),
+      `XY chart series ${seriesIndex + 1} points`
+    );
+    dataItems += Math.max(rawPoints.length, 1);
+    if (dataItems > outputArtifactLimits.chartDataItems) throw chartLimitError(dataItems);
+    const points = rawPoints.map((point, pointIndex) => {
+      const tuple = fixedTuple(point, 2, `XY chart series ${seriesIndex + 1} point ${pointIndex + 1}`);
+      return [
+        chartCoordinate(tuple[0], `XY chart series ${seriesIndex + 1} point ${pointIndex + 1} x coordinate`),
+        chartCoordinate(tuple[1], `XY chart series ${seriesIndex + 1} point ${pointIndex + 1} y coordinate`)
+      ] as const;
+    });
+    const name = optionalString(record, 'name', `XY chart series ${seriesIndex + 1}`);
+    return { ...(name == null ? {} : { name }), points };
+  });
+}
+
+function safeJsonFormat(value: unknown, maxBytes: number, context: string): JsonFormatResult {
+  if (maxBytes <= 0) return { formatted: '', safeValue: null, truncated: true };
+
+  let safeValue: unknown;
+  let estimatedBytes = 0;
+  let truncated = false;
+  const active = new WeakMap<object, string>();
+  const tasks: JsonTask[] = [{
+    kind: 'visit',
+    input: value,
+    path: '$',
+    depth: 0,
+    assign: (next) => {
+      safeValue = next;
+    }
+  }];
+
+  while (tasks.length > 0) {
+    const task = tasks.pop()!;
+    if (task.kind === 'array') {
+      if (estimatedBytes >= maxBytes) {
+        task.output.push('[Truncated]');
+        active.delete(task.input);
+        truncated = true;
+        continue;
+      }
+      if (task.index >= task.input.length) {
+        active.delete(task.input);
+        continue;
+      }
+      if (!Object.hasOwn(task.input, task.index)) {
+        throw new ArtifactValidationError(`${context} contains a sparse array at ${task.path}.`);
+      }
+      tasks.push({ ...task, index: task.index + 1 });
+      const descriptor = dataDescriptor(task.input, task.index, `${context} at ${task.path}`);
+      tasks.push({
+        kind: 'visit',
+        input: descriptor.value,
+        path: `${task.path}[${task.index}]`,
+        depth: task.depth + 1,
+        assign: (next) => {
+          task.output[task.index] = next;
+        }
+      });
+      continue;
+    }
+    if (task.kind === 'object') {
+      if (estimatedBytes >= maxBytes) {
+        active.delete(task.input);
+        truncated = true;
+        continue;
+      }
+      if (task.index >= task.keys.length) {
+        active.delete(task.input);
+        continue;
+      }
+      const key = task.keys[task.index]!;
+      const descriptor = dataDescriptor(task.input, key, `${context} at ${task.path}`);
+      estimatedBytes += utf8ByteLength(key) + 4;
+      tasks.push({ ...task, index: task.index + 1 });
+      tasks.push({
+        kind: 'visit',
+        input: descriptor.value,
+        path: `${task.path}.${key}`,
+        depth: task.depth + 1,
+        assign: (next) => {
+          Object.defineProperty(task.output, key, {
+            configurable: true,
+            enumerable: true,
+            value: next,
+            writable: true
+          });
+        }
+      });
+      continue;
+    }
+
+    if (estimatedBytes >= maxBytes) {
+      task.assign('[Truncated]');
+      truncated = true;
+      continue;
+    }
+    if (task.depth > maximumJsonNestingDepth) {
+      task.assign('[Truncated]');
+      truncated = true;
+      continue;
+    }
+
+    const input = task.input;
+    if (input === null) {
+      estimatedBytes += 4;
+      task.assign(null);
+    } else if (typeof input === 'string') {
+      const bounded = truncateUtf8(input, Math.max(0, maxBytes - estimatedBytes));
+      estimatedBytes += bounded.byteLength + 2;
+      truncated ||= bounded.truncated;
+      task.assign(bounded.value);
+    } else if (typeof input === 'number') {
+      if (!Number.isFinite(input)) {
+        throw new ArtifactValidationError(`${context} contains a non-finite number at ${task.path}.`);
+      }
+      estimatedBytes += String(input).length;
+      task.assign(input);
+    } else if (typeof input === 'boolean') {
+      estimatedBytes += input ? 4 : 5;
+      task.assign(input);
+    } else if (typeof input === 'bigint') {
+      const digits = input.toString();
+      estimatedBytes += utf8ByteLength(digits) + 16;
+      task.assign({ $bigint: digits });
+    } else if (typeof input === 'object') {
+      const existingPath = active.get(input);
+      if (existingPath) {
+        const marker = `[Circular -> ${existingPath}]`;
+        estimatedBytes += utf8ByteLength(marker) + 2;
+        task.assign(marker);
+        continue;
+      }
+      if (Array.isArray(input)) {
+        const array = plainArray(input, `${context} at ${task.path}`);
+        const output: unknown[] = [];
+        estimatedBytes += 2;
+        task.assign(output);
+        active.set(array, task.path);
+        tasks.push({ kind: 'array', input: array, output, path: task.path, depth: task.depth, index: 0 });
+      } else {
+        const record = plainRecord(input, `${context} at ${task.path}`);
+        if (Object.getOwnPropertySymbols(record).length > 0) {
+          throw new ArtifactValidationError(`${context} contains symbol keys at ${task.path}.`);
+        }
+        const output = Object.create(null) as Record<string, unknown>;
+        estimatedBytes += 2;
+        task.assign(output);
+        active.set(record, task.path);
+        tasks.push({
+          kind: 'object',
+          input: record,
+          output,
+          keys: Object.keys(record),
+          path: task.path,
+          depth: task.depth,
+          index: 0
+        });
+      }
+    } else {
+      throw new ArtifactValidationError(`${context} contains unsupported ${typeof input} data at ${task.path}.`);
+    }
+  }
+
+  const serialized = JSON.stringify(safeValue, null, 2) ?? 'null';
+  const bounded = truncateUtf8(serialized, maxBytes);
+  return {
+    formatted: bounded.value,
+    safeValue,
+    truncated: truncated || bounded.truncated
+  };
+}
+
+function validateBase64Image(
+  data: string,
+  mime: 'image/png' | 'image/jpeg'
+): { data: string; decodedBytes: number; source: string } {
+  const parsed = parseDataUrl(data);
+  const payload = parsed ? parsed.payload : data;
+  if (parsed && parsed.mime !== mime) {
+    throw new ArtifactValidationError(
+      `Image artifact MIME mismatch: field is ${mime}, data URL is ${parsed.mime}.`
+    );
+  }
+  if (parsed && !parsed.base64) {
+    throw new ArtifactValidationError(`${mime} image data URLs must use base64 encoding.`);
+  }
+  const decodedBytes = validateBase64(payload);
+  const header = decodeBase64Prefix(payload, mime === 'image/png' ? 8 : 3);
+  const signature = mime === 'image/png'
+    ? [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]
+    : [0xff, 0xd8, 0xff];
+  if (!signature.every((byte, index) => header[index] === byte)) {
+    throw new ArtifactValidationError(`Image artifact payload does not match ${mime}.`);
+  }
+  return { data: payload, decodedBytes, source: `data:${mime};base64,${payload}` };
+}
+
+function validateSvgImage(data: string): { data: string; decodedBytes: number; source: string } {
+  const parsed = parseDataUrl(data);
+  if (parsed && parsed.mime !== 'image/svg+xml') {
+    throw new ArtifactValidationError(
+      `Image artifact MIME mismatch: field is image/svg+xml, data URL is ${parsed.mime}.`
+    );
+  }
+  let svg = data;
+  let decodedBytes: number;
+  if (parsed?.base64) {
+    decodedBytes = validateBase64(parsed.payload);
+    if (decodedBytes > outputArtifactLimits.decodedBytesPerImage) {
+      throw new ArtifactValidationError(
+        `Image artifact is ${decodedBytes} decoded bytes; maximum is ${outputArtifactLimits.decodedBytesPerImage}.`
+      );
+    }
+    try {
+      svg = utf8Decoder.decode(
+        Uint8Array.from(atob(parsed.payload), (character) => character.charCodeAt(0))
+      );
+    } catch {
+      throw new ArtifactValidationError('SVG image artifact must contain valid UTF-8 data.');
+    }
+  } else if (parsed) {
+    try {
+      svg = decodeURIComponent(parsed.payload);
+    } catch {
+      throw new ArtifactValidationError('SVG image data URL contains invalid percent encoding.');
+    }
+    decodedBytes = utf8ByteLength(svg);
+  } else {
+    decodedBytes = utf8ByteLength(svg);
+  }
+  if (!hasSvgRoot(svg)) {
+    throw new ArtifactValidationError('SVG image artifact must contain an <svg> root element.');
+  }
+  let source: string;
+  try {
+    source = `data:image/svg+xml;charset=utf-8,${encodeURIComponent(svg)}`;
+  } catch {
+    throw new ArtifactValidationError('SVG image artifact contains invalid Unicode data.');
+  }
+  return { data: svg, decodedBytes, source };
+}
+
+function hasSvgRoot(svg: string): boolean {
+  const rootMatch = /<svg(?:\s|>)/u.exec(svg);
+  if (!rootMatch) return false;
+  const preamble = svg
+    .slice(0, rootMatch.index)
+    .replace(/^\s*<\?xml[\s\S]*?\?>/u, '')
+    .replace(/^\s*<!DOCTYPE\s+svg[\s\S]*?>/u, '')
+    .replace(/(?:^\s*<!--[\s\S]*?-->)+/gu, '');
+  return preamble.trim().length === 0;
+}
+
+function parseDataUrl(data: string): { base64: boolean; mime: string; payload: string } | undefined {
+  if (!data.startsWith('data:')) return undefined;
+  const match = /^data:([^;,]+)(?:;charset=[^;,]+)?(;base64)?,([\s\S]*)$/u.exec(data);
+  if (!match) throw new ArtifactValidationError('Image artifact data URL is malformed.');
+  return { mime: match[1]!, base64: match[2] === ';base64', payload: match[3]! };
+}
+
+function validateBase64(payload: string): number {
+  if (payload.length === 0 || payload.length % 4 !== 0) {
+    throw new ArtifactValidationError('Image artifact contains invalid base64 data.');
+  }
+  const padding = payload.endsWith('==') ? 2 : payload.endsWith('=') ? 1 : 0;
+  const dataLength = payload.length - padding;
+  for (let index = 0; index < dataLength; index += 1) {
+    const code = payload.charCodeAt(index);
+    const isBase64Character =
+      (code >= 0x41 && code <= 0x5a) ||
+      (code >= 0x61 && code <= 0x7a) ||
+      (code >= 0x30 && code <= 0x39) ||
+      code === 0x2b ||
+      code === 0x2f;
+    if (!isBase64Character) {
+      throw new ArtifactValidationError('Image artifact contains invalid base64 data.');
+    }
+  }
+  for (let index = dataLength; index < payload.length; index += 1) {
+    if (payload[index] !== '=') {
+      throw new ArtifactValidationError('Image artifact contains invalid base64 data.');
+    }
+  }
+  return payload.length / 4 * 3 - padding;
+}
+
+function decodeBase64Prefix(payload: string, byteCount: number): readonly number[] {
+  try {
+    return Array.from(atob(payload.slice(0, Math.ceil(byteCount / 3) * 4)), (character) => character.charCodeAt(0));
+  } catch {
+    throw new ArtifactValidationError('Image artifact contains invalid base64 data.');
+  }
+}
+
+function contentByteBudget(metadataBytes: number, remainingBytes: number): number {
+  if (metadataBytes > remainingBytes) {
+    throw new ArtifactValidationError('Artifact metadata exceeds the remaining 16 MiB run limit.');
+  }
+  return remainingBytes - metadataBytes;
+}
+
+function payloadByteLength(value: unknown): number {
+  return utf8ByteLength(JSON.stringify(value));
+}
+
+function truncateUtf8(value: string, maxBytes: number): { byteLength: number; truncated: boolean; value: string } {
+  const byteLength = utf8ByteLength(value);
+  if (byteLength <= maxBytes) return { value, byteLength, truncated: false };
+  if (maxBytes <= 0) return { value: '', byteLength: 0, truncated: true };
+  const marker = '…';
+  const markerBytes = utf8ByteLength(marker);
+  if (maxBytes < markerBytes) return { value: '', byteLength: 0, truncated: true };
+  let low = 0;
+  let high = value.length;
+  while (low < high) {
+    const middle = Math.ceil((low + high) / 2);
+    const candidate = value.slice(0, middle);
+    if (utf8ByteLength(candidate) + markerBytes <= maxBytes) low = middle;
+    else high = middle - 1;
+  }
+  if (low > 0 && /[\uD800-\uDBFF]/u.test(value[low - 1]!)) low -= 1;
+  const bounded = `${value.slice(0, low)}${marker}`;
+  return { value: bounded, byteLength: utf8ByteLength(bounded), truncated: true };
+}
+
+function utf8ByteLength(value: string): number {
+  return utf8Encoder.encode(value).byteLength;
+}
+
+function plainRecord(value: unknown, context: string): Record<string, unknown> {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    throw new ArtifactValidationError(`${context} must be a plain record.`);
+  }
+  const prototype = Object.getPrototypeOf(value);
+  if (prototype !== Object.prototype && prototype !== null) {
+    throw new ArtifactValidationError(`${context} must not have a custom prototype.`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function plainArray(value: unknown, context: string): unknown[] {
+  if (!Array.isArray(value) || Object.getPrototypeOf(value) !== Array.prototype) {
+    throw new ArtifactValidationError(`${context} must be an array.`);
+  }
+  const inspectionLimit = Math.min(value.length, outputArtifactLimits.chartDataItems + 1);
+  for (let index = 0; index < inspectionLimit; index += 1) {
+    const descriptor = Object.getOwnPropertyDescriptor(value, index);
+    if (!descriptor) throw new ArtifactValidationError(`${context} must not be sparse.`);
+    if (!Object.hasOwn(descriptor, 'value')) {
+      throw new ArtifactValidationError(`${context} item ${index + 1} must be an own data property.`);
+    }
+  }
+  return value;
+}
+
+function dataDescriptor(record: object, key: PropertyKey, context: string): PropertyDescriptor & { value: unknown } {
+  const descriptor = Object.getOwnPropertyDescriptor(record, key);
+  if (!descriptor || !Object.hasOwn(descriptor, 'value')) {
+    throw new ArtifactValidationError(`${context} field ${quoted(String(key))} must be an own data property.`);
+  }
+  return descriptor as PropertyDescriptor & { value: unknown };
+}
+
+function requiredOwnValue(record: Record<string, unknown>, key: string, context: string): unknown {
+  return dataDescriptor(record, key, context).value;
+}
+
+function requiredString(record: Record<string, unknown>, key: string, context: string): string {
+  const value = requiredOwnValue(record, key, context);
+  if (typeof value !== 'string') {
+    throw new ArtifactValidationError(`${context} field ${quoted(key)} must be a string.`);
+  }
+  return value;
+}
+
+function optionalString(record: Record<string, unknown>, key: string, context: string): string | undefined {
+  if (!Object.hasOwn(record, key)) return undefined;
+  const value = requiredOwnValue(record, key, context);
+  if (typeof value !== 'string') {
+    throw new ArtifactValidationError(`${context} field ${quoted(key)} must be a string when provided.`);
+  }
+  return value;
+}
+
+function optionalBoolean(record: Record<string, unknown>, key: string, context: string): boolean | undefined {
+  if (!Object.hasOwn(record, key)) return undefined;
+  const value = requiredOwnValue(record, key, context);
+  if (typeof value !== 'boolean') {
+    throw new ArtifactValidationError(`${context} field ${quoted(key)} must be a boolean when provided.`);
+  }
+  return value;
+}
+
+function optionalNonNegativeInteger(
+  record: Record<string, unknown>,
+  key: string,
+  context: string
+): number | undefined {
+  if (!Object.hasOwn(record, key)) return undefined;
+  const value = requiredOwnValue(record, key, context);
+  if (typeof value !== 'number' || !Number.isSafeInteger(value) || value < 0) {
+    throw new ArtifactValidationError(`${context} field ${quoted(key)} must be a non-negative safe integer.`);
+  }
+  return value;
+}
+
+function rejectTruncated(record: Record<string, unknown>, context: string): void {
+  if (Object.hasOwn(record, 'truncated')) {
+    throw new ArtifactValidationError(`${context} does not support the truncated field.`);
+  }
+}
+
+function fixedTuple(value: unknown, length: number, context: string): unknown[] {
+  const tuple = plainArray(value, context);
+  if (tuple.length !== length || tuple.some((_, index) => !Object.hasOwn(tuple, index))) {
+    throw new ArtifactValidationError(`${context} must contain exactly ${length} values.`);
+  }
+  return tuple;
+}
+
+function stringArray(value: unknown, context: string): string[] {
+  const values = plainArray(value, context);
+  if (values.length > outputArtifactLimits.chartDataItems) throw chartLimitError(values.length);
+  return values.map((item, index) => {
+    if (typeof item !== 'string') {
+      throw new ArtifactValidationError(`${context} item ${index + 1} must be a string.`);
+    }
+    return item;
+  });
+}
+
+function optionalStringArray(
+  record: Record<string, unknown>,
+  key: string,
+  context: string
+): string[] | undefined {
+  if (!Object.hasOwn(record, key)) return undefined;
+  const values = stringArray(requiredOwnValue(record, key, context), `${context} ${key}`);
+  if (values.length > outputArtifactLimits.chartDataItems) throw chartLimitError(values.length);
+  return values;
+}
+
+function finiteNumber(value: unknown, context: string): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    throw new ArtifactValidationError(`${context} must be a finite number.`);
+  }
+  return value;
+}
+
+function chartCoordinate(value: unknown, context: string): number | string {
+  if (typeof value === 'string') return value;
+  return finiteNumber(value, context);
+}
+
+function chartLimitError(dataItems: number): ArtifactValidationError {
+  return new ArtifactValidationError(
+    `Chart contains ${dataItems} data items; maximum is ${outputArtifactLimits.chartDataItems}.`
+  );
+}
+
+function quoted(value: string): string {
+  return JSON.stringify(value);
+}

--- a/packages/oxiquill/src/lib/doc-runtime/output-artifacts.ts
+++ b/packages/oxiquill/src/lib/doc-runtime/output-artifacts.ts
@@ -1,28 +1,20 @@
 import type {
   ChartArtifact,
-  ChartSpec,
   CellExecutionResult,
   OutputArtifact,
   PlotSpec,
   RawCellExecutionResult,
-  TableColumn,
   TextArtifact
 } from './types';
+import {
+  validateOutputArtifacts,
+  type ValidatedArtifactResult,
+  type ValidatedOutputArtifact
+} from './output-artifact-validation';
 
-const artifactKinds = new Set(['text', 'json', 'table', 'chart', 'image', 'html']);
-const artifactStreams = new Set(['stdout', 'stderr', 'display']);
-const tableColumnTypes = new Set([
-  'string',
-  'number',
-  'integer',
-  'boolean',
-  'date',
-  'datetime',
-  'null',
-  'unknown'
-]);
-const chartKinds = new Set(['line', 'scatter', 'bar', 'histogram', 'area', 'heatmap']);
-const imageMimes = new Set(['image/png', 'image/jpeg', 'image/svg+xml']);
+export interface NormalizedCellExecutionResult extends CellExecutionResult {
+  outputResults: readonly ValidatedArtifactResult[];
+}
 
 export function legacyResultToOutputs(result: RawCellExecutionResult): readonly OutputArtifact[] {
   return [
@@ -47,44 +39,103 @@ export function outputsToLegacyResult(outputs: readonly OutputArtifact[]): CellE
   };
 }
 
-export function normalizeCellExecutionResult(result: RawCellExecutionResult): CellExecutionResult {
-  const explicitOutputs = Array.isArray(result.outputs)
-    ? result.outputs.filter(isOutputArtifact)
-    : [];
-  const outputs = explicitOutputs.length > 0 ? explicitOutputs : legacyResultToOutputs(result);
+export function normalizeCellExecutionResult(result: RawCellExecutionResult): NormalizedCellExecutionResult {
+  const rawOutputs = ownDataField(result, 'outputs');
+  const outputCandidates = rawOutputs.present
+    ? Array.isArray(rawOutputs.value) ? rawOutputs.value : [rawOutputs.value]
+    : legacyResultToOutputCandidates(result);
+  const outputResults = validateOutputArtifacts(outputCandidates);
+  const outputs = outputResults.flatMap((output) => output.status === 'valid'
+    ? [publicOutputArtifact(output.artifact)]
+    : []);
   const legacy = outputsToLegacyResult(outputs);
+  const rawStdout = ownDataField(result, 'stdout').value;
+  const rawStderr = ownDataField(result, 'stderr').value;
+  const rawValue = ownDataField(result, 'value');
+  const rawPlots = ownDataField(result, 'plots');
 
   return {
-    stdout: typeof result.stdout === 'string' ? result.stdout : legacy.stdout,
-    ...(typeof result.stderr === 'string' ? { stderr: result.stderr } : legacy.stderr ? { stderr: legacy.stderr } : {}),
-    ...(Object.hasOwn(result, 'value') ? { value: result.value } : Object.hasOwn(legacy, 'value') ? { value: legacy.value } : {}),
-    plots: Array.isArray(result.plots) ? result.plots : legacy.plots,
-    outputs
+    stdout: typeof rawStdout === 'string' ? rawStdout : legacy.stdout,
+    ...(typeof rawStderr === 'string' ? { stderr: rawStderr } : legacy.stderr ? { stderr: legacy.stderr } : {}),
+    ...(rawValue.present ? { value: rawValue.value } : Object.hasOwn(legacy, 'value') ? { value: legacy.value } : {}),
+    plots: rawPlots.present && Array.isArray(rawPlots.value)
+      ? validatedLegacyPlots(rawPlots.value)
+      : legacy.plots,
+    outputs,
+    outputResults
   };
 }
 
-export function isOutputArtifact(value: unknown): value is OutputArtifact {
-  if (!isRecord(value) || !artifactKinds.has(value.kind as string) || !hasValidBaseArtifact(value)) {
-    return false;
-  }
+function legacyResultToOutputCandidates(result: RawCellExecutionResult): readonly unknown[] {
+  const stdout = ownDataField(result, 'stdout').value;
+  const stderr = ownDataField(result, 'stderr').value;
+  const value = ownDataField(result, 'value');
+  const plots = ownDataField(result, 'plots').value;
+  return [
+    typeof stdout === 'string' && stdout.length > 0
+      ? [{ kind: 'text', stream: 'stdout', content: stdout }]
+      : [],
+    typeof stderr === 'string' && stderr.length > 0
+      ? [{ kind: 'text', stream: 'stderr', content: stderr }]
+      : [],
+    value.present && value.value != null && value.value !== ''
+      ? [{ kind: 'json', value: value.value }]
+      : [],
+    ...(Array.isArray(plots) ? plots.map((plot) => [legacyPlotCandidate(plot)]) : [])
+  ].flat();
+}
 
-  switch (value.kind) {
-    case 'text':
-      return artifactStreams.has(value.stream as string) && typeof value.content === 'string';
-    case 'json':
-      return Object.hasOwn(value, 'value');
-    case 'table':
-      return isTableArtifact(value);
-    case 'chart':
-      return isChartSpec(value.spec);
-    case 'image':
-      return isImageArtifact(value);
-    case 'html':
-      return typeof value.html === 'string' && value.sandboxed === true;
-    /* v8 ignore next -- artifactKinds rejects unknown artifact kinds before this switch. */
-    default:
-      return false;
+function validatedLegacyPlots(values: readonly unknown[]): readonly PlotSpec[] {
+  return validateOutputArtifacts(values.map(legacyPlotCandidate))
+    .flatMap((result) => result.status === 'valid' ? chartArtifactToLegacyPlot(result.artifact) : []);
+}
+
+function legacyPlotCandidate(value: unknown): unknown {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return value;
+  const record = value as Record<string, unknown>;
+  const kind = ownDataField(record, 'kind').value;
+  const xLabel = ownDataField(record, 'x_label').value;
+  const yLabel = ownDataField(record, 'y_label').value;
+  const points = ownDataField(record, 'points').value;
+  return {
+    kind: 'chart',
+    spec: {
+      kind,
+      xLabel,
+      yLabel,
+      xType: 'value',
+      yType: 'value',
+      tooltip: true,
+      dataZoom: true,
+      series: [{ points }]
+    }
+  };
+}
+
+function ownDataField(
+  record: object,
+  key: PropertyKey
+): { present: boolean; value: unknown } {
+  const descriptor = Object.getOwnPropertyDescriptor(record, key);
+  return descriptor && Object.hasOwn(descriptor, 'value')
+    ? { present: true, value: descriptor.value }
+    : { present: descriptor != null, value: undefined };
+}
+
+function publicOutputArtifact(artifact: ValidatedOutputArtifact): OutputArtifact {
+  if (artifact.kind === 'json') {
+    const { formattedValue: _formattedValue, ...output } = artifact;
+    return output;
   }
+  if (artifact.kind === 'image') {
+    const { source: _source, ...output } = artifact;
+    return output;
+  }
+  return artifact;
+}
+
+export function isOutputArtifact(value: unknown): value is OutputArtifact {
+  return validateOutputArtifacts([value])[0]?.status === 'valid';
 }
 
 function legacyPlotToChartArtifact(plot: PlotSpec): ChartArtifact {
@@ -129,52 +180,4 @@ function joinTextArtifacts(outputs: readonly OutputArtifact[], stream: TextArtif
     .map((output) => output.content)
     .filter((content) => content.length > 0)
     .join('\n');
-}
-
-function hasValidBaseArtifact(value: Record<string, unknown>): boolean {
-  return (
-    optionalString(value.id) &&
-    optionalString(value.title) &&
-    optionalString(value.caption) &&
-    (typeof value.truncated === 'boolean' || value.truncated == null)
-  );
-}
-
-function isTableArtifact(value: Record<string, unknown>): boolean {
-  return (
-    Array.isArray(value.columns) &&
-    value.columns.every(isTableColumn) &&
-    Array.isArray(value.rows) &&
-    value.rows.every(Array.isArray) &&
-    (typeof value.rowCount === 'number' || value.rowCount == null)
-  );
-}
-
-function isTableColumn(value: unknown): value is TableColumn {
-  return (
-    isRecord(value) &&
-    typeof value.key === 'string' &&
-    typeof value.label === 'string' &&
-    (value.type == null || tableColumnTypes.has(value.type as string))
-  );
-}
-
-function isChartSpec(value: unknown): value is ChartSpec {
-  return isRecord(value) && chartKinds.has(value.kind as string);
-}
-
-function isImageArtifact(value: Record<string, unknown>): boolean {
-  return (
-    imageMimes.has(value.mime as string) &&
-    typeof value.data === 'string' &&
-    optionalString(value.alt)
-  );
-}
-
-function optionalString(value: unknown): boolean {
-  return value == null || typeof value === 'string';
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null;
 }

--- a/packages/oxiquill/src/lib/doc-runtime/python-cell-result.ts
+++ b/packages/oxiquill/src/lib/doc-runtime/python-cell-result.ts
@@ -1,10 +1,6 @@
-import {
-  isOutputArtifact,
-  legacyResultToOutputs
-} from './output-artifacts';
+import { legacyResultToOutputs } from './output-artifacts';
 import type {
-  CellExecutionResult,
-  OutputArtifact
+  RawCellExecutionResult
 } from './types';
 
 export function createPythonCellResult({
@@ -14,12 +10,12 @@ export function createPythonCellResult({
   stdout,
   value
 }: {
-  displayOutputs: readonly OutputArtifact[];
-  plots: CellExecutionResult['plots'];
+  displayOutputs: readonly unknown[];
+  plots: NonNullable<RawCellExecutionResult['plots']>;
   stderr: string;
   stdout: string;
   value: unknown;
-}): CellExecutionResult {
+}): RawCellExecutionResult {
   const streamOutputs = legacyResultToOutputs({ stdout, stderr, plots: [] });
   const valueOutputs = legacyResultToOutputs({ value, plots: [] });
 
@@ -32,6 +28,6 @@ export function createPythonCellResult({
   };
 }
 
-export function toOutputArtifacts(value: unknown): readonly OutputArtifact[] {
-  return Array.isArray(value) ? value.filter(isOutputArtifact) : [];
+export function toOutputArtifacts(value: unknown): readonly unknown[] {
+  return Array.isArray(value) ? value : [];
 }

--- a/packages/oxiquill/src/lib/doc-runtime/python-display-support.ts
+++ b/packages/oxiquill/src/lib/doc-runtime/python-display-support.ts
@@ -6,7 +6,7 @@ import json
 
 __oxiquill_outputs = []
 __oxiquill_displayed_figures = set()
-__oxiquill_table_limit = 1000
+__oxiquill_table_limit = 10000
 __oxiquill_table_column_limit = 100
 
 def __oxiquill_meta(artifact, title=None, caption=None):

--- a/packages/oxiquill/src/lib/doc-runtime/runtime-client.ts
+++ b/packages/oxiquill/src/lib/doc-runtime/runtime-client.ts
@@ -1,16 +1,18 @@
 import type {
-  CellExecutionResult,
   CellLanguage,
   CellManifest,
   InputValues,
   RuntimeWorkerRequest,
   RuntimeWorkerResponse
 } from './types';
-import { normalizeCellExecutionResult } from './output-artifacts';
+import {
+  normalizeCellExecutionResult,
+  type NormalizedCellExecutionResult
+} from './output-artifacts';
 
 type PendingRequest = {
   reject: (reason: Error) => void;
-  resolve: (value: CellExecutionResult) => void;
+  resolve: (value: NormalizedCellExecutionResult) => void;
   timeout: ReturnType<typeof setTimeout>;
   worker: Worker;
 };
@@ -25,7 +27,7 @@ export function runInteractiveCell(
   cell: CellManifest,
   inputs: InputValues,
   runtimeVersion?: string
-): Promise<CellExecutionResult> {
+): Promise<NormalizedCellExecutionResult> {
   /* v8 ignore next -- the factory is unit-tested; this delegates to browser Worker adapters. */
   return defaultRuntimeClient.runInteractiveCell(cell, inputs, runtimeVersion);
 }
@@ -46,7 +48,11 @@ export function createInteractiveCellRunner(dependencies: RuntimeClientDependenc
   const workers = new Map<CellLanguage, Worker>();
   const pending = new Map<number, PendingRequest>();
 
-  function runCell(cell: CellManifest, inputs: InputValues, runtimeVersion?: string): Promise<CellExecutionResult> {
+  function runCell(
+    cell: CellManifest,
+    inputs: InputValues,
+    runtimeVersion?: string
+  ): Promise<NormalizedCellExecutionResult> {
     const requestId = nextRequestId++;
     const worker = getWorker(cell.language);
     const request = createWorkerRequest(requestId, cell, inputs, runtimeVersion);

--- a/packages/oxiquill/src/lib/doc-runtime/types.ts
+++ b/packages/oxiquill/src/lib/doc-runtime/types.ts
@@ -189,7 +189,7 @@ export interface RawCellExecutionResult {
   stderr?: string;
   value?: unknown;
   plots?: readonly PlotSpec[];
-  outputs?: readonly OutputArtifact[];
+  outputs?: readonly unknown[];
 }
 
 export interface CellExecutionResult {

--- a/packages/oxiquill/src/styles/custom.css
+++ b/packages/oxiquill/src/styles/custom.css
@@ -230,10 +230,18 @@
 }
 
 .doc-table-output__caption,
-.doc-table-output__footer p {
+.doc-table-output__footer p,
+.doc-table-output__status,
+.doc-output-artifact__notice {
   margin: 0;
   color: var(--sl-color-gray-2);
   font-size: 0.85rem;
+}
+
+.doc-output-artifact {
+  display: grid;
+  gap: 0.35rem;
+  min-width: 0;
 }
 
 .doc-table-output__scroller {

--- a/tests/unit/components.test.tsx
+++ b/tests/unit/components.test.tsx
@@ -2,6 +2,10 @@ import { act, cleanup, fireEvent, render, screen, waitFor, within } from '@testi
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { CellExecutionResult, CellManifest, InputSpec } from '../../packages/oxiquill/src/lib/doc-runtime/types';
 import {
+  validateOutputArtifacts,
+  type ValidatedImageArtifact
+} from '../../packages/oxiquill/src/lib/doc-runtime/output-artifact-validation';
+import {
   chart,
   echartsInit,
   echartsUse,
@@ -57,6 +61,17 @@ const {
   tableToCsv,
   visibleRows
 } = await import('../../packages/oxiquill/src/components/doc-runtime/TableOutput');
+
+const pngBase64 = 'iVBORw0KGgo=';
+const jpegBase64 = '/9j/';
+
+function validatedImage(value: unknown): ValidatedImageArtifact {
+  const result = validateOutputArtifacts([value])[0];
+  if (result?.status !== 'valid' || result.artifact.kind !== 'image') {
+    throw new Error('Expected a valid image artifact fixture.');
+  }
+  return result.artifact;
+}
 
 class TestResizeObserver {
   static instances: TestResizeObserver[] = [];
@@ -305,13 +320,25 @@ describe('InteractiveCell', () => {
     await waitFor(() => expect(pending).toHaveLength(2));
 
     await act(async () => {
-      pending[1].resolve({ stdout: 'newer result', stderr: '', value: null, plots: [], outputs: [] });
+      pending[1].resolve({
+        stdout: 'newer result',
+        stderr: '',
+        value: null,
+        plots: [],
+        outputs: [{ kind: 'text', stream: 'stdout', content: 'newer result' }]
+      });
       await pending[1].promise;
     });
     await waitFor(() => expect(screen.getByTestId('run-output')).toHaveTextContent('newer result'));
 
     await act(async () => {
-      pending[0].resolve({ stdout: 'older result', stderr: '', value: null, plots: [], outputs: [] });
+      pending[0].resolve({
+        stdout: 'older result',
+        stderr: '',
+        value: null,
+        plots: [],
+        outputs: [{ kind: 'text', stream: 'stdout', content: 'older result' }]
+      });
       await pending[0].promise;
     });
 
@@ -337,7 +364,13 @@ describe('InteractiveCell', () => {
     await waitFor(() => expect(pending).toHaveLength(2));
 
     await act(async () => {
-      pending[1].resolve({ stdout: 'newer result', stderr: '', value: null, plots: [], outputs: [] });
+      pending[1].resolve({
+        stdout: 'newer result',
+        stderr: '',
+        value: null,
+        plots: [],
+        outputs: [{ kind: 'text', stream: 'stdout', content: 'newer result' }]
+      });
       await pending[1].promise;
     });
     await waitFor(() => expect(screen.getByTestId('run-output')).toHaveTextContent('newer result'));
@@ -644,17 +677,17 @@ describe('OutputRenderer', () => {
   it('renders sandboxed HTML, images, tables, and reports unsupported artifacts', () => {
     render(
       <OutputRenderer
-        outputs={[
+        outputs={validateOutputArtifacts([
           { id: 'html-preview', kind: 'html', html: '<strong>safe</strong>', sandboxed: true, title: 'HTML preview' },
           { kind: 'html', html: '<em>default</em>', sandboxed: true },
-          { kind: 'image', mime: 'image/png', data: 'abc', alt: 'plot image' },
+          { kind: 'image', mime: 'image/png', data: pngBase64, alt: 'plot image' },
           {
             kind: 'table',
             columns: [{ key: 'name', label: 'Name', type: 'string' }],
             rows: [['Ada']]
           },
           { kind: 'unknown' }
-        ]}
+        ])}
       />
     );
 
@@ -663,21 +696,21 @@ describe('OutputRenderer', () => {
     expect(htmlOutputs[0]).toHaveAttribute('srcdoc', '<strong>safe</strong>');
     expect(htmlOutputs[0]).toHaveAttribute('title', 'HTML preview');
     expect(htmlOutputs[1]).toHaveAttribute('title', 'HTML output');
-    expect(screen.getByTestId('image-output')).toHaveAttribute('src', 'data:image/png;base64,abc');
+    expect(screen.getByTestId('image-output')).toHaveAttribute('src', `data:image/png;base64,${pngBase64}`);
     expect(screen.getByTestId('image-output')).toHaveAttribute('alt', 'plot image');
     expect(screen.getByTestId('table-output')).toBeVisible();
     expect(screen.getAllByTestId('artifact-error')).toHaveLength(1);
-    expect(screen.getByText('Unsupported output artifact.')).toBeVisible();
+    expect(screen.getByText(/Unsupported artifact kind/)).toBeVisible();
   });
 
   it('renders image fallback text and captions', () => {
     render(
       <OutputRenderer
-        outputs={[
-          { kind: 'image', mime: 'image/png', data: 'abc', title: 'Figure one', caption: 'caption' },
-          { kind: 'image', mime: 'image/png', data: 'def', caption: 'caption only' },
-          { kind: 'image', mime: 'image/png', data: 'ghi' }
-        ]}
+        outputs={validateOutputArtifacts([
+          { kind: 'image', mime: 'image/png', data: pngBase64, title: 'Figure one', caption: 'caption' },
+          { kind: 'image', mime: 'image/png', data: pngBase64, caption: 'caption only' },
+          { kind: 'image', mime: 'image/png', data: pngBase64 }
+        ])}
       />
     );
 
@@ -690,21 +723,55 @@ describe('OutputRenderer', () => {
   });
 
   it('builds data URLs for raw SVG and base64 image artifacts', () => {
-    expect(imageArtifactSource({
+    expect(imageArtifactSource(validatedImage({
       kind: 'image',
       mime: 'image/svg+xml',
       data: '<svg><text>plot</text></svg>'
-    })).toBe('data:image/svg+xml;charset=utf-8,%3Csvg%3E%3Ctext%3Eplot%3C%2Ftext%3E%3C%2Fsvg%3E');
-    expect(imageArtifactSource({
+    }))).toBe('data:image/svg+xml;charset=utf-8,%3Csvg%3E%3Ctext%3Eplot%3C%2Ftext%3E%3C%2Fsvg%3E');
+    expect(imageArtifactSource(validatedImage({
       kind: 'image',
       mime: 'image/jpeg',
-      data: 'abc'
-    })).toBe('data:image/jpeg;base64,abc');
-    expect(imageArtifactSource({
+      data: jpegBase64
+    }))).toBe(`data:image/jpeg;base64,${jpegBase64}`);
+    expect(imageArtifactSource(validatedImage({
       kind: 'image',
       mime: 'image/png',
-      data: 'data:image/png;base64,existing'
-    })).toBe('data:image/png;base64,existing');
+      data: `data:image/png;base64,${pngBase64}`
+    }))).toBe(`data:image/png;base64,${pngBase64}`);
+  });
+
+  it('isolates renderer failures and resets the boundary for replacement output', async () => {
+    mocks.chart.setOption.mockImplementationOnce(() => {
+      throw new Error('chart renderer failed');
+    });
+    const { rerender } = render(
+      <OutputRenderer outputs={validateOutputArtifacts([
+        { kind: 'text', stream: 'stdout', content: 'before' },
+        { kind: 'chart', spec: { kind: 'line', series: [] } },
+        { kind: 'text', stream: 'stdout', content: 'after' }
+      ])} />
+    );
+
+    await waitFor(() => expect(screen.getByText(/chart renderer failed/)).toBeVisible());
+    expect(screen.getByText('before')).toBeVisible();
+    expect(screen.getByText('after')).toBeVisible();
+
+    rerender(<OutputRenderer outputs={validateOutputArtifacts([
+      { kind: 'text', stream: 'stdout', content: 'replacement' }
+    ])} />);
+    await waitFor(() => expect(screen.getByText('replacement')).toBeVisible());
+    expect(screen.queryByText(/chart renderer failed/)).not.toBeInTheDocument();
+  });
+
+  it('shows truncation without hiding the validated artifact', () => {
+    render(<OutputRenderer outputs={validateOutputArtifacts([{
+      kind: 'text',
+      stream: 'stdout',
+      content: 'x'.repeat(1024 * 1024 + 1)
+    }])} />);
+
+    expect(screen.getByTestId('run-output')).toBeVisible();
+    expect(screen.getByTestId('artifact-truncated')).toHaveTextContent('Output truncated.');
   });
 });
 
@@ -761,7 +828,43 @@ describe('TableOutput', () => {
 
     fireEvent.click(screen.getByTestId('table-copy-csv'));
     await waitFor(() => expect(writeText).toHaveBeenCalledWith(expect.stringContaining('Score,Label,Enabled')));
+    expect(screen.getByTestId('table-copy-status')).toHaveTextContent('Copied visible rows as CSV.');
     expect(rows[0]).toEqual([12, 'row 1', true]);
+  });
+
+  it('surfaces clipboard and CSV conversion failures', async () => {
+    const writeText = vi.fn().mockRejectedValue(new Error('permission denied'));
+    Object.defineProperty(globalThis.navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText }
+    });
+    const { rerender } = render(
+      <TableOutput table={{
+        kind: 'table',
+        columns: [{ key: 'value', label: 'Value' }],
+        rows: [['safe']]
+      }} />
+    );
+
+    fireEvent.click(screen.getByTestId('table-copy-csv'));
+    await waitFor(() => expect(screen.getByRole('alert')).toHaveTextContent('permission denied'));
+
+    rerender(<TableOutput table={{
+      kind: 'table',
+      columns: [{ key: 'value', label: 'Value' }],
+      rows: [[1, 2]]
+    }} />);
+    fireEvent.click(screen.getByTestId('table-copy-csv'));
+    await waitFor(() => expect(screen.getByRole('alert')).toHaveTextContent('Row 1 has 2 cells; expected 1.'));
+
+    Object.defineProperty(globalThis.navigator, 'clipboard', { configurable: true, value: undefined });
+    rerender(<TableOutput table={{
+      kind: 'table',
+      columns: [{ key: 'value', label: 'Value' }],
+      rows: [['safe again']]
+    }} />);
+    fireEvent.click(screen.getByTestId('table-copy-csv'));
+    expect(screen.getByRole('alert')).toHaveTextContent('Clipboard access is unavailable.');
   });
 
   it('renders empty tables with a stable row range', () => {
@@ -793,7 +896,7 @@ describe('TableOutput', () => {
     expect(formatTableCell(Number.POSITIVE_INFINITY)).toBe('Infinity');
     expect(formatTableCell(null)).toBe('null');
     expect(formatTableCell(undefined)).toBe('missing');
-    expect(formatTableCell({ nested: true })).toBe('{"nested":true}');
+    expect(() => formatTableCell({ nested: true })).toThrow('Unsupported validated table cell type');
   });
 
   it('copies visible table data as escaped CSV', () => {
@@ -806,9 +909,16 @@ describe('TableOutput', () => {
         [
           ['comma,value', 'quote "value"'],
           ['line\nbreak', null],
-          [true, { nested: true }]
+          [true, '{"nested":true}']
         ]
       )
-    ).toBe('A,B\n"comma,value","quote ""value"""\n"line\nbreak",\ntrue,"{""nested"":true}"');
+    ).toEqual({
+      ok: true,
+      csv: 'A,B\n"comma,value","quote ""value"""\n"line\nbreak",\ntrue,"{""nested"":true}"'
+    });
+    expect(tableToCsv([{ key: 'a', label: 'A' }], [[1, 2]])).toEqual({
+      ok: false,
+      error: 'Row 1 has 2 cells; expected 1.'
+    });
   });
 });

--- a/tests/unit/doc-runtime-core.test.mjs
+++ b/tests/unit/doc-runtime-core.test.mjs
@@ -476,7 +476,8 @@ describe('doc runtime core', () => {
     expect(generateRustLib([preludeCell])).toContain('Json(JsonArtifact)');
     expect(generateRustLib([preludeCell])).toContain('Html(HtmlArtifact)');
     expect(generateRustLib([preludeCell])).toContain('Image(ImageArtifact)');
-    expect(generateRustLib([preludeCell])).toContain('fn ensure_output_size');
+    expect(generateRustLib([preludeCell])).not.toContain('fn ensure_output_size');
+    expect(generateRustLib([tableCell])).toContain('row_count > 10_000');
     expect(generateRustLib([preludeCell])).toContain('fn json_artifact');
     expect(generateRustLib([preludeCell])).toContain('fn html_artifact');
     expect(generateRustLib([preludeCell])).toContain('fn image_artifact');

--- a/tests/unit/output-artifact-validation.test.ts
+++ b/tests/unit/output-artifact-validation.test.ts
@@ -1,0 +1,429 @@
+import { Buffer } from 'node:buffer';
+import { describe, expect, it } from 'vitest';
+import {
+  outputArtifactLimits,
+  validateOutputArtifacts,
+  type ValidatedOutputArtifact
+} from '../../packages/oxiquill/src/lib/doc-runtime/output-artifact-validation';
+
+const pngBase64 = 'iVBORw0KGgo=';
+const jpegBase64 = '/9j/';
+
+function validArtifact(value: unknown): ValidatedOutputArtifact {
+  const result = validateOutputArtifacts([value])[0];
+  expect(result?.status).toBe('valid');
+  if (!result || result.status !== 'valid') throw new Error('Expected a valid artifact.');
+  return result.artifact;
+}
+
+function validationError(value: unknown): string {
+  const result = validateOutputArtifacts([value])[0];
+  expect(result?.status).toBe('error');
+  if (!result || result.status !== 'error') throw new Error('Expected an artifact validation error.');
+  return result.message;
+}
+
+describe('output artifact validation', () => {
+  it('validates every public artifact kind and copies supported metadata', () => {
+    expect(validArtifact({
+      id: 'text-one',
+      title: 'Title',
+      caption: 'Caption',
+      kind: 'text',
+      stream: 'display',
+      content: 'hello'
+    })).toMatchObject({ kind: 'text', id: 'text-one', content: 'hello' });
+
+    expect(validArtifact({ kind: 'json', value: { ok: true } })).toMatchObject({
+      kind: 'json',
+      formattedValue: '{\n  "ok": true\n}'
+    });
+    expect(validArtifact({
+      kind: 'table',
+      columns: [{ key: 'value', label: 'Value', type: 'integer' }],
+      rows: [[1]],
+      rowCount: 1
+    })).toMatchObject({ kind: 'table', rows: [[1]], rowCount: 1 });
+    expect(validArtifact({ kind: 'chart', spec: { kind: 'line', series: [] } })).toMatchObject({
+      kind: 'chart',
+      spec: { kind: 'line', series: [] }
+    });
+    expect(validArtifact({ kind: 'image', mime: 'image/png', data: pngBase64, alt: 'plot' })).toMatchObject({
+      kind: 'image',
+      source: `data:image/png;base64,${pngBase64}`
+    });
+    expect(validArtifact({ kind: 'html', html: '<strong>safe</strong>', sandboxed: true })).toMatchObject({
+      kind: 'html',
+      sandboxed: true
+    });
+  });
+
+  it('rejects malformed artifact records, metadata, discriminators, and accessors', () => {
+    expect(validationError(null)).toContain('plain record');
+    expect(validationError(Object.assign(Object.create({ unsafe: true }), { kind: 'json', value: null })))
+      .toContain('custom prototype');
+    expect(validationError({ kind: 'missing' })).toContain('Unsupported artifact kind');
+    expect(validationError({ kind: 'text', stream: 'debug', content: 'x' })).toContain('stream');
+    expect(validationError({ kind: 'text', stream: 'stdout', content: 1 })).toContain('content');
+    expect(validationError({ kind: 'json' })).toContain('own data property');
+    expect(validationError({ kind: 'html', html: '', sandboxed: false })).toContain('sandboxed');
+    expect(validationError({ kind: 'chart', truncated: false, spec: { kind: 'line', series: [] } }))
+      .toContain('does not support');
+
+    const accessor = { kind: 'text', stream: 'stdout' } as Record<string, unknown>;
+    Object.defineProperty(accessor, 'content', { enumerable: true, get: () => 'unsafe' });
+    expect(validationError(accessor)).toContain('own data property');
+    expect(validationError({ kind: 'text', stream: 'stdout', content: 'x', title: 1 }))
+      .toContain('when provided');
+  });
+
+  it('accepts exact text and HTML limits, truncates text, and rejects oversized HTML', () => {
+    const exact = 'x'.repeat(outputArtifactLimits.bytesPerTextJsonOrHtml);
+    const text = validArtifact({ kind: 'text', stream: 'stdout', content: exact });
+    expect(text).toMatchObject({ kind: 'text', content: exact });
+    expect(text).not.toHaveProperty('truncated');
+
+    const oversizedText = validArtifact({ kind: 'text', stream: 'stdout', content: `${exact}x` });
+    expect(oversizedText).toMatchObject({ kind: 'text', truncated: true });
+    if (oversizedText.kind === 'text') {
+      expect(new TextEncoder().encode(oversizedText.content).byteLength)
+        .toBeLessThanOrEqual(outputArtifactLimits.bytesPerTextJsonOrHtml);
+      expect(oversizedText.content.endsWith('…')).toBe(true);
+    }
+
+    expect(validArtifact({ kind: 'html', html: exact, sandboxed: true })).toMatchObject({ kind: 'html' });
+    expect(validationError({ kind: 'html', html: `${exact}x`, sandboxed: true })).toContain('maximum');
+  });
+
+  it('formats cyclic JSON and BigInt explicitly without invoking unsafe JSON operations', () => {
+    const value: Record<string, unknown> = { integer: 123n };
+    value.self = value;
+    const artifact = validArtifact({ kind: 'json', value });
+    expect(artifact).toMatchObject({ kind: 'json' });
+    if (artifact.kind === 'json') {
+      expect(artifact.formattedValue).toContain('"$bigint": "123"');
+      expect(artifact.formattedValue).toContain('[Circular -> $]');
+    }
+
+    expect(validationError({ kind: 'json', value: Number.NaN })).toContain('non-finite');
+    expect(validationError({ kind: 'json', value: Symbol('unsafe') })).toContain('unsupported symbol');
+    expect(validationError({ kind: 'json', value: Object.assign(Object.create({}), { key: 'value' }) }))
+      .toContain('custom prototype');
+
+    const sparse = new Array(2);
+    sparse[0] = 'present';
+    expect(validationError({ kind: 'json', value: sparse })).toContain('sparse');
+
+    const symbolKey = { visible: true } as Record<PropertyKey, unknown>;
+    symbolKey[Symbol('hidden')] = true;
+    expect(validationError({ kind: 'json', value: symbolKey })).toContain('symbol keys');
+  });
+
+  it('bounds deeply nested and oversized JSON while preserving a scoped result', () => {
+    const root: Record<string, unknown> = {};
+    let current = root;
+    for (let index = 0; index < 2_000; index += 1) {
+      const next: Record<string, unknown> = {};
+      current.next = next;
+      current = next;
+    }
+    current.payload = 'x'.repeat(outputArtifactLimits.bytesPerTextJsonOrHtml);
+
+    const artifact = validArtifact({ kind: 'json', value: root });
+    expect(artifact).toMatchObject({ kind: 'json', truncated: true });
+    if (artifact.kind === 'json') {
+      expect(new TextEncoder().encode(artifact.formattedValue).byteLength)
+        .toBeLessThanOrEqual(outputArtifactLimits.bytesPerTextJsonOrHtml);
+    }
+  });
+
+  it('accepts the exact serialized JSON limit and truncates one byte over it', () => {
+    const exactValue = 'x'.repeat(outputArtifactLimits.bytesPerTextJsonOrHtml - 2);
+    const exact = validArtifact({ kind: 'json', value: exactValue });
+    expect(exact).not.toHaveProperty('truncated');
+
+    const oversized = validArtifact({ kind: 'json', value: `${exactValue}x` });
+    expect(oversized).toMatchObject({ kind: 'json', truncated: true });
+  });
+
+  it('validates table shape, safe cells, row counts, and column metadata', () => {
+    const cyclic: Record<string, unknown> = { big: 9n };
+    cyclic.self = cyclic;
+    const artifact = validArtifact({
+      kind: 'table',
+      columns: [
+        { key: 'object', label: 'Object', type: 'unknown' },
+        { key: 'missing', label: 'Missing' }
+      ],
+      rows: [[cyclic, undefined]],
+      rowCount: 4,
+      truncated: true
+    });
+    expect(artifact).toMatchObject({ kind: 'table', rowCount: 4, truncated: true });
+    if (artifact.kind === 'table') {
+      expect(artifact.rows[0]?.[0]).toContain('"$bigint": "9"');
+      expect(artifact.rows[0]?.[1]).toBeNull();
+    }
+
+    expect(validationError({
+      kind: 'table',
+      columns: [{ key: 'x', label: 'X' }],
+      rows: [[]]
+    })).toContain('expected 1');
+    expect(validationError({
+      kind: 'table',
+      columns: [{ key: 'x', label: 'X' }, { key: 'x', label: 'Duplicate' }],
+      rows: [[1, 2]]
+    })).toContain('unique');
+    expect(validationError({
+      kind: 'table',
+      columns: [{ key: 'x', label: 'X', type: 'wide' }],
+      rows: [[1]]
+    })).toContain('not supported');
+    expect(validationError({
+      kind: 'table',
+      columns: [{ key: 'x', label: 'X' }],
+      rows: [[1]],
+      rowCount: 0
+    })).toContain('smaller');
+    expect(validationError({
+      kind: 'table',
+      columns: [{ key: 'x', label: 'X' }],
+      rows: [[Number.POSITIVE_INFINITY]]
+    })).toContain('finite');
+  });
+
+  it('truncates tables at the row and column boundaries', () => {
+    const exactRows = validArtifact({
+      kind: 'table',
+      columns: [{ key: 'x', label: 'X' }],
+      rows: Array.from({ length: outputArtifactLimits.rowsPerTable }, (_, index) => [index])
+    });
+    expect(exactRows).not.toHaveProperty('truncated');
+
+    const rowLimited = validArtifact({
+      kind: 'table',
+      columns: [{ key: 'x', label: 'X' }],
+      rows: Array.from({ length: outputArtifactLimits.rowsPerTable + 1 }, (_, index) => [index])
+    });
+    expect(rowLimited).toMatchObject({ kind: 'table', truncated: true });
+    if (rowLimited.kind === 'table') expect(rowLimited.rows).toHaveLength(outputArtifactLimits.rowsPerTable);
+
+    const columns = Array.from(
+      { length: outputArtifactLimits.columnsPerTable + 1 },
+      (_, index) => ({ key: String(index), label: String(index) })
+    );
+    const columnLimited = validArtifact({
+      kind: 'table',
+      columns,
+      rows: [columns.map((_, index) => index)]
+    });
+    expect(columnLimited).toMatchObject({ kind: 'table', truncated: true });
+    if (columnLimited.kind === 'table') {
+      expect(columnLimited.columns).toHaveLength(outputArtifactLimits.columnsPerTable);
+      expect(columnLimited.rows[0]).toHaveLength(outputArtifactLimits.columnsPerTable);
+    }
+  });
+
+  it.each([
+    { kind: 'line', series: [{ name: 'line', points: [[0, 1]] }] },
+    { kind: 'scatter', series: [{ points: [['x', 1]] }] },
+    { kind: 'area', series: [{ points: [[0, 'y']] }] },
+    { kind: 'bar', categories: ['a'], series: [{ name: 'bar', values: [1] }] },
+    { kind: 'histogram', bins: [[0, 1, 2]] },
+    { kind: 'heatmap', xCategories: ['x'], yCategories: ['y'], data: [['x', 'y', 3]] }
+  ])('validates the $kind chart variant', (spec) => {
+    expect(validArtifact({
+      kind: 'chart',
+      spec: {
+        title: 'Chart',
+        xLabel: 'x',
+        yLabel: 'y',
+        xType: 'value',
+        yType: 'log',
+        legend: true,
+        tooltip: false,
+        dataZoom: true,
+        ...spec
+      }
+    })).toMatchObject({ kind: 'chart', spec: { kind: spec.kind } });
+  });
+
+  it('rejects malformed and excessive chart data', () => {
+    expect(validationError({ kind: 'chart', spec: { kind: 'pie' } })).toContain('not supported');
+    expect(validationError({
+      kind: 'chart',
+      spec: { kind: 'line', xType: 'ordinal', series: [] }
+    })).toContain('xType');
+    expect(validationError({
+      kind: 'chart',
+      spec: { kind: 'line', series: [{ points: [[0]] }] }
+    })).toContain('exactly 2');
+    expect(validationError({
+      kind: 'chart',
+      spec: { kind: 'scatter', series: [{ points: [[0, Number.NaN]] }] }
+    })).toContain('finite');
+    expect(validationError({
+      kind: 'chart',
+      spec: { kind: 'bar', categories: ['a', 'b'], series: [{ values: [1] }] }
+    })).toContain('expected 2');
+    expect(validationError({
+      kind: 'chart',
+      spec: { kind: 'histogram', bins: [[0, 1, Number.POSITIVE_INFINITY]] }
+    })).toContain('finite');
+    expect(validationError({
+      kind: 'chart',
+      spec: { kind: 'heatmap', data: [[0, 0, 'hot']] }
+    })).toContain('finite');
+    expect(validationError({
+      kind: 'chart',
+      spec: { kind: 'area', series: [{ points: 'not-an-array' }] }
+    })).toContain('array');
+
+    const points = Array.from(
+      { length: outputArtifactLimits.chartDataItems + 1 },
+      (_, index) => [index, index] as const
+    );
+    expect(validationError({
+      kind: 'chart',
+      spec: { kind: 'line', series: [{ points }] }
+    })).toContain('maximum');
+  });
+
+  it.each(['line', 'scatter', 'area'] as const)(
+    'accepts the exact %s chart point limit and rejects one point over it',
+    (kind) => {
+      const points = Array.from(
+        { length: outputArtifactLimits.chartDataItems },
+        (_, index) => [index, index] as const
+      );
+      expect(validArtifact({ kind: 'chart', spec: { kind, series: [{ points }] } }))
+        .toMatchObject({ kind: 'chart' });
+      expect(validationError({
+        kind: 'chart',
+        spec: { kind, series: [{ points: [...points, [0, 0]] }] }
+      })).toContain('maximum');
+    }
+  );
+
+  it.each([
+    {
+      kind: 'bar',
+      exact: () => ({
+        kind: 'bar',
+        categories: Array.from({ length: outputArtifactLimits.chartDataItems }, () => 'x'),
+        series: [{ values: Array.from({ length: outputArtifactLimits.chartDataItems }, () => 1) }]
+      }),
+      excessive: () => ({
+        kind: 'bar',
+        categories: Array.from({ length: outputArtifactLimits.chartDataItems + 1 }, () => 'x'),
+        series: []
+      })
+    },
+    {
+      kind: 'histogram',
+      exact: () => ({
+        kind: 'histogram',
+        bins: Array.from({ length: outputArtifactLimits.chartDataItems }, () => [0, 1, 1])
+      }),
+      excessive: () => ({
+        kind: 'histogram',
+        bins: Array.from({ length: outputArtifactLimits.chartDataItems + 1 }, () => [0, 1, 1])
+      })
+    },
+    {
+      kind: 'heatmap',
+      exact: () => ({
+        kind: 'heatmap',
+        data: Array.from({ length: outputArtifactLimits.chartDataItems }, () => [0, 0, 1])
+      }),
+      excessive: () => ({
+        kind: 'heatmap',
+        data: Array.from({ length: outputArtifactLimits.chartDataItems + 1 }, () => [0, 0, 1])
+      })
+    }
+  ])('accepts the exact $kind data limit and rejects one item over it', ({ exact, excessive }) => {
+    expect(validArtifact({ kind: 'chart', spec: exact() })).toMatchObject({ kind: 'chart' });
+    expect(validationError({ kind: 'chart', spec: excessive() })).toContain('maximum');
+  });
+
+  it('validates image encodings, MIME declarations, signatures, and SVG payloads', () => {
+    expect(validArtifact({ kind: 'image', mime: 'image/jpeg', data: jpegBase64 })).toMatchObject({
+      kind: 'image',
+      source: `data:image/jpeg;base64,${jpegBase64}`
+    });
+    expect(validArtifact({
+      kind: 'image',
+      mime: 'image/svg+xml',
+      data: 'data:image/svg+xml,%3Csvg%3E%3C%2Fsvg%3E'
+    })).toMatchObject({ kind: 'image', data: '<svg></svg>' });
+    expect(validArtifact({
+      kind: 'image',
+      mime: 'image/svg+xml',
+      data: '<?xml version="1.0"?><!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"><svg></svg>'
+    })).toMatchObject({ kind: 'image' });
+    expect(validationError({ kind: 'image', mime: 'image/gif', data: '' })).toContain('not supported');
+    expect(validationError({ kind: 'image', mime: 'image/png', data: 'abc' })).toContain('base64');
+    expect(validationError({ kind: 'image', mime: 'image/png', data: jpegBase64 })).toContain('does not match');
+    expect(validationError({
+      kind: 'image',
+      mime: 'image/png',
+      data: `data:image/jpeg;base64,${jpegBase64}`
+    })).toContain('MIME mismatch');
+    expect(validationError({ kind: 'image', mime: 'image/svg+xml', data: '<div></div>' })).toContain('<svg>');
+    expect(validationError({
+      kind: 'image',
+      mime: 'image/svg+xml',
+      data: 'data:image/svg+xml,%not-encoded'
+    })).toContain('percent encoding');
+    expect(validationError({
+      kind: 'image',
+      mime: 'image/png',
+      data: 'data:image/png,plain'
+    })).toContain('base64 encoding');
+    expect(validationError({
+      kind: 'image',
+      mime: 'image/svg+xml',
+      data: `data:image/svg+xml;base64,${Buffer.from([0xff]).toString('base64')}`
+    })).toContain('valid UTF-8');
+  });
+
+  it('accepts the exact decoded image limit and rejects one byte over it', () => {
+    const exact = Buffer.alloc(outputArtifactLimits.decodedBytesPerImage);
+    Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]).copy(exact);
+    expect(validArtifact({ kind: 'image', mime: 'image/png', data: exact.toString('base64') }))
+      .toMatchObject({ kind: 'image' });
+
+    const oversized = Buffer.alloc(outputArtifactLimits.decodedBytesPerImage + 1);
+    Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]).copy(oversized);
+    expect(validationError({ kind: 'image', mime: 'image/png', data: oversized.toString('base64') }))
+      .toContain('maximum');
+  });
+
+  it('enforces per-run artifact and validated-byte limits without hiding valid siblings', () => {
+    const artifactLimit = validateOutputArtifacts(
+      Array.from(
+        { length: outputArtifactLimits.artifactsPerRun + 1 },
+        () => ({ kind: 'text', stream: 'stdout', content: 'x' })
+      )
+    );
+    expect(artifactLimit).toHaveLength(outputArtifactLimits.artifactsPerRun + 1);
+    expect(artifactLimit.at(-1)).toMatchObject({ status: 'error', index: outputArtifactLimits.artifactsPerRun });
+
+    const oneMiB = 'x'.repeat(outputArtifactLimits.bytesPerTextJsonOrHtml);
+    const runLimited = validateOutputArtifacts([
+      ...Array.from({ length: 16 }, () => ({ kind: 'text', stream: 'stdout', content: oneMiB })),
+      { kind: 'chart', spec: { kind: 'line', series: [] } },
+      { kind: 'text', stream: 'stdout', content: 'later' }
+    ]);
+    expect(runLimited[16]).toMatchObject({ status: 'error' });
+    expect(runLimited[17]).toMatchObject({ status: 'valid', artifact: { kind: 'text', truncated: true } });
+
+    const siblings = validateOutputArtifacts([
+      { kind: 'chart', spec: { kind: 'line', series: [{ points: [[0, Number.NaN]] }] } },
+      { kind: 'text', stream: 'stdout', content: 'still usable' }
+    ]);
+    expect(siblings[0]).toMatchObject({ status: 'error' });
+    expect(siblings[1]).toMatchObject({ status: 'valid', artifact: { content: 'still usable' } });
+  });
+});

--- a/tests/unit/output-artifacts.test.ts
+++ b/tests/unit/output-artifacts.test.ts
@@ -2,9 +2,15 @@ import { describe, expect, it } from 'vitest';
 import {
   isOutputArtifact,
   legacyResultToOutputs,
+  type NormalizedCellExecutionResult,
   normalizeCellExecutionResult,
   outputsToLegacyResult
 } from '../../packages/oxiquill/src/lib/doc-runtime/output-artifacts';
+
+function publicResult(result: NormalizedCellExecutionResult) {
+  const { outputResults: _outputResults, ...publicFields } = result;
+  return publicFields;
+}
 
 describe('output artifact normalization', () => {
   it('converts legacy cell fields to ordered output artifacts', () => {
@@ -83,16 +89,16 @@ describe('output artifact normalization', () => {
   });
 
   it('normalizes legacy-only and outputs-only worker results', () => {
-    expect(normalizeCellExecutionResult({ stdout: 'old', plots: [] })).toEqual({
+    expect(publicResult(normalizeCellExecutionResult({ stdout: 'old', plots: [] }))).toEqual({
       stdout: 'old',
       plots: [],
       outputs: [{ kind: 'text', stream: 'stdout', content: 'old' }]
     });
 
     expect(
-      normalizeCellExecutionResult({
+      publicResult(normalizeCellExecutionResult({
         outputs: [{ kind: 'json', value: ['new'] }]
-      })
+      }))
     ).toEqual({
       stdout: '',
       value: ['new'],
@@ -101,9 +107,9 @@ describe('output artifact normalization', () => {
     });
 
     expect(
-      normalizeCellExecutionResult({
+      publicResult(normalizeCellExecutionResult({
         outputs: [{ kind: 'text', stream: 'stderr', content: 'from outputs' }]
-      })
+      }))
     ).toEqual({
       stdout: '',
       stderr: 'from outputs',
@@ -112,10 +118,10 @@ describe('output artifact normalization', () => {
     });
 
     expect(
-      normalizeCellExecutionResult({
+      publicResult(normalizeCellExecutionResult({
         stderr: 'explicit',
         outputs: [{ kind: 'text', stream: 'stderr', content: 'from outputs' }]
-      })
+      }))
     ).toEqual({
       stdout: '',
       stderr: 'explicit',
@@ -126,18 +132,36 @@ describe('output artifact normalization', () => {
 
   it('keeps explicit legacy aliases when outputs are already present', () => {
     expect(
-      normalizeCellExecutionResult({
+      publicResult(normalizeCellExecutionResult({
         stdout: 'alias',
         value: null,
         plots: [{ kind: 'line', x_label: 'old-x', y_label: 'old-y', points: [[0, 0]] }],
         outputs: [{ kind: 'json', value: { from: 'outputs' } }]
-      })
+      }))
     ).toEqual({
       stdout: 'alias',
       value: null,
       plots: [{ kind: 'line', x_label: 'old-x', y_label: 'old-y', points: [[0, 0]] }],
       outputs: [{ kind: 'json', value: { from: 'outputs' } }]
     });
+  });
+
+  it('keeps validation failures scoped and never exposes invalid artifacts as normalized outputs', () => {
+    const result = normalizeCellExecutionResult({
+      stdout: 'must not replace explicit outputs',
+      outputs: [
+        { kind: 'chart', spec: { kind: 'line', series: [{ points: [[0, Number.NaN]] }] } },
+        { kind: 'text', stream: 'display', content: 'still usable' }
+      ]
+    });
+
+    expect(result.outputs).toEqual([
+      { kind: 'text', stream: 'display', content: 'still usable' }
+    ]);
+    expect(result.outputResults).toMatchObject([
+      { status: 'error', index: 0 },
+      { status: 'valid', index: 1, artifact: { content: 'still usable' } }
+    ]);
   });
 
   it('validates supported artifact shapes', () => {

--- a/tests/unit/python-worker.test.ts
+++ b/tests/unit/python-worker.test.ts
@@ -114,6 +114,7 @@ describe('python rich display support', () => {
   });
 
   it('converts pandas dataframes and series to table artifacts', () => {
+    expect(pythonDisplaySupportCode).toContain('__oxiquill_table_limit = 10000');
     expect(pythonDisplaySupportCode).toContain('def __oxiquill_is_pandas_dataframe');
     expect(pythonDisplaySupportCode).toContain('def __oxiquill_is_pandas_series');
     expect(pythonDisplaySupportCode).toContain('def __oxiquill_pandas_dataframe_artifact');
@@ -161,10 +162,10 @@ describe('python rich display support', () => {
     });
   });
 
-  it('filters Python display values to valid output artifacts', () => {
+  it('preserves Python display values for validation at the runtime boundary', () => {
     const artifact = { kind: 'text' as const, stream: 'display' as const, content: 'ok' };
 
-    expect(toOutputArtifacts([artifact, { kind: 'unknown' }, null])).toEqual([artifact]);
+    expect(toOutputArtifacts([artifact, { kind: 'unknown' }, null])).toEqual([artifact, { kind: 'unknown' }, null]);
     expect(toOutputArtifacts({ kind: 'text', stream: 'display', content: 'ok' })).toEqual([]);
   });
 });

--- a/tests/unit/runtime-client.test.ts
+++ b/tests/unit/runtime-client.test.ts
@@ -5,6 +5,7 @@ import {
   runtimeHaskellFingerprintHash,
   runInteractiveCell
 } from '../../packages/oxiquill/src/lib/doc-runtime/runtime-client';
+import { normalizeCellExecutionResult } from '../../packages/oxiquill/src/lib/doc-runtime/output-artifacts';
 import type {
   CellExecutionResult,
   CellLanguage,
@@ -51,6 +52,7 @@ const result: CellExecutionResult = {
   plots: [],
   outputs: [{ kind: 'text', stream: 'stdout', content: 'ok' }]
 };
+const normalizedResult = normalizeCellExecutionResult(result);
 
 type DefaultFakeWorker = FakeWorker & {
   options: WorkerOptions;
@@ -114,9 +116,9 @@ describe('runtime client', () => {
     defaultWorkers[1].emitMessage({ requestId: 2, ok: true, result });
     defaultWorkers[2].emitMessage({ requestId: 3, ok: true, result });
 
-    await expect(rust).resolves.toEqual(result);
-    await expect(python).resolves.toEqual(result);
-    await expect(haskell).resolves.toEqual(result);
+    await expect(rust).resolves.toEqual(normalizedResult);
+    await expect(python).resolves.toEqual(normalizedResult);
+    await expect(haskell).resolves.toEqual(normalizedResult);
 
     resetInteractiveRuntime('rust');
     expect(defaultWorkers[0].terminated).toBe(true);
@@ -145,7 +147,7 @@ describe('runtime client', () => {
     workers[0].emitMessage({ requestId: 999, ok: true, result });
     workers[0].emitMessage({ requestId: 1, ok: true, result });
 
-    await expect(promise).resolves.toEqual(result);
+    await expect(promise).resolves.toEqual(normalizedResult);
   });
 
   it('normalizes legacy worker responses before resolving', async () => {
@@ -200,8 +202,8 @@ describe('runtime client', () => {
     workers[0].emitMessage({ requestId: 1, ok: true, result });
     workers[0].emitMessage({ requestId: 2, ok: true, result });
 
-    await expect(first).resolves.toEqual(result);
-    await expect(second).resolves.toEqual(result);
+    await expect(first).resolves.toEqual(normalizedResult);
+    await expect(second).resolves.toEqual(normalizedResult);
   });
 
   it('sends Haskell input arguments in manifest order', async () => {
@@ -233,8 +235,8 @@ describe('runtime client', () => {
     workers[0].emitMessage({ requestId: 1, ok: true, result });
     workers[0].emitMessage({ requestId: 2, ok: true, result });
 
-    await expect(first).resolves.toEqual(result);
-    await expect(second).resolves.toEqual(result);
+    await expect(first).resolves.toEqual(normalizedResult);
+    await expect(second).resolves.toEqual(normalizedResult);
   });
 
   it('extracts the Haskell fingerprint hash from generated runtime versions', () => {
@@ -292,6 +294,6 @@ describe('runtime client', () => {
 
     await expect(rust).rejects.toThrow('worker failed');
     workers[1].emitMessage({ requestId: 2, ok: true, result });
-    await expect(python).resolves.toEqual(result);
+    await expect(python).resolves.toEqual(normalizedResult);
   });
 });


### PR DESCRIPTION
## Summary

- validate and normalize every rich output artifact before rendering
- enforce per-artifact and per-run limits with safe truncation or scoped rejection
- isolate renderer failures and report table CSV clipboard outcomes
- align Python and Rust producer limits and document the public guarantees

## Validation

- pnpm test
- pnpm check
- pnpm lint:rust

Closes #54