### PR TITLE
Complete runtime and release readiness

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,19 @@
 version: 2
 
 updates:
+  - package-ecosystem: github-actions
+    directory: /
+    target-branch: main
+    schedule:
+      interval: weekly
+      day: monday
+      time: '09:00'
+      timezone: Etc/UTC
+    groups:
+      github-actions:
+        patterns:
+          - '*'
+
   - package-ecosystem: npm
     directory: /
     target-branch: main

--- a/.github/scripts/install-ghc-wasm.sh
+++ b/.github/scripts/install-ghc-wasm.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+: "${GHC_WASM_ARCHIVE_SHA256:?GHC_WASM_ARCHIVE_SHA256 must be set}"
+: "${GHC_WASM_FLAVOUR:?GHC_WASM_FLAVOUR must be set}"
+: "${GHC_WASM_REVISION:?GHC_WASM_REVISION must be set}"
+
+if [[ ! "$GHC_WASM_REVISION" =~ ^[0-9a-f]{40}$ ]]; then
+  echo "GHC_WASM_REVISION must be a full lowercase commit SHA" >&2
+  exit 1
+fi
+
+if [[ ! "$GHC_WASM_ARCHIVE_SHA256" =~ ^[0-9a-f]{64}$ ]]; then
+  echo "GHC_WASM_ARCHIVE_SHA256 must be a lowercase SHA-256 digest" >&2
+  exit 1
+fi
+
+prefix="$HOME/.ghc-wasm"
+compiler="$prefix/wasm32-wasi-ghc/bin/wasm32-wasi-ghc"
+
+if [[ ! -x "$compiler" ]]; then
+  if [[ "${RUNNER_OS:-}" == "Linux" ]]; then
+    sudo apt-get update
+    sudo apt-get install -y jq unzip zstd
+  elif [[ "${RUNNER_OS:-}" == "macOS" ]]; then
+    brew list jq >/dev/null 2>&1 || brew install jq
+    brew list zstd >/dev/null 2>&1 || brew install zstd
+  else
+    echo "Unsupported runner OS for ghc-wasm: ${RUNNER_OS:-unknown}" >&2
+    exit 1
+  fi
+
+  temporary_directory="$(mktemp -d)"
+  trap 'rm -rf "$temporary_directory"' EXIT
+  archive="$temporary_directory/ghc-wasm-meta.tar.gz"
+  source_directory="$temporary_directory/source"
+  mkdir "$source_directory"
+
+  curl --fail --location --proto '=https' --retry 5 --show-error --silent --tlsv1.2 \
+    "https://gitlab.haskell.org/haskell-wasm/ghc-wasm-meta/-/archive/$GHC_WASM_REVISION/ghc-wasm-meta-$GHC_WASM_REVISION.tar.gz" \
+    --output "$archive"
+
+  if command -v sha256sum >/dev/null 2>&1; then
+    actual_sha256="$(sha256sum "$archive" | awk '{print $1}')"
+  else
+    actual_sha256="$(shasum -a 256 "$archive" | awk '{print $1}')"
+  fi
+
+  if [[ "$actual_sha256" != "$GHC_WASM_ARCHIVE_SHA256" ]]; then
+    echo "ghc-wasm archive SHA-256 mismatch" >&2
+    echo "Expected: $GHC_WASM_ARCHIVE_SHA256" >&2
+    echo "Actual:   $actual_sha256" >&2
+    exit 1
+  fi
+
+  tar xzf "$archive" -C "$source_directory" --strip-components=1
+  (
+    cd "$source_directory"
+    FLAVOUR="$GHC_WASM_FLAVOUR" PREFIX="$prefix" ./setup.sh
+  )
+fi
+
+if [[ -n "${GITHUB_ENV:-}" ]]; then
+  echo "OXIQUILL_HASKELL_GHC=$compiler" >> "$GITHUB_ENV"
+fi
+"$compiler" --version

--- a/.github/scripts/release-archive.mjs
+++ b/.github/scripts/release-archive.mjs
@@ -1,0 +1,173 @@
+import { spawnSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { appendFile, mkdir, readFile, readdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+export const CHECKSUM_FILE = 'SHA256SUMS';
+export const MANIFEST_FILE = 'release-manifest.json';
+
+const packageRoot = fileURLToPath(new URL('../../packages/oxiquill', import.meta.url));
+
+export async function createReleaseArchive(destination, { outputFile = process.env.GITHUB_OUTPUT } = {}) {
+  await mkdir(destination, { recursive: true });
+  const existing = await readdir(destination);
+  if (existing.length > 0) {
+    throw new Error(`Release artifact directory must be empty: ${destination}`);
+  }
+
+  const packageJson = JSON.parse(await readFile(path.join(packageRoot, 'package.json'), 'utf8'));
+  const result = spawnSync('npm', ['pack', '--json', '--silent', '--pack-destination', destination], {
+    cwd: packageRoot,
+    encoding: 'utf8'
+  });
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    throw new Error(result.stderr || result.stdout || 'npm pack failed.');
+  }
+
+  const records = JSON.parse(result.stdout);
+  if (!Array.isArray(records) || records.length !== 1) {
+    throw new Error('npm pack must produce exactly one archive record.');
+  }
+
+  const [pack] = records;
+  assertPackManifest(pack, { name: packageJson.name, version: packageJson.version });
+  const archivePath = path.join(destination, pack.filename);
+  const archive = await readFile(archivePath);
+  const archiveSha256 = digest('sha256', archive, 'hex');
+  assertArchiveDigests(pack, archive);
+
+  const manifest = { archiveSha256, pack, schemaVersion: 1 };
+  await writeFile(path.join(destination, MANIFEST_FILE), `${JSON.stringify(manifest, null, 2)}\n`);
+  await writeFile(path.join(destination, CHECKSUM_FILE), `${archiveSha256}  ${pack.filename}\n`);
+  await assertArtifactFileSet(destination, pack.filename);
+
+  if (outputFile) {
+    await appendFile(
+      outputFile,
+      `archive_filename=${pack.filename}\nrelease_version=${pack.version}\nartifact_name=oxiquill-${pack.version}\n`
+    );
+  }
+
+  return { archivePath, manifest };
+}
+
+export async function verifyReleaseArchive(
+  destination,
+  expectedVersion,
+  { environment = process.env, outputFile = process.env.GITHUB_OUTPUT, requireOidc = false } = {}
+) {
+  if (requireOidc) assertPublishEnvironment(environment);
+
+  const manifest = JSON.parse(await readFile(path.join(destination, MANIFEST_FILE), 'utf8'));
+  if (manifest.schemaVersion !== 1 || typeof manifest.archiveSha256 !== 'string') {
+    throw new Error('Release manifest has an unsupported schema.');
+  }
+  assertPackManifest(manifest.pack, { name: 'oxiquill', version: expectedVersion });
+  await assertArtifactFileSet(destination, manifest.pack.filename);
+
+  const checksum = await readFile(path.join(destination, CHECKSUM_FILE), 'utf8');
+  const expectedChecksum = `${manifest.archiveSha256}  ${manifest.pack.filename}\n`;
+  if (checksum !== expectedChecksum) {
+    throw new Error('SHA256SUMS does not match the release manifest.');
+  }
+
+  const archivePath = path.join(destination, manifest.pack.filename);
+  const archive = await readFile(archivePath);
+  const actualSha256 = digest('sha256', archive, 'hex');
+  if (actualSha256 !== manifest.archiveSha256) {
+    throw new Error('Release archive SHA-256 mismatch.');
+  }
+  assertArchiveDigests(manifest.pack, archive);
+
+  if (outputFile) await appendFile(outputFile, `archive_path=${archivePath}\n`);
+  return { archivePath, manifest };
+}
+
+export function assertPublishEnvironment(environment) {
+  for (const name of ['ACTIONS_ID_TOKEN_REQUEST_URL', 'ACTIONS_ID_TOKEN_REQUEST_TOKEN']) {
+    if (!environment[name]) throw new Error(`OIDC environment is incomplete: ${name} is missing.`);
+  }
+  for (const name of ['NPM_TOKEN', 'NODE_AUTH_TOKEN']) {
+    if (environment[name]) throw new Error(`Long-lived npm credential is forbidden: ${name}.`);
+  }
+}
+
+export function assertPackManifest(pack, expected) {
+  if (!pack || typeof pack !== 'object') throw new Error('npm pack manifest is missing.');
+  if (pack.name !== expected.name || pack.version !== expected.version) {
+    throw new Error(`npm pack identity mismatch: expected ${expected.name}@${expected.version}.`);
+  }
+  const expectedFilename = `${expected.name}-${expected.version}.tgz`;
+  if (pack.filename !== expectedFilename) {
+    throw new Error(`Unexpected release archive filename: ${pack.filename}.`);
+  }
+  if (!Array.isArray(pack.files) || pack.files.length === 0 || pack.entryCount !== pack.files.length) {
+    throw new Error('npm pack manifest must contain every archive entry.');
+  }
+
+  const paths = new Set();
+  for (const file of pack.files) {
+    if (
+      !file ||
+      typeof file.path !== 'string' ||
+      path.posix.isAbsolute(file.path) ||
+      path.posix.normalize(file.path) !== file.path ||
+      file.path.startsWith('../') ||
+      !Number.isInteger(file.size) ||
+      file.size < 0 ||
+      !Number.isInteger(file.mode)
+    ) {
+      throw new Error('npm pack manifest contains an invalid file entry.');
+    }
+    if (paths.has(file.path)) throw new Error(`npm pack manifest contains duplicate path ${file.path}.`);
+    paths.add(file.path);
+  }
+}
+
+function assertArchiveDigests(pack, archive) {
+  const integrity = `sha512-${digest('sha512', archive, 'base64')}`;
+  if (pack.integrity !== integrity) throw new Error('Release archive npm integrity mismatch.');
+  if (pack.shasum !== digest('sha1', archive, 'hex')) {
+    throw new Error('Release archive npm shasum mismatch.');
+  }
+}
+
+async function assertArtifactFileSet(destination, archiveFilename) {
+  const actual = (await readdir(destination)).sort();
+  const expected = [CHECKSUM_FILE, MANIFEST_FILE, archiveFilename].sort();
+  if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+    throw new Error(`Release artifact contains unexpected files: ${actual.join(', ')}.`);
+  }
+}
+
+function digest(algorithm, value, encoding) {
+  return createHash(algorithm).update(value).digest(encoding);
+}
+
+async function main() {
+  const [command, destination, expectedVersion, ...flags] = process.argv.slice(2);
+  if (command === 'create' && destination && !expectedVersion) {
+    const { archivePath } = await createReleaseArchive(destination);
+    console.log(`Created ${archivePath}.`);
+    return;
+  }
+  if (command === 'verify' && destination && expectedVersion) {
+    const requireOidc = flags.includes('--require-oidc');
+    const { archivePath } = await verifyReleaseArchive(destination, expectedVersion, { requireOidc });
+    console.log(`Verified ${archivePath}.`);
+    return;
+  }
+  throw new Error('Usage: release-archive.mjs create <directory> | verify <directory> <version> [--require-oidc]');
+}
+
+const isMainModule = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+if (isMainModule) {
+  try {
+    await main();
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : error);
+    process.exitCode = 1;
+  }
+}

--- a/.github/scripts/verify-release.mjs
+++ b/.github/scripts/verify-release.mjs
@@ -1,0 +1,168 @@
+import { execFileSync, spawnSync } from 'node:child_process';
+import { appendFile, readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+export const BLOCKER_LABEL = 'release-blocker';
+export const RELEASE_MILESTONE = 'npm release readiness';
+
+const stableReleaseTag = /^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/u;
+
+export function assertReleaseIdentity({ packageVersion, releasePrerelease, rootVersion, tag }) {
+  const match = stableReleaseTag.exec(tag);
+  if (!match) {
+    throw new Error(`Release tag ${tag} must match vMAJOR.MINOR.PATCH.`);
+  }
+
+  if (releasePrerelease) {
+    throw new Error('Prerelease GitHub Releases cannot publish the stable package.');
+  }
+
+  const tagVersion = match.slice(1).join('.');
+  if (rootVersion !== tagVersion) {
+    throw new Error(`Release tag ${tag} does not match root package version ${rootVersion}.`);
+  }
+  if (packageVersion !== tagVersion) {
+    throw new Error(`Release tag ${tag} does not match oxiquill package version ${packageVersion}.`);
+  }
+}
+
+export function assertTagOnMain({ headCommit, isAncestor, tag, tagCommit }) {
+  if (headCommit !== tagCommit) {
+    throw new Error(`Checked out commit ${headCommit} does not match ${tag} commit ${tagCommit}.`);
+  }
+  if (!isAncestor) {
+    throw new Error(`Release tag ${tag} is not contained in origin/main.`);
+  }
+}
+
+export function assertNoOpenReleaseBlockers(blockers) {
+  if (blockers.length === 0) return;
+
+  const details = blockers.map((issue) => `#${issue.number} ${issue.title}`).join('\n');
+  throw new Error(`Open ${BLOCKER_LABEL} issues remain in ${RELEASE_MILESTONE}:\n${details}`);
+}
+
+export async function fetchOpenReleaseBlockers({ fetchImplementation = fetch, repository, token }) {
+  if (!/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/u.test(repository)) {
+    throw new Error(`Invalid GitHub repository identifier: ${repository}`);
+  }
+
+  const apiRoot = `https://api.github.com/repos/${repository}`;
+  const milestones = await fetchAllPages(`${apiRoot}/milestones?state=all&per_page=100`, {
+    fetchImplementation,
+    token
+  });
+  const milestone = milestones.find(({ title }) => title === RELEASE_MILESTONE);
+  if (!milestone) {
+    throw new Error(`GitHub milestone not found: ${RELEASE_MILESTONE}`);
+  }
+
+  const label = encodeURIComponent(BLOCKER_LABEL);
+  const issues = await fetchAllPages(
+    `${apiRoot}/issues?milestone=${milestone.number}&state=open&labels=${label}&per_page=100`,
+    { fetchImplementation, token }
+  );
+  return issues
+    .filter((issue) => !issue.pull_request)
+    .map(({ html_url: url, number, title }) => ({ number, title, url }));
+}
+
+export async function verifyRelease({ environment = process.env, repositoryRoot = process.cwd() } = {}) {
+  const tag = requireEnvironment(environment, 'RELEASE_TAG');
+  const releasePrerelease = parseBooleanEnvironment(environment, 'RELEASE_PRERELEASE');
+  const repository = requireEnvironment(environment, 'GITHUB_REPOSITORY');
+  const rootPackage = await readJson(path.join(repositoryRoot, 'package.json'));
+  const publishedPackage = await readJson(path.join(repositoryRoot, 'packages/oxiquill/package.json'));
+
+  assertReleaseIdentity({
+    packageVersion: publishedPackage.version,
+    releasePrerelease,
+    rootVersion: rootPackage.version,
+    tag
+  });
+
+  const headCommit = gitOutput(['rev-parse', 'HEAD'], repositoryRoot);
+  const tagCommit = gitOutput(['rev-parse', `${tag}^{commit}`], repositoryRoot);
+  const ancestry = spawnSync('git', ['merge-base', '--is-ancestor', tagCommit, 'origin/main'], {
+    cwd: repositoryRoot,
+    encoding: 'utf8'
+  });
+  if (ancestry.error) throw ancestry.error;
+  if (ancestry.status !== 0 && ancestry.status !== 1) {
+    throw new Error(ancestry.stderr || 'Unable to verify release ancestry.');
+  }
+  assertTagOnMain({ headCommit, isAncestor: ancestry.status === 0, tag, tagCommit });
+
+  const blockers = await fetchOpenReleaseBlockers({
+    repository,
+    token: environment.GITHUB_TOKEN
+  });
+  assertNoOpenReleaseBlockers(blockers);
+
+  if (environment.GITHUB_OUTPUT) {
+    await appendFile(environment.GITHUB_OUTPUT, `release_tag=${tag}\nrelease_version=${publishedPackage.version}\n`);
+  }
+
+  return { tag, version: publishedPackage.version };
+}
+
+async function fetchAllPages(url, { fetchImplementation, token }) {
+  const results = [];
+  let page = 1;
+
+  while (true) {
+    const separator = url.includes('?') ? '&' : '?';
+    const response = await fetchImplementation(`${url}${separator}page=${page}`, {
+      headers: {
+        Accept: 'application/vnd.github+json',
+        ...(token ? { Authorization: `Bearer ${token}` } : {}),
+        'X-GitHub-Api-Version': '2022-11-28'
+      }
+    });
+    if (!response.ok) {
+      throw new Error(`GitHub API request failed with ${response.status}: ${await response.text()}`);
+    }
+
+    const values = await response.json();
+    if (!Array.isArray(values)) {
+      throw new Error('GitHub API returned a non-array response.');
+    }
+    results.push(...values);
+    if (values.length < 100) return results;
+    page += 1;
+  }
+}
+
+function gitOutput(args, cwd) {
+  return execFileSync('git', args, { cwd, encoding: 'utf8' }).trim();
+}
+
+function parseBooleanEnvironment(environment, name) {
+  const value = requireEnvironment(environment, name);
+  if (value !== 'true' && value !== 'false') {
+    throw new Error(`${name} must be true or false.`);
+  }
+  return value === 'true';
+}
+
+function requireEnvironment(environment, name) {
+  const value = environment[name];
+  if (!value) throw new Error(`${name} must be set.`);
+  return value;
+}
+
+async function readJson(filePath) {
+  return JSON.parse(await readFile(filePath, 'utf8'));
+}
+
+const isMainModule = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+if (isMainModule) {
+  try {
+    const { tag, version } = await verifyRelease();
+    console.log(`Verified ${tag} for oxiquill ${version}.`);
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : error);
+    process.exitCode = 1;
+  }
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,9 +179,7 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Test packed consumer
-        env:
-          PACKAGE_MANAGER: ${{ matrix.package-manager }}
-        run: pnpm "test:consumer:${PACKAGE_MANAGER}"
+        run: pnpm "test:consumer:${{ matrix.package-manager }}"
 
   runtime:
     name: Runtime (${{ matrix.label }})

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,8 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
+  GHC_WASM_ARCHIVE_SHA256: 82453d58b0ec5e1be8f162cb71f2c236ae96d5d81e18bf4574edc50883354e40
+  GHC_WASM_FLAVOUR: '9.14'
   GHC_WASM_REVISION: 8fd59591635cb47ad7db124562039bea8441cae8
   NODE_VERSION: '24'
   PNPM_VERSION: '11.2.2'
@@ -26,14 +28,14 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       - name: Set up pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
         with:
           version: ${{ env.PNPM_VERSION }}
           run_install: false
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: pnpm
@@ -51,14 +53,14 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       - name: Set up pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
         with:
           version: ${{ env.PNPM_VERSION }}
           run_install: false
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: pnpm
@@ -69,9 +71,10 @@ jobs:
           rustup toolchain install "$RUST_TOOLCHAIN" --profile minimal --component clippy --component rustfmt
           rustup default "$RUST_TOOLCHAIN"
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@742a3317eac7bd62f91cd888b4eead5e784ba833 # v2.87.1
         with:
-          tool: cargo-llvm-cov
+          fallback: none
+          tool: cargo-llvm-cov@0.9.0
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Run Rust lint, docs, and coverage
@@ -93,14 +96,14 @@ jobs:
             os: windows-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       - name: Set up pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
         with:
           version: ${{ env.PNPM_VERSION }}
           run_install: false
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: pnpm
@@ -143,14 +146,14 @@ jobs:
             package-manager: pnpm
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       - name: Set up pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
         with:
           version: ${{ env.PNPM_VERSION }}
           run_install: false
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: pnpm
@@ -161,9 +164,10 @@ jobs:
           rustup toolchain install "$RUST_TOOLCHAIN" --profile minimal --target wasm32-unknown-unknown
           rustup default "$RUST_TOOLCHAIN"
       - name: Install wasm-pack
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@742a3317eac7bd62f91cd888b4eead5e784ba833 # v2.87.1
         with:
-          tool: wasm-pack
+          fallback: none
+          tool: wasm-pack@0.15.0
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Test packed consumer
@@ -183,14 +187,14 @@ jobs:
             os: macos-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       - name: Set up pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
         with:
           version: ${{ env.PNPM_VERSION }}
           run_install: false
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: pnpm
@@ -201,45 +205,25 @@ jobs:
           rustup toolchain install "$RUST_TOOLCHAIN" --profile minimal --target wasm32-unknown-unknown
           rustup default "$RUST_TOOLCHAIN"
       - name: Install wasm-pack
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@742a3317eac7bd62f91cd888b4eead5e784ba833 # v2.87.1
         with:
-          tool: wasm-pack
+          fallback: none
+          tool: wasm-pack@0.15.0
       - name: Cache ghc-wasm
-        uses: actions/cache@v5
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           path: ~/.ghc-wasm
-          key: ghc-wasm-${{ runner.os }}-${{ runner.arch }}-9.14-${{ env.GHC_WASM_REVISION }}
+          key: ghc-wasm-${{ runner.os }}-${{ runner.arch }}-${{ env.GHC_WASM_FLAVOUR }}-${{ env.GHC_WASM_REVISION }}-${{ env.GHC_WASM_ARCHIVE_SHA256 }}
       - name: Install ghc-wasm
         shell: bash
-        run: |
-          set -euo pipefail
-          compiler="$HOME/.ghc-wasm/wasm32-wasi-ghc/bin/wasm32-wasi-ghc"
-          if [ ! -x "$compiler" ]; then
-            if [ "$RUNNER_OS" = "Linux" ]; then
-              sudo apt-get update
-              sudo apt-get install -y jq unzip zstd
-            else
-              brew list jq >/dev/null 2>&1 || brew install jq
-              brew list zstd >/dev/null 2>&1 || brew install zstd
-            fi
-            source_dir="$(mktemp -d)"
-            curl --fail --location --retry 5 --silent --show-error \
-              "https://gitlab.haskell.org/haskell-wasm/ghc-wasm-meta/-/archive/$GHC_WASM_REVISION/ghc-wasm-meta-$GHC_WASM_REVISION.tar.gz" \
-              | tar xz -C "$source_dir" --strip-components=1
-            (
-              cd "$source_dir"
-              FLAVOUR=9.14 PREFIX="$HOME/.ghc-wasm" ./setup.sh
-            )
-          fi
-          echo "OXIQUILL_HASKELL_GHC=$compiler" >> "$GITHUB_ENV"
-          "$compiler" --version
+        run: bash .github/scripts/install-ghc-wasm.sh
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Run generated runtime and static build tests
         run: pnpm test:runtime
       - name: Upload Linux browser site
         if: matrix.label == 'Linux'
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
         with:
           name: browser-site
           path: examples/docs-site/dist
@@ -263,14 +247,14 @@ jobs:
             project: webkit
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       - name: Set up pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
         with:
           version: ${{ env.PNPM_VERSION }}
           run_install: false
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: pnpm
@@ -278,7 +262,7 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Download built browser site
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
         with:
           name: browser-site
           path: examples/docs-site/dist
@@ -288,7 +272,7 @@ jobs:
         run: pnpm test:e2e --project=${{ matrix.project }}
       - name: Upload failed browser report
         if: failure()
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
         with:
           name: playwright-${{ matrix.project }}-${{ github.run_attempt }}
           path: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
       - name: Set up pnpm
         uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
         with:
@@ -54,6 +56,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
       - name: Set up pnpm
         uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
         with:
@@ -97,6 +101,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
       - name: Set up pnpm
         uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
         with:
@@ -147,6 +153,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
       - name: Set up pnpm
         uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
         with:
@@ -171,7 +179,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Test packed consumer
-        run: pnpm test:consumer:${{ matrix.package-manager }}
+        env:
+          PACKAGE_MANAGER: ${{ matrix.package-manager }}
+        run: pnpm "test:consumer:${PACKAGE_MANAGER}"
 
   runtime:
     name: Runtime (${{ matrix.label }})
@@ -188,6 +198,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
       - name: Set up pnpm
         uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
         with:
@@ -248,6 +260,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
       - name: Set up pnpm
         uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
         with:
@@ -267,9 +281,13 @@ jobs:
           name: browser-site
           path: examples/docs-site/dist
       - name: Install Playwright browser
-        run: pnpm exec playwright install --with-deps ${{ matrix.project }}
+        env:
+          PLAYWRIGHT_PROJECT: ${{ matrix.project }}
+        run: pnpm exec playwright install --with-deps "$PLAYWRIGHT_PROJECT"
       - name: Run browser suite
-        run: pnpm test:e2e --project=${{ matrix.project }}
+        env:
+          PLAYWRIGHT_PROJECT: ${{ matrix.project }}
+        run: pnpm test:e2e --project="$PLAYWRIGHT_PROJECT"
       - name: Upload failed browser report
         if: failure()
         uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -142,7 +142,7 @@ jobs:
 
   publish:
     name: Stage npm package
-    if: github.event_name == 'release'
+    if: github.event_name == 'release' && needs.verify.outputs.release_version != '0.3.0'
     needs: verify
     runs-on: ubuntu-latest
     timeout-minutes: 15

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -4,13 +4,17 @@ on:
   release:
     types:
       - published
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: Existing vMAJOR.MINOR.PATCH tag to verify without publishing
+        required: true
+        type: string
 
-permissions:
-  contents: read
-  id-token: write
+permissions: {}
 
 concurrency:
-  group: npm-publish-${{ github.event.release.tag_name }}
+  group: npm-publish-${{ github.event.release.tag_name || inputs.release_tag }}
   cancel-in-progress: false
 
 env:
@@ -19,20 +23,52 @@ env:
   GHC_WASM_FLAVOUR: '9.14'
   GHC_WASM_REVISION: 8fd59591635cb47ad7db124562039bea8441cae8
   NODE_VERSION: '24'
+  NPM_VERSION: '11.19.1'
   PNPM_VERSION: '11.2.2'
   RUST_TOOLCHAIN: '1.95.0'
 
 jobs:
-  publish:
-    name: Validate and publish
+  verify:
+    name: Verify release archive
     runs-on: ubuntu-latest
+    timeout-minutes: 120
+    permissions:
+      contents: read
+      issues: read # Required to enforce the release-blocker milestone gate.
+    outputs:
+      archive_filename: ${{ steps.archive.outputs.archive_filename }}
+      artifact_name: ${{ steps.archive.outputs.artifact_name }}
+      release_tag: ${{ steps.release.outputs.release_tag }}
+      release_version: ${{ steps.release.outputs.release_version }}
 
     steps:
       - name: Check out the release tag
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           fetch-depth: 0
-          ref: ${{ github.event.release.tag_name }}
+          persist-credentials: false
+          ref: ${{ github.event.release.tag_name || inputs.release_tag }}
+
+      - name: Verify the release tag is on main
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name || inputs.release_tag }}
+        run: |
+          set -euo pipefail
+          if [[ ! "$RELEASE_TAG" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
+            echo "Release tag $RELEASE_TAG must match vMAJOR.MINOR.PATCH" >&2
+            exit 1
+          fi
+          git fetch origin main:refs/remotes/origin/main --no-tags
+          tag_commit="$(git rev-parse "$RELEASE_TAG^{commit}")"
+          head_commit="$(git rev-parse HEAD)"
+          if [[ "$head_commit" != "$tag_commit" ]]; then
+            echo "Checked out commit $head_commit does not match $RELEASE_TAG commit $tag_commit" >&2
+            exit 1
+          fi
+          if ! git merge-base --is-ancestor "$tag_commit" origin/main; then
+            echo "Release tag $RELEASE_TAG is not contained in origin/main" >&2
+            exit 1
+          fi
 
       - name: Set up pnpm
         uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
@@ -45,34 +81,18 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
           package-manager-cache: false
-          registry-url: https://registry.npmjs.org
 
-      - name: Verify release identity and ancestry
-        shell: bash
+      - name: Install the pinned npm CLI
+        run: npm install --global "npm@${NPM_VERSION}"
+
+      - name: Verify release identity and blockers
+        id: release
         env:
-          RELEASE_PRERELEASE: ${{ github.event.release.prerelease }}
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          GITHUB_TOKEN: ${{ github.token }}
+          RELEASE_PRERELEASE: ${{ github.event.release.prerelease || false }}
+          RELEASE_TAG: ${{ github.event.release.tag_name || inputs.release_tag }}
         run: |
-          set -euo pipefail
-          package_version="$(node -p "require('./packages/oxiquill/package.json').version")"
-          if [[ "$package_version" == *-* ]]; then
-            echo "Refusing to publish prerelease package version $package_version" >&2
-            exit 1
-          fi
-          if [[ "$RELEASE_PRERELEASE" == "true" ]]; then
-            echo "Refusing to publish from a prerelease GitHub Release" >&2
-            exit 1
-          fi
-          if [[ "$RELEASE_TAG" != "v$package_version" ]]; then
-            echo "Release tag $RELEASE_TAG does not match package version v$package_version" >&2
-            exit 1
-          fi
-          git fetch origin main --no-tags
-          tag_commit="$(git rev-list -n 1 "$RELEASE_TAG")"
-          if ! git merge-base --is-ancestor "$tag_commit" origin/main; then
-            echo "Release tag $RELEASE_TAG is not based on main" >&2
-            exit 1
-          fi
+          node .github/scripts/verify-release.mjs
           legacy_license_pattern='AG''PL|Aff''ero'
           if git grep -n -E "$legacy_license_pattern"; then
             echo "Tracked current-license references must be removed before publishing" >&2
@@ -91,12 +111,6 @@ jobs:
           fallback: none
           tool: cargo-llvm-cov@0.9.0,wasm-pack@0.15.0
 
-      - name: Cache ghc-wasm
-        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
-        with:
-          path: ~/.ghc-wasm
-          key: ghc-wasm-${{ runner.os }}-${{ runner.arch }}-${{ env.GHC_WASM_FLAVOUR }}-${{ env.GHC_WASM_REVISION }}-${{ env.GHC_WASM_ARCHIVE_SHA256 }}
-
       - name: Install ghc-wasm
         shell: bash
         run: bash .github/scripts/install-ghc-wasm.sh
@@ -113,8 +127,60 @@ jobs:
       - name: Run release validation
         run: pnpm test
 
-      - name: Publish package
-        working-directory: packages/oxiquill
-        run: npm publish --access public --provenance
+      - name: Build the release archive once
+        id: archive
+        run: node .github/scripts/release-archive.mjs create "$RUNNER_TEMP/npm-release"
+
+      - name: Upload the verified release archive
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+        with:
+          name: ${{ steps.archive.outputs.artifact_name }}
+          path: ${{ runner.temp }}/npm-release
+          if-no-files-found: error
+          compression-level: 0
+          retention-days: 14
+
+  publish:
+    name: Stage npm package
+    if: github.event_name == 'release'
+    needs: verify
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    environment:
+      name: npm-publish
+    permissions:
+      contents: read
+      id-token: write # Required for npm Trusted Publishing and provenance.
+
+    steps:
+      - name: Check out release verification code
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
+          ref: ${{ needs.verify.outputs.release_tag }}
+
+      - name: Set up Node.js
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          package-manager-cache: false
+
+      - name: Install the pinned npm CLI
+        run: npm install --global "npm@${NPM_VERSION}"
+
+      - name: Download the verified release archive
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
+        with:
+          name: ${{ needs.verify.outputs.artifact_name }}
+          path: ${{ runner.temp }}/npm-release
+
+      - name: Verify the release archive and OIDC environment
+        id: archive
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          RELEASE_VERSION: ${{ needs.verify.outputs.release_version }}
+        run: node .github/scripts/release-archive.mjs verify "$RUNNER_TEMP/npm-release" "$RELEASE_VERSION" --require-oidc
+
+      - name: Submit package for staged publication
+        env:
+          RELEASE_ARCHIVE: ${{ steps.archive.outputs.archive_path }}
+        run: npm stage publish "$RELEASE_ARCHIVE" --registry https://registry.npmjs.org/

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -15,6 +15,8 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
+  GHC_WASM_ARCHIVE_SHA256: 82453d58b0ec5e1be8f162cb71f2c236ae96d5d81e18bf4574edc50883354e40
+  GHC_WASM_FLAVOUR: '9.14'
   GHC_WASM_REVISION: 8fd59591635cb47ad7db124562039bea8441cae8
   NODE_VERSION: '24'
   PNPM_VERSION: '11.2.2'
@@ -27,19 +29,19 @@ jobs:
 
     steps:
       - name: Check out the release tag
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           fetch-depth: 0
           ref: ${{ github.event.release.tag_name }}
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
         with:
           version: ${{ env.PNPM_VERSION }}
           run_install: false
 
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           package-manager-cache: false
@@ -84,34 +86,20 @@ jobs:
           rustup default "$RUST_TOOLCHAIN"
 
       - name: Install Rust build tools
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@742a3317eac7bd62f91cd888b4eead5e784ba833 # v2.87.1
         with:
-          tool: cargo-llvm-cov,wasm-pack
+          fallback: none
+          tool: cargo-llvm-cov@0.9.0,wasm-pack@0.15.0
 
       - name: Cache ghc-wasm
-        uses: actions/cache@v5
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           path: ~/.ghc-wasm
-          key: ghc-wasm-${{ runner.os }}-${{ runner.arch }}-9.14-${{ env.GHC_WASM_REVISION }}
+          key: ghc-wasm-${{ runner.os }}-${{ runner.arch }}-${{ env.GHC_WASM_FLAVOUR }}-${{ env.GHC_WASM_REVISION }}-${{ env.GHC_WASM_ARCHIVE_SHA256 }}
 
       - name: Install ghc-wasm
         shell: bash
-        run: |
-          set -euo pipefail
-          if [ ! -x "$HOME/.ghc-wasm/wasm32-wasi-ghc/bin/wasm32-wasi-ghc" ]; then
-            sudo apt-get update
-            sudo apt-get install -y jq unzip zstd
-            source_dir="$(mktemp -d)"
-            curl --fail --location --retry 5 --silent --show-error \
-              "https://gitlab.haskell.org/haskell-wasm/ghc-wasm-meta/-/archive/$GHC_WASM_REVISION/ghc-wasm-meta-$GHC_WASM_REVISION.tar.gz" \
-              | tar xz -C "$source_dir" --strip-components=1
-            (
-              cd "$source_dir"
-              FLAVOUR=9.14 PREFIX="$HOME/.ghc-wasm" ./setup.sh
-            )
-          fi
-          echo "OXIQUILL_HASKELL_GHC=$HOME/.ghc-wasm/wasm32-wasi-ghc/bin/wasm32-wasi-ghc" >> "$GITHUB_ENV"
-          "$HOME/.ghc-wasm/wasm32-wasi-ghc/bin/wasm32-wasi-ghc" --version
+        run: bash .github/scripts/install-ghc-wasm.sh
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -6,10 +6,7 @@ on:
       - main
   workflow_dispatch:
 
-permissions:
-  contents: read
-  pages: write
-  id-token: write
+permissions: {}
 
 concurrency:
   group: pages
@@ -30,10 +27,14 @@ jobs:
   build:
     name: Build Pages artifact
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # Required to check out the site sources.
 
     steps:
       - name: Check out repository
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
 
       - name: Set up pnpm
         uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
@@ -88,6 +89,9 @@ jobs:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
+    permissions:
+      id-token: write # Required to authenticate the Pages deployment.
+      pages: write # Required to deploy the Pages artifact.
 
     steps:
       - name: Deploy Pages artifact

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -17,6 +17,8 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
+  GHC_WASM_ARCHIVE_SHA256: 82453d58b0ec5e1be8f162cb71f2c236ae96d5d81e18bf4574edc50883354e40
+  GHC_WASM_FLAVOUR: '9.14'
   GHC_WASM_REVISION: 8fd59591635cb47ad7db124562039bea8441cae8
   NODE_VERSION: '24'
   PNPM_VERSION: '11.2.2'
@@ -31,16 +33,16 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
         with:
           version: ${{ env.PNPM_VERSION }}
           run_install: false
 
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: pnpm
@@ -53,32 +55,20 @@ jobs:
           rustup default "$RUST_TOOLCHAIN"
 
       - name: Install wasm-pack
-        uses: taiki-e/install-action@wasm-pack
+        uses: taiki-e/install-action@742a3317eac7bd62f91cd888b4eead5e784ba833 # v2.87.1
+        with:
+          fallback: none
+          tool: wasm-pack@0.15.0
 
       - name: Cache ghc-wasm
-        uses: actions/cache@v5
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           path: ~/.ghc-wasm
-          key: ghc-wasm-${{ runner.os }}-${{ runner.arch }}-9.14-${{ env.GHC_WASM_REVISION }}
+          key: ghc-wasm-${{ runner.os }}-${{ runner.arch }}-${{ env.GHC_WASM_FLAVOUR }}-${{ env.GHC_WASM_REVISION }}-${{ env.GHC_WASM_ARCHIVE_SHA256 }}
 
       - name: Install ghc-wasm
         shell: bash
-        run: |
-          set -euo pipefail
-          if [ ! -x "$HOME/.ghc-wasm/wasm32-wasi-ghc/bin/wasm32-wasi-ghc" ]; then
-            sudo apt-get update
-            sudo apt-get install -y jq unzip zstd
-            source_dir="$(mktemp -d)"
-            curl --fail --location --retry 5 --silent --show-error \
-              "https://gitlab.haskell.org/haskell-wasm/ghc-wasm-meta/-/archive/$GHC_WASM_REVISION/ghc-wasm-meta-$GHC_WASM_REVISION.tar.gz" \
-              | tar xz -C "$source_dir" --strip-components=1
-            (
-              cd "$source_dir"
-              FLAVOUR=9.14 PREFIX="$HOME/.ghc-wasm" ./setup.sh
-            )
-          fi
-          echo "OXIQUILL_HASKELL_GHC=$HOME/.ghc-wasm/wasm32-wasi-ghc/bin/wasm32-wasi-ghc" >> "$GITHUB_ENV"
-          "$HOME/.ghc-wasm/wasm32-wasi-ghc/bin/wasm32-wasi-ghc" --version
+        run: bash .github/scripts/install-ghc-wasm.sh
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -87,7 +77,7 @@ jobs:
         run: pnpm build
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
         with:
           path: examples/docs-site/dist
 
@@ -102,4 +92,4 @@ jobs:
     steps:
       - name: Deploy Pages artifact
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5

--- a/README.md
+++ b/README.md
@@ -289,7 +289,7 @@ For docs-only prose changes, `pnpm check` is usually enough. For interactive cel
 
 Production builds write `dist/oxiquill/bundle-report.json` and fail when any emitted client or worker JavaScript chunk exceeds 650 KiB uncompressed. Run `pnpm test:bundle` after `pnpm build` to verify the budget and the ECharts and Mermaid dynamic import boundaries.
 
-`test:e2e` runs the full suite in Chromium, Firefox, and WebKit. `test:consumer:npm` and `test:consumer:pnpm` install the packed package tarball into a temporary standalone project, generate a Rust/Wasm cell, run static checks, and build the site without workspace links.
+`test:e2e` runs the full suite in Chromium, Firefox, and WebKit. `test:consumer:npm` and `test:consumer:pnpm` install the packed package tarball into a temporary standalone project, check and build a zero-cell site with only Node on `PATH`, then generate Rust and Python runtimes without workspace links.
 
 ### License
 
@@ -607,7 +607,7 @@ docs-only の本文変更では、通常 `pnpm check` で十分です。実行�
 
 production build は `dist/oxiquill/bundle-report.json` を生成し、出力された client または worker の JavaScript chunk が uncompressed で 650 KiB を超えると失敗します。`pnpm build` の後に `pnpm test:bundle` を実行すると、budget と ECharts/Mermaid の dynamic import boundary を検証できます。
 
-`test:e2e` は Chromium、Firefox、WebKit で full suite を実行します。`test:consumer:npm` と `test:consumer:pnpm` は packed tarball を一時的な standalone project に installし、workspace link を使わずに Rust/Wasm cell の生成、static check、site build を確認します。
+`test:e2e` は Chromium、Firefox、WebKit で full suite を実行します。`test:consumer:npm` と `test:consumer:pnpm` は packed tarball を一時的な standalone project に install し、`PATH` に Node だけがある zero-cell site を check/build した後、workspace link を使わずに Rust/Python runtime の生成を確認します。
 
 ### ライセンス
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,17 +1,3 @@
 # Releasing Oxiquill
 
-Create `release/vX.Y.Z` from the latest `main`, then update and validate the version there. Open a pull request to `main` and squash-merge it after every required check passes and review conversations are resolved. Tag the resulting `main` commit as `vX.Y.Z` and publish a GitHub Release for that tag. Do not tag the release-branch commit: squash merge creates a different commit, and the publication workflow requires the tag to be contained in `main`.
-
-Retain the protected release branch after merging as a record of the release preparation. Do not update, force-push, or delete it after the pull request is merged. Other merged topic branches are deleted automatically.
-
-The `.github/workflows/npm-publish.yml` workflow rejects prerelease versions, prerelease GitHub Releases, mismatched tags, and tags that are not contained in `main`. It runs repository validation, checks the npm tarball, and builds a fresh consumer from that tarball before publishing `packages/oxiquill`.
-
-## First publication
-
-npm Trusted Publishing cannot be configured until the package exists. For the first publication only, create a short-lived granular npm access token scoped to publish `oxiquill`, store it as the repository secret `NPM_TOKEN`, and publish the GitHub Release. Revoke the token and remove the secret immediately after the workflow succeeds.
-
-## Subsequent publications
-
-Configure npm Trusted Publishing for repository `kakune/oxiquill` and workflow filename `npm-publish.yml`. The workflow grants `id-token: write`, runs on a GitHub-hosted runner, and invokes npm directly, so npm can exchange the GitHub OIDC identity for a short-lived publishing credential and attach provenance.
-
-Do not retain `NPM_TOKEN` after bootstrap. Do not publish from a topic or release branch, or by manually running `npm publish` on a workstation. Publish only from a GitHub Release tag that points to a commit contained in `main`.
+The canonical maintainer release process, including the one-time npm bootstrap and normal staged publishing, is documented in [docs/RELEASING.md](./docs/RELEASING.md).

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -8,8 +8,10 @@ This runbook covers the one-time npm package bootstrap and every later stable re
 - The `npm release readiness` milestone has no open `release-blocker` issue.
 - Required CI is green on the latest `main`.
 - The release version is stable `MAJOR.MINOR.PATCH`; prereleases require a separately reviewed runbook change.
-- Node.js 24+, the repository's pinned pnpm/Rust tools, `wasm-pack`, `cargo-llvm-cov`, `wasm32-wasi-ghc`, Playwright, GitHub CLI, and current npm CLI are available.
+- Node.js 24+, npm 11.15.0+, the repository's pinned pnpm/Rust tools, `wasm-pack`, `cargo-llvm-cov`, `wasm32-wasi-ghc`, Playwright, and GitHub CLI are available.
 - The protected publish environment and npm staged trusted publisher are configured for normal releases.
+
+The GitHub environment is named `npm-publish`. It has `kakune` as a required reviewer, permits only tags matching `v*`, allows self-review for the sole maintainer, and contains no npm credential. The npm Trusted Publisher must match repository `kakune/oxiquill`, workflow filename `npm-publish.yml`, environment `npm-publish`, and only the `npm stage publish` action.
 
 Never reuse, move, or replace a published tag. npm versions are immutable; recover from a bad release with deprecation and a patch release.
 
@@ -20,7 +22,7 @@ Never reuse, move, or replace a published tag. npm versions are immutable; recov
 3. Move releasable entries from `CHANGELOG.md`'s Unreleased section into `## [X.Y.Z] - YYYY-MM-DD`, restore empty Unreleased categories, and update comparison links.
 4. Update `SECURITY.md` if the supported minor line changes.
 5. Regenerate required runtime/package artifacts through existing commands; never edit generated output directly.
-6. Run the release validation documented below and inspect the packed archive.
+6. Run the local release validation documented below.
 7. Commit focused version/changelog and generated-metadata changes on the protected release branch.
 
 Retain the protected `release/vX.Y.Z` branch after release. Do not add later commits to it.
@@ -40,51 +42,72 @@ pnpm test:package
 pnpm test:consumer
 ```
 
-Run the release workflow's manual dry-run path from the release-shaped ref. It must verify:
+The package and consumer tests inspect temporary packs locally. The immutable release archive is produced later by the workflow from the tag on `main`.
 
-- tag/version shape and equality for root and package metadata;
-- candidate ancestry from `main`;
-- zero open release blockers and zero production advisories;
-- all required checks and language/browser/consumer fixtures;
-- the complete npm tarball allowlist and README/licenses;
-- one tarball built exactly once, with its SHA-256 and file manifest recorded.
-
-Download that workflow artifact, verify the recorded SHA-256 locally, and inspect the archive contents before approval. The publish job must consume the same archive and must not rebuild it.
-
-## Merge and Tag
+## Merge, Tag, and Dry Run
 
 1. Open an English pull request from `release/vX.Y.Z` to `main` with the validation results and release checklist.
 2. Bring the branch up to date with `main`, resolve every review conversation, and wait for all required checks.
 3. Squash-merge the release pull request. Do not merge, rebase-merge, or push directly to `main`.
 4. Record the resulting squash commit on `main` and confirm its tree contains the reviewed release state.
-5. Create annotated tag `vX.Y.Z` on that resulting `main` commit and push the tag.
-6. Create the GitHub Release from the exact tag, using the changelog entry as release notes. Do not mark a stable release as a prerelease.
+5. Create annotated tag `vX.Y.Z` on that resulting `main` commit and push the tag. Do not tag the release branch commit.
+6. Dispatch `npm-publish.yml` against that exact tag with `release_tag` set to the same `vX.Y.Z` value.
 
-Publishing the GitHub Release starts the stable verification/staging workflow. The workflow must reject a tag not contained in `main`, a mismatched version, an open release blocker, a changed archive, or missing OIDC.
+The manual path never contacts an npm publish endpoint. It must verify:
+
+- tag/version shape and equality for root and package metadata;
+- the checked-out tag commit and its ancestry from `main`;
+- zero open release blockers and zero production advisories;
+- all required checks and language/browser/consumer fixtures;
+- the complete npm tarball allowlist and README/licenses;
+- one tarball built exactly once, with its SHA-256 and file manifest recorded.
+
+Download artifact `oxiquill-X.Y.Z`. It contains only `oxiquill-X.Y.Z.tgz`, `SHA256SUMS`, and `release-manifest.json`. Verify and inspect it from an isolated directory:
+
+```sh
+sha256sum --check SHA256SUMS
+tar -tzf oxiquill-X.Y.Z.tgz
+npm pack --dry-run --json ./oxiquill-X.Y.Z.tgz
+```
+
+On macOS, use `shasum -a 256 -c SHA256SUMS` if `sha256sum` is unavailable. Confirm the manifest records every tarball path, the expected package/version, npm integrity, and the same SHA-256. Do not rebuild or rename the archive.
 
 ## One-Time npm Bootstrap
 
 Use this section only for the first publication of the unscoped `oxiquill` package, before package-scoped trusted publishing can be configured.
 
-1. Recheck that `oxiquill` is available and that the maintainer controls the intended npm account and organization settings.
-2. Run the complete release dry run and download the exact verified tarball, SHA-256, and manifest.
-3. Recompute the hash locally and inspect both the recorded manifest and `npm pack --dry-run` output.
-4. Sign in with an interactive npm session protected by 2FA. Publish that exact archive once with public access and provenance; do not rebuild it.
-5. Immediately configure the GitHub trusted publisher for this repository and the stable workflow filename with stage-only permission.
-6. Configure publishing access to require 2FA and disallow token-based publication.
-7. Remove or revoke every bootstrap write credential. Do not add `NPM_TOKEN`, `NODE_AUTH_TOKEN`, or a permanent token fallback to GitHub.
-8. Verify the installed package, tarball hash/contents, public provenance attestation, package README, and generated license files.
+1. Recheck that `oxiquill` returns npm E404 and that `kakune` controls the intended npm account and organization settings.
+2. Complete the tagged manual dry run above for `v0.3.0`, then download and inspect its exact three-file artifact.
+3. Sign in with an interactive npm session protected by 2FA. Publish that exact archive once with public access; do not rebuild it. Local interactive publishing cannot use trusted OIDC provenance, so override the package default only for this bootstrap command:
+
+   ```sh
+   npm publish ./oxiquill-0.3.0.tgz --access public --provenance=false
+   ```
+
+4. Immediately configure the GitHub Trusted Publisher with the repository, workflow, environment, and stage-only permission listed in Preconditions.
+5. Configure publishing access to require 2FA and disallow token-based publication.
+6. Remove or revoke every bootstrap credential and end the interactive session. Do not add `NPM_TOKEN`, `NODE_AUTH_TOKEN`, or a permanent token fallback to GitHub.
+7. Create the stable GitHub Release for `v0.3.0` from the exact tag and changelog entry. The workflow re-verifies and archives this release, but deliberately skips the staged publish job for the one-time bootstrap version.
+8. Verify the installed package, tarball hash/contents, package README, and generated license files. Record that provenance begins with subsequent OIDC-published versions.
 
 Record completion in the GitHub Release without exposing credentials or private account data. This exception is never used again.
 
 ## Normal Staged Publication
 
-1. The least-privilege verify job builds and validates the archive without publish permission.
-2. The protected publish job obtains only `contents: read` and `id-token: write`, downloads the verified artifact, checks its SHA-256, and submits it with `npm stage publish` through the configured trusted publisher.
-3. A required reviewer downloads/inspects the staged archive and compares its hash and manifest with the verify job.
-4. The maintainer approves the staged release with npm 2FA.
-5. Confirm the exact version is public, installable with npm and pnpm, and shows npm provenance/publish attestations tied to this repository/workflow.
-6. Verify the package exports, README, licenses, static starter, check, build, preview, and language fixtures from the published package rather than a workspace link.
+1. Create the stable GitHub Release from the exact `vX.Y.Z` tag and changelog entry. Do not mark a stable release as a prerelease.
+2. Wait for the least-privilege verify job to finish, then download that release run's `oxiquill-X.Y.Z` artifact and repeat the hash/manifest/archive inspection. The workflow rejects a non-main tag, version mismatch, open release blocker, advisory, failed validation, or changed archive.
+3. Approve the waiting `npm-publish` environment only after inspecting that exact artifact. The publish job obtains only `contents: read` and `id-token: write`, downloads the same artifact, verifies it without rebuilding, and submits the tarball with `npm stage publish` through OIDC.
+4. Inspect the staged package through npmjs.com or the current npm CLI. Download it and compare its hash and contents with the GitHub artifact before approval:
+
+   ```sh
+   npm stage list oxiquill
+   npm stage view <stage-id>
+   npm stage download <stage-id>
+   ```
+
+5. Approve the stage through npmjs.com or run `npm stage approve <stage-id>` and complete the required npm 2FA challenge.
+6. Confirm the exact version is public, installable with npm and pnpm, and shows npm provenance/publish attestations tied to this repository, workflow, tag, and protected environment.
+7. Verify the package exports, README, licenses, static starter, check, build, preview, and language fixtures from the published package rather than a workspace link.
 
 No normal release uses a long-lived npm write token.
 

--- a/examples/docs-site/content/docs/features/interactive-cells.mdx
+++ b/examples/docs-site/content/docs/features/interactive-cells.mdx
@@ -42,7 +42,7 @@ This button cell waits for an explicit run even when its input changes.
 //| run: button
 //| crates: []
 //| inputs:
-//|   value: { type: integer, label: value, min: 1, max: 10, step: 1, value: 3 }
+//|   value: { type: integer, label: Input value, description: Choose an integer from 1 through 10., min: 1, max: 10, step: 1, value: 3 }
 println!("button value = {value}");
 ```
 
@@ -60,7 +60,7 @@ Superseded queued work is discarded, stale results cannot replace newer state, a
 
 ## Input Schema
 
-Every input accepts only fields relevant to its type. Common fields are `type`, `label`, and `value`; numeric inputs also use `min`, `max`, `step`, and `integer`, while `select` and `radio` use `options`.
+Every input accepts only fields relevant to its type. Common fields are `type`, `label`, `description`, and `value`; numeric inputs also use `min`, `max`, `step`, and `integer`, while `select` and `radio` use `options`.
 
 | Type               | Value and constraints                                                                                  |
 | ------------------ | ------------------------------------------------------------------------------------------------------ |
@@ -70,7 +70,7 @@ Every input accepts only fields relevant to its type. Common fields are `type`, 
 | `checkbox`         | Boolean value.                                                                                         |
 | `select`, `radio`  | Non-empty unique string options or `{ label, value }` objects; the default must equal an option value. |
 
-`type` defaults to `text`, and `label` defaults to the input name. Default values are `false` for checkbox, `0` for numeric inputs, and an empty string for text inputs. Numeric-only fields are rejected on non-numeric controls, and `options` is rejected outside `select` and `radio`.
+`type` defaults to `text`, and `label` defaults to the input name. `description` is an optional non-empty string associated with the control for assistive technology. Default values are `false` for checkbox, `0` for numeric inputs, and an empty string for text inputs. Numeric-only fields are rejected on non-numeric controls, and `options` is rejected outside `select` and `radio`.
 
 The visible `label` is the control's accessible name; the input key is only the generated language binding. Normalization must not make two Rust or Haskell bindings collide. Labels, descriptions, current values, validation messages, and grouped controls use stable IDs, keyboard focus remains visible, and run/error status is announced without stealing focus.
 

--- a/examples/docs-site/content/docs/guides/authoring.mdx
+++ b/examples/docs-site/content/docs/guides/authoring.mdx
@@ -59,7 +59,7 @@ Python cells are fenced `python` code blocks with metadata in leading `#|` comme
 #| title: Python calculation
 #| run: reactive
 #| inputs:
-#|   scale: { type: number, label: scale, min: 1, max: 10, step: 1, value: 2 }
+#|   scale: { type: number, label: Scale, description: Multiplier from 1 through 10., min: 1, max: 10, step: 1, value: 2 }
 print(scale * 10)
 ```
 ````

--- a/examples/docs-site/content/docs/guides/validation.mdx
+++ b/examples/docs-site/content/docs/guides/validation.mdx
@@ -76,7 +76,7 @@ pnpm test:consumer:npm
 pnpm test:consumer:pnpm
 ```
 
-Each command packs `oxiquill`, installs the tarball in a temporary standalone project, runs the CLI and static check, generates a Rust/Wasm cell, and builds the site.
+Each command packs `oxiquill`, installs the tarball in a temporary standalone project, checks and builds a zero-cell site with only Node on `PATH`, then adds Rust and Python cells and verifies their generated runtimes without workspace links.
 
 Pull requests require compatibility jobs on Linux, macOS, and Windows, Haskell runtime jobs on Linux and macOS, and full browser jobs for Chromium, Firefox, and WebKit. Every supported matrix cell is merge-blocking.
 

--- a/examples/docs-site/content/docs/ja/features/interactive-cells.mdx
+++ b/examples/docs-site/content/docs/ja/features/interactive-cells.mdx
@@ -42,7 +42,7 @@ Haskell cell は standard-library code のみで `packages`/`crates` を受け�
 //| run: button
 //| crates: []
 //| inputs:
-//|   value: { type: integer, label: value, min: 1, max: 10, step: 1, value: 3 }
+//|   value: { type: integer, label: Input value, description: Choose an integer from 1 through 10., min: 1, max: 10, step: 1, value: 3 }
 println!("button value = {value}");
 ```
 
@@ -60,7 +60,7 @@ superseded queued work は破棄され、stale result が新しい state を上�
 
 ## Input schema
 
-各 input が受け取るのは type に関係する field だけです。共通 field は `type`、`label`、`value`。numeric input は `min`、`max`、`step`、`integer`、`select`/`radio` は `options` も使います。
+各 input が受け取るのは type に関係する field だけです。共通 field は `type`、`label`、`description`、`value`。numeric input は `min`、`max`、`step`、`integer`、`select`/`radio` は `options` も使います。
 
 | Type               | Value と constraint                                                                               |
 | ------------------ | ------------------------------------------------------------------------------------------------- |
@@ -70,7 +70,7 @@ superseded queued work は破棄され、stale result が新しい state を上�
 | `checkbox`         | boolean value。                                                                                   |
 | `select`, `radio`  | non-empty unique string option または `{ label, value }` object。default は option value と一致。 |
 
-`type` の default は `text`、`label` の default は input name です。default value は checkbox が `false`、numeric input が `0`、text input が空 string です。numeric 専用 field は non-numeric control で拒否され、`options` は `select`/`radio` 以外では使えません。
+`type` の default は `text`、`label` の default は input name です。`description` は control と assistive technology 向けに関連付ける optional non-empty string です。default value は checkbox が `false`、numeric input が `0`、text input が空 string です。numeric 専用 field は non-numeric control で拒否され、`options` は `select`/`radio` 以外では使えません。
 
 visible `label` が control の accessible name で、input key は generated language binding にだけ使います。normalization で二つの Rust/Haskell binding が衝突してはなりません。label、description、current value、validation message、grouped control は stable ID で関連付けられ、keyboard focus を表示し、run/error status は focus を奪わず announce されます。
 

--- a/examples/docs-site/content/docs/ja/guides/authoring.mdx
+++ b/examples/docs-site/content/docs/ja/guides/authoring.mdx
@@ -59,7 +59,7 @@ Python セルは `python` の fenced code block で、先頭に `#|` metadata co
 #| title: Python calculation
 #| run: reactive
 #| inputs:
-#|   scale: { type: number, label: scale, min: 1, max: 10, step: 1, value: 2 }
+#|   scale: { type: number, label: Scale, description: Multiplier from 1 through 10., min: 1, max: 10, step: 1, value: 2 }
 print(scale * 10)
 ```
 ````

--- a/examples/docs-site/content/docs/ja/guides/validation.mdx
+++ b/examples/docs-site/content/docs/ja/guides/validation.mdx
@@ -76,7 +76,7 @@ pnpm test:consumer:npm
 pnpm test:consumer:pnpm
 ```
 
-各 command は `oxiquill` を pack し、tarball を一時的な standalone project に installして、CLI と static check、Rust/Wasm cell generation、site build を実行します。
+各 command は `oxiquill` を pack し、tarball を一時的な standalone project に install して、`PATH` に Node だけがある状態で zero-cell site を check/build します。その後 Rust/Python cell を追加し、workspace link なしで対応 runtime の生成を検証します。
 
 pull request では Linux、macOS、Windows の compatibility job、Linux/macOS の Haskell runtime job、Chromium、Firefox、WebKit の full browser job が必須です。supported matrix の全 cell が merge-blocking です。
 

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "0.18.5",
+    "@axe-core/playwright": "4.13.0",
     "@bjorn3/browser_wasi_shim": "0.4.2",
     "@eslint/js": "9.39.5",
     "@playwright/test": "1.61.1",

--- a/packages/oxiquill/src/astro/index.ts
+++ b/packages/oxiquill/src/astro/index.ts
@@ -29,12 +29,10 @@ import {
   collectBundleModuleIds,
   createBundledModuleCollector,
   createDocRuntimeContext,
-  markRuntimeReady,
   syncDocRuntime,
   syncLicenseArtifacts
 } from '../generator/doc-runtime-service.mjs';
 import { createBrowserBundleCollector, syncBrowserBundleReport } from '../generator/browser-bundle-report.mjs';
-import { buildHaskellWasm, buildRustWasm } from '../generator/doc-runtime/wasm-build.mjs';
 import remarkInteractiveCells from '../lib/doc-runtime/remark-interactive-cells.mjs';
 import remarkMermaidDiagrams from '../lib/doc-runtime/remark-mermaid-diagrams.mjs';
 import remarkPublicAssetBase from '../lib/doc-runtime/remark-public-asset-base.mjs';
@@ -134,6 +132,9 @@ export interface OxiquillIntegrationOptions {
 const createDocRuntimeContextForPaths = createDocRuntimeContext as unknown as (options: {
   paths: OxiquillPaths;
 }) => Promise<DocRuntimeContext>;
+const syncDocRuntimeForBuild = syncDocRuntime as unknown as (
+  options: DocRuntimeContext & { mode: 'build' }
+) => Promise<unknown>;
 
 export function defineOxiquillConfig<StarlightOptions extends object>(
   options: OxiquillConfig<StarlightOptions>
@@ -288,14 +289,10 @@ function createOxiquillIntegration(
 
         bundledModules.reset();
         browserBundle.reset();
+        if (process.env.OXIQUILL_RUNTIME_OWNER === 'cli') return;
+
         const context = await createDocRuntimeContextForPaths({ paths });
-        const summary = await syncDocRuntime(context);
-        await buildRustWasm({ mode: 'build', paths });
-        if (summary.haskellCellCount > 0) {
-          await buildHaskellWasm({ haskellFingerprint: summary.haskellFingerprint, mode: 'build', paths });
-        }
-        await syncLicenseArtifacts({ outputDirectory: undefined, paths });
-        await markRuntimeReady({ paths, summary });
+        await syncDocRuntimeForBuild({ ...context, mode: 'build' });
       },
       'astro:build:done': async ({ dir }) => {
         if (!paths) return;

--- a/packages/oxiquill/src/cli/commands.mjs
+++ b/packages/oxiquill/src/cli/commands.mjs
@@ -5,14 +5,7 @@ import path from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { pathFromUrl, pathInUrl } from '../config/paths.mjs';
 import { loadOxiquillProjectConfig } from '../config/project-config.mjs';
-import {
-  buildHaskellWasm,
-  buildRustWasm,
-  createDocRuntimeContext,
-  markRuntimeReady,
-  syncLicenseArtifacts,
-  syncDocRuntime
-} from '../generator/doc-runtime-service.mjs';
+import { createDocRuntimeContext, syncDocRuntime } from '../generator/doc-runtime-service.mjs';
 import { cleanOxiquillWorkspace } from '../generator/clean.mjs';
 import { runHelperCargo } from '../generator/run-helper-cargo.mjs';
 import { parseConfigOption } from './config-option.mjs';
@@ -78,7 +71,7 @@ export async function runCli(
     case 'build':
       await generateRuntime({ projectConfig, wasmMode: 'build' });
       await runOxiquillCheck(projectConfig, [], { runCommand, selectNode });
-      await runAstro(projectConfig, ['build', ...astroArgs], { runCommand, selectNode });
+      await runAstro(projectConfig, ['build', ...astroArgs], { runCommand, runtimeOwner: 'cli', selectNode });
       return;
     case 'check':
       await generateRuntime({ projectConfig, wasmMode: 'dev' });
@@ -116,7 +109,10 @@ export async function runCli(
       await runHelperCargo({ argv: ['doc', '--no-deps'], paths });
       return;
     case 'test-wasm':
-      await generateRuntime({ projectConfig, wasmMode: 'dev' });
+      if ((await generateRuntime({ projectConfig, wasmMode: 'dev' })).rustCellCount === 0) {
+        console.log('[runtime] no Rust cells; skipping wasm-pack test');
+        return;
+      }
       await runCommand('wasm-pack', ['test', '--node', pathFromUrl(paths.rustCellsDir)], {
         cwd: pathFromUrl(paths.workspaceRoot)
       });
@@ -127,24 +123,14 @@ export async function runCli(
 async function generateRuntime({ projectConfig, tolerateHaskellBuildFailure = false, wasmMode }) {
   const { paths } = projectConfig;
   const context = await createDocRuntimeContext({ paths });
-  const summary = await syncDocRuntime(context);
+  const summary = await syncDocRuntime({
+    ...context,
+    mode: wasmMode,
+    tolerateHaskellBuildFailure
+  });
   console.log(`Generated ${summary.cellCount} interactive cell(s).`);
-
-  if (wasmMode) {
-    await buildRustWasm({ mode: wasmMode, paths });
-    if (summary.haskellCellCount > 0) {
-      const result = await buildHaskellWasm({
-        haskellFingerprint: summary.haskellFingerprint,
-        mode: wasmMode,
-        paths,
-        tolerateFailure: tolerateHaskellBuildFailure
-      });
-      warnToleratedHaskellBuildFailure(result);
-    }
-    await syncLicenseArtifacts({ paths });
-  }
-
-  await markRuntimeReady({ paths, summary });
+  if (summary.haskellBuildResult) warnToleratedHaskellBuildFailure(summary.haskellBuildResult);
+  return summary;
 }
 
 function warnToleratedHaskellBuildFailure(result) {
@@ -181,13 +167,13 @@ async function runDevServer({ args, projectConfig, selectNode }) {
   }
 }
 
-async function runAstro(projectConfig, args, { runCommand, selectNode }) {
+async function runAstro(projectConfig, args, { runCommand, runtimeOwner, selectNode }) {
   const { paths } = projectConfig;
   const nodePath = selectNode(paths);
 
   await runCommand(nodePath, [frameworkBinScript(paths, 'astro'), ...args], {
     cwd: projectConfig.cwd,
-    env: frameworkEnv(paths, { nodePath })
+    env: frameworkEnv(paths, { nodePath, runtimeOwner })
   });
 }
 
@@ -313,7 +299,7 @@ function frameworkBinScript(paths, packageName, binName = packageName) {
   return path.resolve(path.dirname(packageJsonPath), binPath);
 }
 
-export function frameworkEnv(paths, { env = process.env, nodePath } = {}) {
+export function frameworkEnv(paths, { env = process.env, nodePath, runtimeOwner } = {}) {
   const frameworkNodePath = pathInUrl(paths.frameworkRoot, 'node_modules');
   const currentNodePath = env.NODE_PATH;
   const nextEnv = {
@@ -328,6 +314,8 @@ export function frameworkEnv(paths, { env = process.env, nodePath } = {}) {
       ? `${path.dirname(nodePath)}${path.delimiter}${currentPath}`
       : path.dirname(nodePath);
   }
+
+  if (runtimeOwner) nextEnv.OXIQUILL_RUNTIME_OWNER = runtimeOwner;
 
   return nextEnv;
 }

--- a/packages/oxiquill/src/components/doc-runtime/ArtifactErrorBoundary.tsx
+++ b/packages/oxiquill/src/components/doc-runtime/ArtifactErrorBoundary.tsx
@@ -1,8 +1,10 @@
 import { Component, type ComponentChildren } from 'preact';
+import type { RuntimeLabels } from '../../lib/doc-runtime/runtime-localization.js';
 
 interface ArtifactErrorBoundaryProps {
   children: ComponentChildren;
   index: number;
+  labels: RuntimeLabels;
   resetKey: object;
 }
 
@@ -23,9 +25,9 @@ export default class ArtifactErrorBoundary extends Component<ArtifactErrorBounda
     }
   }
 
-  render({ children, index }: ArtifactErrorBoundaryProps, { error }: ArtifactErrorBoundaryState) {
+  render({ children, index, labels }: ArtifactErrorBoundaryProps, { error }: ArtifactErrorBoundaryState) {
     if (error) {
-      return <ArtifactError message={`Artifact ${index + 1} failed to render: ${error}`} />;
+      return <ArtifactError message={labels.artifactRenderError(index + 1, error)} />;
     }
     return children;
   }

--- a/packages/oxiquill/src/components/doc-runtime/CellOutput.tsx
+++ b/packages/oxiquill/src/components/doc-runtime/CellOutput.tsx
@@ -9,30 +9,61 @@ import OutputRenderer from './OutputRenderer.js';
 type RuntimeLabels = ReturnType<typeof labelsForLanguage>;
 
 export function CellOutput({
+  cellTitle,
   error,
   isRunning,
   labels,
+  outputId,
   result,
   runMode
 }: {
+  cellTitle: string;
   error?: string;
   isRunning: boolean;
   labels: RuntimeLabels;
+  outputId: string;
   result?: CellExecutionResult | NormalizedCellExecutionResult;
   runMode: CellManifest['run'];
 }) {
-  if (error) return <p class="error-state">{error}</p>;
-  if (isRunning) return <p class="empty-state">{labels.runningCell}</p>;
-  if (!result) {
-    return <p class="empty-state">{idleOutputMessage(runMode, labels)}</p>;
-  }
-
-  const outputResults =
-    'outputResults' in result ? result.outputResults : normalizeCellExecutionResult(result).outputResults;
+  const outputResults = result
+    ? 'outputResults' in result
+      ? result.outputResults
+      : normalizeCellExecutionResult(result).outputResults
+    : undefined;
+  const liveMessage = isRunning
+    ? labels.cellRunningAnnouncement
+    : result
+      ? outputResults?.length
+        ? labels.cellCompleted
+        : labels.cellCompletedWithoutOutput
+      : '';
 
   return (
-    <div class="doc-cell__outputs">
-      <OutputRenderer outputs={outputResults} />
+    <div
+      id={outputId}
+      class="doc-cell__output-region"
+      aria-busy={isRunning}
+      aria-label={labels.cellOutput(cellTitle)}
+      role="region"
+    >
+      <p class="doc-visually-hidden" aria-atomic="true" aria-live="polite" role="status">
+        {liveMessage}
+      </p>
+      {error ? (
+        <p class="error-state" role="alert">
+          {labels.executionErrorLabel} <span>{labels.diagnosticDetail(error)}</span>
+        </p>
+      ) : isRunning ? (
+        <p class="empty-state">{labels.runningCell}</p>
+      ) : !result ? (
+        <p class="empty-state">{idleOutputMessage(runMode, labels)}</p>
+      ) : outputResults?.length ? (
+        <div class="doc-cell__outputs">
+          <OutputRenderer idPrefix={outputId} labels={labels} outputs={outputResults} />
+        </div>
+      ) : (
+        <p class="empty-state">{labels.cellCompletedWithoutOutput}</p>
+      )}
     </div>
   );
 }

--- a/packages/oxiquill/src/components/doc-runtime/ChartOutput.tsx
+++ b/packages/oxiquill/src/components/doc-runtime/ChartOutput.tsx
@@ -1,8 +1,11 @@
 import { useEffect, useRef, useState } from 'preact/hooks';
-import type { ChartSpec } from '../../lib/doc-runtime/types.js';
+import type { RuntimeLabels } from '../../lib/doc-runtime/runtime-localization.js';
+import type { ChartArtifact, ChartSpec } from '../../lib/doc-runtime/types.js';
 
 interface ChartOutputProps {
-  spec: ChartSpec;
+  artifact: ChartArtifact;
+  idPrefix: string;
+  labels: RuntimeLabels;
 }
 
 type EChartsCore = typeof import('echarts/core');
@@ -40,7 +43,8 @@ function loadECharts(): Promise<EChartsCore> {
   return echartsModule;
 }
 
-export default function ChartOutput({ spec }: ChartOutputProps) {
+export default function ChartOutput({ artifact, idPrefix, labels }: ChartOutputProps) {
+  const { spec } = artifact;
   const element = useRef<HTMLDivElement>(null);
   const chart = useRef<EChartsInstance>();
   const latestSpec = useRef(spec);
@@ -86,7 +90,23 @@ export default function ChartOutput({ spec }: ChartOutputProps) {
     }
   }, [spec]);
 
-  return <div ref={element} class="doc-plot" data-testid="doc-plot" />;
+  const titleId = `${idPrefix}-title`;
+  const descriptionId = `${idPrefix}-description`;
+  const title = artifact.title ?? spec.title ?? labels.chartTitle(spec.kind);
+
+  return (
+    <figure class="doc-chart-output" aria-labelledby={titleId} aria-describedby={descriptionId}>
+      <figcaption id={titleId}>
+        <strong>{title}</strong>
+        {artifact.caption ? <span>{artifact.caption}</span> : null}
+      </figcaption>
+      <div ref={element} class="doc-plot" aria-hidden="true" data-testid="doc-plot" />
+      <p id={descriptionId} class="doc-chart-output__summary">
+        <span class="doc-visually-hidden">{labels.chartCaption}: </span>
+        {chartDataSummary(spec, labels)}
+      </p>
+    </figure>
+  );
 }
 
 function toError(value: unknown): Error {
@@ -117,6 +137,72 @@ export function chartSpecToEChartsOptions(spec: ChartSpec): EChartsOptions {
   }
 
   return base;
+}
+
+export function chartDataSummary(spec: ChartSpec, labels: RuntimeLabels): string {
+  const details = chartSummaryDetails(spec, labels);
+  return details.dataCount === 0 ? labels.noChartData : labels.chartSummary(details);
+}
+
+function chartSummaryDetails(spec: ChartSpec, labels: RuntimeLabels) {
+  const numberFormat = new Intl.NumberFormat(labels.locale === 'ja' ? 'ja-JP' : 'en-US', {
+    maximumSignificantDigits: 6
+  });
+  const range = (values: readonly unknown[]) => numericRange(values, numberFormat);
+
+  switch (spec.kind) {
+    case 'line':
+    case 'scatter':
+    case 'area': {
+      const points = spec.series.flatMap((series) => series.points);
+      return {
+        dataCount: points.length,
+        seriesCount: spec.series.length,
+        seriesNames: seriesNames(spec.series),
+        xRange: range(points.map((point) => point[0])),
+        yRange: range(points.map((point) => point[1]))
+      };
+    }
+    case 'bar': {
+      const values = spec.series.flatMap((series) => series.values);
+      return {
+        dataCount: values.length,
+        seriesCount: spec.series.length,
+        seriesNames: seriesNames(spec.series),
+        yRange: range(values)
+      };
+    }
+    case 'histogram':
+      return {
+        dataCount: spec.bins.length,
+        seriesCount: 1,
+        seriesNames: '',
+        xRange: range(spec.bins.flatMap((bin) => [bin[0], bin[1]])),
+        yRange: range(spec.bins.map((bin) => bin[2]))
+      };
+    case 'heatmap':
+      return {
+        dataCount: spec.data.length,
+        seriesCount: 1,
+        seriesNames: '',
+        xRange: range(spec.data.map((item) => item[0])),
+        yRange: range(spec.data.map((item) => item[2]))
+      };
+  }
+}
+
+function seriesNames(series: readonly { name?: string }[]): string {
+  return series.flatMap((item) => (item.name ? [item.name] : [])).join(', ');
+}
+
+function numericRange(values: readonly unknown[], numberFormat: Intl.NumberFormat): string | undefined {
+  const numbers = values.filter((value): value is number => typeof value === 'number' && Number.isFinite(value));
+  if (numbers.length === 0) return undefined;
+  const minimum = Math.min(...numbers);
+  const maximum = Math.max(...numbers);
+  return minimum === maximum
+    ? numberFormat.format(minimum)
+    : `${numberFormat.format(minimum)}–${numberFormat.format(maximum)}`;
 }
 
 function chartSeries(spec: ChartSpec): readonly Record<string, unknown>[] {

--- a/packages/oxiquill/src/components/doc-runtime/ChartOutput.tsx
+++ b/packages/oxiquill/src/components/doc-runtime/ChartOutput.tsx
@@ -91,14 +91,19 @@ export default function ChartOutput({ artifact, idPrefix, labels }: ChartOutputP
   }, [spec]);
 
   const titleId = `${idPrefix}-title`;
+  const captionId = artifact.caption ? `${idPrefix}-caption` : undefined;
   const descriptionId = `${idPrefix}-description`;
   const title = artifact.title ?? spec.title ?? labels.chartTitle(spec.kind);
 
   return (
-    <figure class="doc-chart-output" aria-labelledby={titleId} aria-describedby={descriptionId}>
-      <figcaption id={titleId}>
-        <strong>{title}</strong>
-        {artifact.caption ? <span>{artifact.caption}</span> : null}
+    <figure
+      class="doc-chart-output"
+      aria-labelledby={titleId}
+      aria-describedby={[captionId, descriptionId].filter(Boolean).join(' ')}
+    >
+      <figcaption>
+        <strong id={titleId}>{title}</strong>
+        {artifact.caption ? <span id={captionId}>{artifact.caption}</span> : null}
       </figcaption>
       <div ref={element} class="doc-plot" aria-hidden="true" data-testid="doc-plot" />
       <p id={descriptionId} class="doc-chart-output__summary">

--- a/packages/oxiquill/src/components/doc-runtime/InputControl.tsx
+++ b/packages/oxiquill/src/components/doc-runtime/InputControl.tsx
@@ -1,59 +1,79 @@
 import { coerceInputValue, formatInputValue } from '../../lib/doc-runtime/interactive-cell-model.js';
+import type { RuntimeLabels } from '../../lib/doc-runtime/runtime-localization.js';
 import type { InputSpec } from '../../lib/doc-runtime/types.js';
+import { useState } from 'preact/hooks';
 
 type InputValue = string | number | boolean;
 
 export function InputControl({
   cellId,
   input,
+  labels,
   value,
   onChange
 }: {
   cellId: string;
   input: InputSpec;
+  labels: RuntimeLabels;
   onChange: (value: InputValue) => void;
   value: InputValue;
 }) {
-  const id = inputControlId(cellId, input.name);
+  const ids = inputControlIds(cellId, input.name);
+  const [validation, setValidation] = useState<string>();
+  const descriptionId = input.description ? ids.description : undefined;
+  const validationId = validation ? ids.validation : undefined;
 
   if (input.type === 'checkbox') {
     return (
-      <label class="doc-input doc-input--checkbox" for={id}>
-        <input
-          id={id}
-          type="checkbox"
-          checked={Boolean(value)}
-          onInput={(event) => onChange(event.currentTarget.checked)}
-        />
-        <span>{input.label}</span>
-      </label>
+      <div class="doc-input">
+        <label class="doc-input--checkbox" for={ids.control} id={ids.label}>
+          <input
+            id={ids.control}
+            aria-describedby={descriptionId}
+            type="checkbox"
+            checked={Boolean(value)}
+            onInput={(event) => onChange(event.currentTarget.checked)}
+          />
+          <span>{input.label}</span>
+        </label>
+        <InputDescription id={descriptionId} description={input.description} />
+      </div>
     );
   }
 
   if (input.type === 'select') {
     return (
-      <label class="doc-input" for={id}>
-        <span>{input.label}</span>
-        <select id={id} value={String(value)} onInput={(event) => onChange(event.currentTarget.value)}>
+      <div class="doc-input">
+        <label for={ids.control} id={ids.label}>
+          {input.label}
+        </label>
+        <select
+          id={ids.control}
+          aria-describedby={descriptionId}
+          value={String(value)}
+          onInput={(event) => onChange(event.currentTarget.value)}
+        >
           {input.options.map((option) => (
             <option key={option.value} value={option.value}>
               {option.label}
             </option>
           ))}
         </select>
-      </label>
+        <InputDescription id={descriptionId} description={input.description} />
+      </div>
     );
   }
 
   if (input.type === 'radio') {
     return (
-      <fieldset class="doc-input doc-input--radio">
-        <legend>{input.label}</legend>
-        {input.options.map((option) => (
-          <label key={option.value}>
+      <fieldset class="doc-input doc-input--radio" aria-describedby={descriptionId}>
+        <legend id={ids.label}>{input.label}</legend>
+        {input.options.map((option, optionIndex) => (
+          <label key={option.value} for={`${ids.control}-option-${optionIndex}`}>
             <input
+              id={`${ids.control}-option-${optionIndex}`}
               type="radio"
-              name={id}
+              name={ids.control}
               value={option.value}
               checked={String(value) === option.value}
               onInput={(event) => onChange(event.currentTarget.value)}
@@ -61,28 +81,42 @@ export function InputControl({
             <span>{option.label}</span>
           </label>
         ))}
+        <InputDescription id={descriptionId} description={input.description} />
       </fieldset>
     );
   }
 
   if (input.type === 'textarea') {
     return (
-      <label class="doc-input" for={id}>
-        <span>{input.label}</span>
-        <textarea id={id} value={String(value)} onInput={(event) => onChange(event.currentTarget.value)} />
-      </label>
+      <div class="doc-input">
+        <label for={ids.control} id={ids.label}>
+          {input.label}
+        </label>
+        <textarea
+          id={ids.control}
+          aria-describedby={descriptionId}
+          value={String(value)}
+          onInput={(event) => onChange(event.currentTarget.value)}
+        />
+        <InputDescription id={descriptionId} description={input.description} />
+      </div>
     );
   }
 
   if (input.type === 'range') {
     return (
-      <label class="doc-input" for={id}>
-        <span>
-          {input.label} <strong data-testid={`${input.name}-value`}>{formatInputValue(value)}</strong>
-        </span>
+      <div class="doc-input">
+        <div class="doc-input__label-row">
+          <label for={ids.control} id={ids.label}>
+            {input.label}
+          </label>
+          <output id={ids.value} for={ids.control} data-testid={`${input.name}-value`}>
+            {formatInputValue(value)}
+          </output>
+        </div>
         <input
-          id={id}
-          aria-label={input.name}
+          id={ids.control}
+          aria-describedby={describedBy(descriptionId, ids.value)}
           type="range"
           min={input.min}
           max={input.max}
@@ -90,31 +124,76 @@ export function InputControl({
           value={Number(value)}
           onInput={(event) => onChange(Number(event.currentTarget.value))}
         />
-      </label>
+        <InputDescription id={descriptionId} description={input.description} />
+      </div>
     );
   }
 
   const numeric = input.type === 'number' || input.type === 'integer';
 
   return (
-    <label class="doc-input" for={id}>
-      <span>{input.label}</span>
+    <div class="doc-input">
+      <label for={ids.control} id={ids.label}>
+        {input.label}
+      </label>
       <input
-        id={id}
-        aria-label={input.name}
+        id={ids.control}
+        aria-describedby={descriptionId}
+        aria-errormessage={validationId}
+        aria-invalid={validation ? true : undefined}
         type={numeric ? 'number' : 'text'}
         min={input.min}
         max={input.max}
-        step={input.step}
+        step={input.type === 'integer' ? (input.step ?? 1) : input.step}
         value={String(value)}
         onInput={(event) => {
+          setValidation(numeric ? inputValidationMessage(event.currentTarget.validity, input, labels) : undefined);
           onChange(coerceInputValue(input, event.currentTarget.value));
         }}
       />
-    </label>
+      <InputDescription id={descriptionId} description={input.description} />
+      {validation ? (
+        <p id={ids.validation} class="doc-input__validation error-state" role="alert">
+          {validation}
+        </p>
+      ) : null}
+    </div>
   );
 }
 
 export function inputControlId(cellId: string, inputName: string): string {
   return `doc-input-${cellId}-${inputName}`;
+}
+
+export function inputControlIds(cellId: string, inputName: string) {
+  const control = inputControlId(cellId, inputName);
+  return {
+    control,
+    description: `${control}-description`,
+    label: `${control}-label`,
+    validation: `${control}-validation`,
+    value: `${control}-value`
+  };
+}
+
+function InputDescription({ description, id }: { description?: string; id?: string }) {
+  return description && id ? (
+    <p id={id} class="doc-input__description">
+      {description}
+    </p>
+  ) : null;
+}
+
+function describedBy(...ids: Array<string | undefined>): string | undefined {
+  const value = ids.filter(Boolean).join(' ');
+  return value || undefined;
+}
+
+function inputValidationMessage(validity: ValidityState, input: InputSpec, labels: RuntimeLabels): string | undefined {
+  if (validity.valid) return undefined;
+  if (validity.badInput) return labels.inputNumber;
+  if (validity.rangeUnderflow && input.min !== undefined) return labels.inputMinimum(input.min);
+  if (validity.rangeOverflow && input.max !== undefined) return labels.inputMaximum(input.max);
+  if (validity.stepMismatch) return labels.inputStep;
+  return labels.inputNumber;
 }

--- a/packages/oxiquill/src/components/doc-runtime/InteractiveCell.tsx
+++ b/packages/oxiquill/src/components/doc-runtime/InteractiveCell.tsx
@@ -1,9 +1,6 @@
 import { useState } from 'preact/hooks';
-import {
-  labelsForLanguage,
-  shouldShowInputControls,
-  shouldShowRunButton
-} from '../../lib/doc-runtime/interactive-cell-model.js';
+import { shouldShowInputControls, shouldShowRunButton } from '../../lib/doc-runtime/interactive-cell-model.js';
+import type { RuntimeLabels } from '../../lib/doc-runtime/runtime-localization.js';
 import type { CellManifest } from '../../lib/doc-runtime/types.js';
 import { CellOutput } from './CellOutput.js';
 import { InputControl } from './InputControl.js';
@@ -24,7 +21,9 @@ export default function InteractiveCell({ cell: initialCell, cellId }: Interacti
   if (!cell) {
     return (
       <section class="doc-cell doc-cell--error">
-        <p class="error-state">{labels.unknownCell(cellId)}</p>
+        <p class="error-state" role="alert">
+          {labels.unknownCell(cellId)}
+        </p>
       </section>
     );
   }
@@ -38,30 +37,48 @@ function InteractiveCellPanel({
   runtimeVersion
 }: {
   cell: CellManifest;
-  labels: ReturnType<typeof labelsForLanguage>;
+  labels: RuntimeLabels;
   runtimeVersion: string;
 }) {
   const [isSourceVisible, setIsSourceVisible] = useState(cell.showSource);
   const runtime = useInteractiveCellRun(cell, runtimeVersion);
+  const ids = interactiveCellIds(cell.id);
 
   return (
-    <section class="doc-cell" data-cell-id={cell.id} data-language={cell.language} data-testid={`cell-${cell.id}`}>
+    <section
+      class="doc-cell"
+      aria-labelledby={ids.title}
+      data-cell-id={cell.id}
+      data-language={cell.language}
+      data-testid={`cell-${cell.id}`}
+    >
       <div class="doc-cell__header">
         <div>
-          <p class="doc-cell__eyebrow">{runtimeEyebrow(cell.language)}</p>
-          <h3>{cell.title}</h3>
+          <p class="doc-cell__eyebrow">{labels.runtimeLanguage(cell.language)}</p>
+          <h3 id={ids.title}>{cell.title}</h3>
         </div>
-        <div class="doc-cell__actions">
+        <div class="doc-cell__actions" role="group" aria-labelledby={ids.actionsLabel}>
+          <span id={ids.actionsLabel} class="doc-visually-hidden">
+            {labels.cellActions}
+          </span>
           <button
             type="button"
             class="secondary-button"
+            aria-controls={ids.source}
             aria-expanded={isSourceVisible}
             onClick={() => setIsSourceVisible((visible) => !visible)}
           >
             {isSourceVisible ? labels.hideCode : labels.showCode}
           </button>
           {shouldShowRunButton(cell.run) ? (
-            <button type="button" class="run-button" disabled={runtime.isRunning} onClick={runtime.run}>
+            <button
+              type="button"
+              class="run-button"
+              aria-busy={runtime.isRunning}
+              aria-controls={ids.output}
+              disabled={runtime.isRunning}
+              onClick={runtime.run}
+            >
               {runtime.isRunning ? labels.running : labels.run}
             </button>
           ) : null}
@@ -69,22 +86,27 @@ function InteractiveCellPanel({
       </div>
 
       {shouldShowInputControls(cell.run) && cell.inputs.length > 0 ? (
-        <div class="doc-input-grid">
+        <fieldset class="doc-input-grid">
+          <legend id={ids.inputsLabel} class="doc-visually-hidden">
+            {labels.cellInputs}
+          </legend>
           {cell.inputs.map((input) => (
             <InputControl
               key={input.name}
               cellId={cell.id}
               input={input}
+              labels={labels}
               value={runtime.values[input.name]}
               onChange={(value) => runtime.setInputValue(input.name, value)}
             />
           ))}
-        </div>
+        </fieldset>
       ) : null}
 
       {isSourceVisible ? (
         <div
           key={`${cell.id}:${cell.source}`}
+          id={ids.source}
           class="doc-source"
           data-testid="cell-source"
           dangerouslySetInnerHTML={{ __html: cell.sourceHtml }}
@@ -92,23 +114,25 @@ function InteractiveCellPanel({
       ) : null}
 
       <CellOutput
+        cellTitle={cell.title}
         result={runtime.result}
         error={runtime.error}
         isRunning={runtime.isRunning}
         labels={labels}
+        outputId={ids.output}
         runMode={cell.run}
       />
     </section>
   );
 }
 
-function runtimeEyebrow(language: CellManifest['language']): string {
-  switch (language) {
-    case 'rust':
-      return 'Rust + Wasm';
-    case 'python':
-      return 'Python + Pyodide';
-    case 'haskell':
-      return 'Haskell + WASI';
-  }
+function interactiveCellIds(cellId: string) {
+  const root = `doc-cell-${cellId}`;
+  return {
+    actionsLabel: `${root}-actions-label`,
+    inputsLabel: `${root}-inputs-label`,
+    output: `${root}-output`,
+    source: `${root}-source`,
+    title: `${root}-title`
+  };
 }

--- a/packages/oxiquill/src/components/doc-runtime/InteractiveCell.tsx
+++ b/packages/oxiquill/src/components/doc-runtime/InteractiveCell.tsx
@@ -76,8 +76,10 @@ function InteractiveCellPanel({
               class="run-button"
               aria-busy={runtime.isRunning}
               aria-controls={ids.output}
-              disabled={runtime.isRunning}
-              onClick={runtime.run}
+              aria-disabled={runtime.isRunning}
+              onClick={() => {
+                if (!runtime.isRunning) runtime.run();
+              }}
             >
               {runtime.isRunning ? labels.running : labels.run}
             </button>

--- a/packages/oxiquill/src/components/doc-runtime/MermaidDiagram.tsx
+++ b/packages/oxiquill/src/components/doc-runtime/MermaidDiagram.tsx
@@ -1,5 +1,6 @@
 import type { MermaidConfig } from 'mermaid';
 import { useEffect, useMemo, useRef, useState } from 'preact/hooks';
+import { labelsForLanguage, type MermaidDiagramKind } from '../../lib/doc-runtime/runtime-localization.js';
 
 interface MermaidDiagramProps {
   diagramId: string;
@@ -19,6 +20,8 @@ export default function MermaidDiagram({ diagramId, source }: MermaidDiagramProp
   const [state, setState] = useState<RenderState>('idle');
   const [colorScheme, setColorScheme] = useState<MermaidColorScheme>(() => getMermaidColorScheme());
   const renderId = useMemo(() => `doc-${diagramId}`, [diagramId]);
+  const labels = useMemo(() => labelsForLanguage(globalThis.document?.documentElement.lang), []);
+  const ids = mermaidIds(diagramId);
 
   useEffect(() => {
     setColorScheme(getMermaidColorScheme());
@@ -55,13 +58,13 @@ export default function MermaidDiagram({ diagramId, source }: MermaidDiagramProp
         if (cancelled) return;
 
         renderElement.innerHTML = svg;
+        hideRenderedSvgFromAccessibility(renderElement);
         bindFunctions?.(renderElement);
         setState('ready');
       } catch (caught) {
         if (cancelled) return;
 
         const message = caught instanceof Error ? caught.message : String(caught);
-        renderElement.textContent = 'Mermaid diagram could not be rendered.';
         setError(message);
         setState('error');
       }
@@ -76,19 +79,65 @@ export default function MermaidDiagram({ diagramId, source }: MermaidDiagramProp
   }, [colorScheme, renderId, source]);
 
   return (
-    <figure class="mermaid-diagram" data-state={state} data-testid="mermaid-diagram">
-      <div ref={container} class="mermaid-diagram__surface" aria-label="Mermaid diagram" />
+    <figure
+      class="mermaid-diagram"
+      aria-labelledby={ids.title}
+      aria-describedby={ids.description}
+      data-state={state}
+      data-testid="mermaid-diagram"
+    >
+      <span id={ids.title} class="doc-visually-hidden">
+        {labels.mermaidTitle(mermaidDiagramKind(source))}
+      </span>
+      <span id={ids.description} class="doc-visually-hidden">
+        {labels.mermaidDescription(source)}
+      </span>
+      <div
+        ref={container}
+        class="mermaid-diagram__surface"
+        aria-describedby={ids.description}
+        aria-labelledby={ids.title}
+        role="img"
+      />
       {state === 'idle' || state === 'rendering' ? (
         <figcaption class="empty-state" role="status">
-          Rendering diagram...
+          {labels.mermaidLoading}
         </figcaption>
       ) : error ? (
         <figcaption class="error-state" role="alert">
-          {error}
+          {labels.mermaidError(error)}
         </figcaption>
       ) : null}
     </figure>
   );
+}
+
+export function mermaidDiagramKind(source: string): MermaidDiagramKind {
+  const firstLine = source
+    .split('\n')
+    .map((line) => line.trim())
+    .find((line) => line !== '' && !line.startsWith('%%'))
+    ?.toLowerCase();
+  if (!firstLine) return 'diagram';
+  if (firstLine.startsWith('flowchart') || firstLine.startsWith('graph')) return 'flowchart';
+  if (firstLine.startsWith('sequencediagram')) return 'sequence';
+  if (firstLine.startsWith('statediagram')) return 'state';
+  if (firstLine.startsWith('classdiagram')) return 'class';
+  if (firstLine.startsWith('erdiagram')) return 'entityRelationship';
+  if (firstLine.startsWith('journey')) return 'journey';
+  if (firstLine.startsWith('timeline')) return 'timeline';
+  return 'diagram';
+}
+
+function mermaidIds(diagramId: string) {
+  const root = `doc-mermaid-${diagramId}`;
+  return { description: `${root}-description`, title: `${root}-title` };
+}
+
+function hideRenderedSvgFromAccessibility(container: HTMLDivElement): void {
+  const svg = container.querySelector('svg');
+  svg?.setAttribute('aria-hidden', 'true');
+  svg?.setAttribute('focusable', 'false');
 }
 
 export function getMermaidColorScheme(): MermaidColorScheme {

--- a/packages/oxiquill/src/components/doc-runtime/OutputRenderer.tsx
+++ b/packages/oxiquill/src/components/doc-runtime/OutputRenderer.tsx
@@ -4,6 +4,8 @@ import type {
   ValidatedJsonArtifact,
   ValidatedOutputArtifact
 } from '../../lib/doc-runtime/output-artifact-validation.js';
+import type { RuntimeLabels } from '../../lib/doc-runtime/runtime-localization.js';
+import { labelsForLanguage } from '../../lib/doc-runtime/runtime-localization.js';
 import type { ComponentChildren } from 'preact';
 import { useEffect, useState } from 'preact/hooks';
 import type { ChartSpec, TextArtifact } from '../../lib/doc-runtime/types.js';
@@ -18,43 +20,71 @@ type ChartRendererState =
 let chartOutputModuleReady: Promise<ChartOutputModule> | undefined;
 
 interface OutputRendererProps {
+  idPrefix?: string;
+  labels?: RuntimeLabels;
   outputs: readonly ValidatedArtifactResult[];
 }
 
-export default function OutputRenderer({ outputs }: OutputRendererProps) {
+export default function OutputRenderer({
+  idPrefix = 'doc-output',
+  labels = labelsForLanguage(globalThis.document?.documentElement.lang),
+  outputs
+}: OutputRendererProps) {
   return (
     <>
       {outputs.map((output, index) => (
-        <ArtifactErrorBoundary key={artifactKey(output, index)} index={output.index} resetKey={output}>
-          <ArtifactOutput output={output} />
+        <ArtifactErrorBoundary key={artifactKey(output, index)} index={output.index} labels={labels} resetKey={output}>
+          <ArtifactOutput idPrefix={`${idPrefix}-artifact-${output.index}`} labels={labels} output={output} />
         </ArtifactErrorBoundary>
       ))}
     </>
   );
 }
 
-function ArtifactOutput({ output }: { output: ValidatedArtifactResult }) {
+function ArtifactOutput({
+  idPrefix,
+  labels,
+  output
+}: {
+  idPrefix: string;
+  labels: RuntimeLabels;
+  output: ValidatedArtifactResult;
+}) {
   if (output.status === 'error') {
-    return <ArtifactError message={`Artifact ${output.index + 1}: ${output.message}`} />;
+    return <ArtifactError message={labels.artifactError(output.index + 1, labels.diagnosticDetail(output.message))} />;
   }
 
   switch (output.artifact.kind) {
     case 'text':
-      return <TextOutput output={output.artifact} />;
+      return <TextOutput labels={labels} output={output.artifact} />;
     case 'json':
-      return <JsonOutput output={output.artifact} />;
+      return <JsonOutput labels={labels} output={output.artifact} />;
     case 'html':
-      return <HtmlOutput output={output.artifact} />;
+      return <HtmlOutput labels={labels} output={output.artifact} />;
     case 'chart':
-      return <LazyChartOutput spec={output.artifact.spec} />;
+      return <LazyChartOutput artifact={output.artifact} idPrefix={idPrefix} labels={labels} />;
     case 'table':
-      return <TableOutput table={output.artifact} />;
+      return <TableOutput idPrefix={idPrefix} labels={labels} table={output.artifact} />;
     case 'image':
-      return <ImageOutput output={output.artifact} />;
+      return <ImageOutput labels={labels} output={output.artifact} />;
   }
 }
 
-export function LazyChartOutput({ load = loadChartOutput, spec }: { load?: LoadChartOutput; spec: ChartSpec }) {
+export function LazyChartOutput({
+  artifact,
+  idPrefix = 'doc-chart',
+  labels = labelsForLanguage(globalThis.document?.documentElement.lang),
+  load = loadChartOutput,
+  spec
+}: {
+  artifact?: Extract<ValidatedOutputArtifact, { kind: 'chart' }>;
+  spec?: ChartSpec;
+} & {
+  idPrefix?: string;
+  labels?: RuntimeLabels;
+  load?: LoadChartOutput;
+}) {
+  const chartArtifact = artifact ?? { kind: 'chart' as const, spec: spec as ChartSpec };
   const [state, setState] = useState<ChartRendererState>({ status: 'loading' });
 
   useEffect(() => {
@@ -83,7 +113,7 @@ export function LazyChartOutput({ load = loadChartOutput, spec }: { load?: LoadC
   if (state.status === 'loading') {
     return (
       <p class="empty-state" data-testid="chart-loading" role="status">
-        Loading chart renderer...
+        {labels.chartLoading}
       </p>
     );
   }
@@ -91,21 +121,21 @@ export function LazyChartOutput({ load = loadChartOutput, spec }: { load?: LoadC
   if (state.status === 'error') {
     return (
       <p class="error-state" data-testid="artifact-error" role="alert">
-        Chart renderer could not be loaded: {state.message}
+        {labels.chartLoadError(state.message)}
       </p>
     );
   }
 
   const ChartOutput = state.module.default;
-  return <ChartOutput spec={spec} />;
+  return <ChartOutput artifact={chartArtifact} idPrefix={idPrefix} labels={labels} />;
 }
 
-function TextOutput({ output }: { output: TextArtifact }) {
+function TextOutput({ labels, output }: { labels: RuntimeLabels; output: TextArtifact }) {
   const isError = output.stream === 'stderr';
   const className = isError ? 'error-output' : 'run-output';
 
   return (
-    <OutputWithTruncation truncated={output.truncated}>
+    <OutputWithTruncation labels={labels} truncated={output.truncated}>
       <pre class={className} data-testid={isError ? undefined : 'run-output'}>
         <code>{output.content}</code>
       </pre>
@@ -113,9 +143,9 @@ function TextOutput({ output }: { output: TextArtifact }) {
   );
 }
 
-function JsonOutput({ output }: { output: ValidatedJsonArtifact }) {
+function JsonOutput({ labels, output }: { labels: RuntimeLabels; output: ValidatedJsonArtifact }) {
   return (
-    <OutputWithTruncation truncated={output.truncated}>
+    <OutputWithTruncation labels={labels} truncated={output.truncated}>
       <pre class="run-output" data-testid="value-output">
         <code>{output.formattedValue}</code>
       </pre>
@@ -123,11 +153,11 @@ function JsonOutput({ output }: { output: ValidatedJsonArtifact }) {
   );
 }
 
-function ImageOutput({ output }: { output: ValidatedImageArtifact }) {
+function ImageOutput({ labels, output }: { labels: RuntimeLabels; output: ValidatedImageArtifact }) {
   return (
     <figure class="doc-image-output">
       <img
-        alt={output.alt ?? output.title ?? 'Image output'}
+        alt={output.alt ?? output.title ?? labels.imageOutput}
         data-testid="image-output"
         src={imageArtifactSource(output)}
       />
@@ -142,25 +172,39 @@ function ImageOutput({ output }: { output: ValidatedImageArtifact }) {
   );
 }
 
-function HtmlOutput({ output }: { output: Extract<ValidatedOutputArtifact, { kind: 'html' }> }) {
+function HtmlOutput({
+  labels,
+  output
+}: {
+  labels: RuntimeLabels;
+  output: Extract<ValidatedOutputArtifact, { kind: 'html' }>;
+}) {
   return (
     <iframe
       class="doc-html-output"
       data-testid="html-output"
       sandbox=""
       srcdoc={output.html}
-      title={output.title ?? 'HTML output'}
+      title={output.title ?? labels.htmlOutput}
     />
   );
 }
 
-function OutputWithTruncation({ children, truncated }: { children: ComponentChildren; truncated?: boolean }) {
+function OutputWithTruncation({
+  children,
+  labels,
+  truncated
+}: {
+  children: ComponentChildren;
+  labels: RuntimeLabels;
+  truncated?: boolean;
+}) {
   return (
     <div class="doc-output-artifact">
       {children}
       {truncated ? (
         <p class="doc-output-artifact__notice" data-testid="artifact-truncated">
-          Output truncated.
+          {labels.outputTruncated}
         </p>
       ) : null}
     </div>

--- a/packages/oxiquill/src/components/doc-runtime/TableOutput.tsx
+++ b/packages/oxiquill/src/components/doc-runtime/TableOutput.tsx
@@ -54,7 +54,7 @@ export default function TableOutput({
   async function copyVisibleCsv(): Promise<void> {
     if (copyStatus?.kind === 'copying') return;
     setCopyStatus({ kind: 'copying', message: labels.copyingCsv });
-    const converted = tableToCsv(table.columns, currentRows);
+    const converted = tableToCsv(table.columns, currentRows, labels);
     if (!converted.ok) {
       setCopyStatus({ kind: 'error', message: labels.copyCsvError(converted.error) });
       return;
@@ -189,17 +189,21 @@ export function visibleRows(rows: readonly unknown[][], page: number, pageSize: 
   return rows.slice(page * pageSize, (page + 1) * pageSize);
 }
 
-export function tableToCsv(columns: readonly TableColumn[], rows: readonly unknown[][]): TableCsvResult {
+export function tableToCsv(
+  columns: readonly TableColumn[],
+  rows: readonly unknown[][],
+  labels: RuntimeLabels = labelsForLanguage('en')
+): TableCsvResult {
   try {
     return {
       ok: true,
       csv: [
-        columns.map((column) => csvCell(column.label)).join(','),
+        columns.map((column) => csvCell(column.label, labels)).join(','),
         ...rows.map((row, rowIndex) => {
           if (row.length !== columns.length) {
-            throw new Error(`Row ${rowIndex + 1} has ${row.length} cells; expected ${columns.length}.`);
+            throw new Error(labels.tableRowWidthError(rowIndex + 1, row.length, columns.length));
           }
-          return columns.map((_, index) => csvCell(row[index])).join(',');
+          return columns.map((_, index) => csvCell(row[index], labels)).join(',');
         })
       ].join('\n')
     };
@@ -218,7 +222,7 @@ export function formatTableCell(value: unknown, labels: RuntimeLabels = labelsFo
   }
   if (typeof value === 'boolean') return value ? 'true' : 'false';
   if (typeof value === 'string') return value;
-  throw new Error(`Unsupported validated table cell type: ${typeof value}.`);
+  throw new Error(labels.tableCellTypeError(typeof value));
 }
 
 function compareCellValues(left: unknown, right: unknown): number {
@@ -230,13 +234,13 @@ function compareCellValues(left: unknown, right: unknown): number {
   return String(left).localeCompare(String(right));
 }
 
-function csvCell(value: unknown): string {
+function csvCell(value: unknown, labels: RuntimeLabels): string {
   if (value == null) return '';
   if (!['string', 'number', 'boolean'].includes(typeof value)) {
-    throw new Error(`Unsupported validated table cell type: ${typeof value}.`);
+    throw new Error(labels.tableCellTypeError(typeof value));
   }
   if (typeof value === 'number' && !Number.isFinite(value)) {
-    throw new Error('Validated table cells must contain finite numbers.');
+    throw new Error(labels.tableFiniteNumberError);
   }
   const text = String(value);
   return /[",\n\r]/u.test(text) ? `"${text.replace(/"/gu, '""')}"` : text;

--- a/packages/oxiquill/src/components/doc-runtime/TableOutput.tsx
+++ b/packages/oxiquill/src/components/doc-runtime/TableOutput.tsx
@@ -52,6 +52,7 @@ export default function TableOutput({
   }
 
   async function copyVisibleCsv(): Promise<void> {
+    if (copyStatus?.kind === 'copying') return;
     setCopyStatus({ kind: 'copying', message: labels.copyingCsv });
     const converted = tableToCsv(table.columns, currentRows);
     if (!converted.ok) {
@@ -134,8 +135,8 @@ export default function TableOutput({
           <button
             type="button"
             aria-busy={copyStatus?.kind === 'copying'}
+            aria-disabled={copyStatus?.kind === 'copying'}
             data-testid="table-copy-csv"
-            disabled={copyStatus?.kind === 'copying'}
             onClick={copyVisibleCsv}
           >
             {copyStatus?.kind === 'copying' ? labels.copyingCsv : labels.copyCsv}

--- a/packages/oxiquill/src/components/doc-runtime/TableOutput.tsx
+++ b/packages/oxiquill/src/components/doc-runtime/TableOutput.tsx
@@ -1,7 +1,10 @@
 import { useEffect, useMemo, useState } from 'preact/hooks';
+import { labelsForLanguage, type RuntimeLabels } from '../../lib/doc-runtime/runtime-localization.js';
 import type { TableArtifact, TableColumn } from '../../lib/doc-runtime/types.js';
 
 interface TableOutputProps {
+  idPrefix?: string;
+  labels?: RuntimeLabels;
   table: TableArtifact;
 }
 
@@ -14,13 +17,17 @@ type SortState = {
 export type TableCsvResult = { ok: true; csv: string } | { ok: false; error: string };
 
 type CopyStatus = {
-  kind: 'success' | 'error';
+  kind: 'copying' | 'success' | 'error';
   message: string;
 };
 
 const pageSizes = [10, 25, 50, 100] as const;
 
-export default function TableOutput({ table }: TableOutputProps) {
+export default function TableOutput({
+  idPrefix = 'doc-table',
+  labels = labelsForLanguage(globalThis.document?.documentElement.lang),
+  table
+}: TableOutputProps) {
   const [pageSize, setPageSize] = useState<(typeof pageSizes)[number]>(pageSizes[0]);
   const [page, setPage] = useState(0);
   const [sort, setSort] = useState<SortState>();
@@ -31,6 +38,8 @@ export default function TableOutput({ table }: TableOutputProps) {
   const currentRows = visibleRows(sortedRows, safePage, pageSize);
   const firstRow = sortedRows.length === 0 ? 0 : safePage * pageSize + 1;
   const lastRow = Math.min(sortedRows.length, (safePage + 1) * pageSize);
+  const captionId = `${idPrefix}-title`;
+  const descriptionId = table.caption ? `${idPrefix}-description` : undefined;
 
   useEffect(() => setCopyStatus(undefined), [table]);
 
@@ -43,33 +52,40 @@ export default function TableOutput({ table }: TableOutputProps) {
   }
 
   async function copyVisibleCsv(): Promise<void> {
+    setCopyStatus({ kind: 'copying', message: labels.copyingCsv });
     const converted = tableToCsv(table.columns, currentRows);
     if (!converted.ok) {
-      setCopyStatus({ kind: 'error', message: `Unable to copy CSV: ${converted.error}` });
+      setCopyStatus({ kind: 'error', message: labels.copyCsvError(converted.error) });
       return;
     }
     try {
       const clipboard = globalThis.navigator.clipboard;
       if (!clipboard) {
-        setCopyStatus({ kind: 'error', message: 'Unable to copy CSV: Clipboard access is unavailable.' });
+        setCopyStatus({ kind: 'error', message: labels.copyCsvError(labels.clipboardUnavailable) });
         return;
       }
       await clipboard.writeText(converted.csv);
-      setCopyStatus({ kind: 'success', message: 'Copied visible rows as CSV.' });
+      setCopyStatus({ kind: 'success', message: labels.copyCsvSuccess });
     } catch (error) {
       setCopyStatus({
         kind: 'error',
-        message: `Unable to copy CSV: ${error instanceof Error ? error.message : String(error)}`
+        message: labels.copyCsvError(error instanceof Error ? error.message : String(error))
       });
     }
   }
 
   return (
-    <section class="doc-table-output" data-testid="table-output">
-      {table.caption ? <p class="doc-table-output__caption">{table.caption}</p> : null}
+    <section class="doc-table-output" aria-labelledby={captionId} data-testid="table-output">
+      {table.caption ? (
+        <p id={descriptionId} class="doc-table-output__caption">
+          {table.caption}
+        </p>
+      ) : null}
       <div class="doc-table-output__scroller">
-        <table>
-          {table.title ? <caption>{table.title}</caption> : null}
+        <table aria-describedby={descriptionId}>
+          <caption id={captionId} class={table.title ? undefined : 'doc-visually-hidden'}>
+            {table.title ?? labels.tableOutput}
+          </caption>
           <thead>
             <tr>
               {table.columns.map((column, columnIndex) => (
@@ -86,7 +102,7 @@ export default function TableOutput({ table }: TableOutputProps) {
               <tr key={`${safePage}:${rowIndex}`}>
                 {table.columns.map((column, columnIndex) => (
                   <td key={column.key} data-type={column.type ?? 'unknown'}>
-                    {formatTableCell(row[columnIndex])}
+                    {formatTableCell(row[columnIndex], labels)}
                   </td>
                 ))}
               </tr>
@@ -95,13 +111,11 @@ export default function TableOutput({ table }: TableOutputProps) {
         </table>
       </div>
       <div class="doc-table-output__footer">
-        <p>
-          Rows {firstRow}-{lastRow} of {table.rowCount ?? sortedRows.length}
-          {table.truncated ? ' (truncated)' : ''}
-        </p>
-        <div class="doc-table-output__controls">
+        <p>{labels.rowsRange(firstRow, lastRow, table.rowCount ?? sortedRows.length, Boolean(table.truncated))}</p>
+        <fieldset class="doc-table-output__controls">
+          <legend class="doc-visually-hidden">{labels.tableControls}</legend>
           <label>
-            <span>Rows</span>
+            <span>{labels.rowsPerPage}</span>
             <select
               data-testid="table-page-size"
               value={String(pageSize)}
@@ -117,8 +131,14 @@ export default function TableOutput({ table }: TableOutputProps) {
               ))}
             </select>
           </label>
-          <button type="button" data-testid="table-copy-csv" onClick={copyVisibleCsv}>
-            Copy CSV
+          <button
+            type="button"
+            aria-busy={copyStatus?.kind === 'copying'}
+            data-testid="table-copy-csv"
+            disabled={copyStatus?.kind === 'copying'}
+            onClick={copyVisibleCsv}
+          >
+            {copyStatus?.kind === 'copying' ? labels.copyingCsv : labels.copyCsv}
           </button>
           <button
             type="button"
@@ -126,7 +146,7 @@ export default function TableOutput({ table }: TableOutputProps) {
             disabled={safePage === 0}
             onClick={() => setPage((current) => Math.max(0, current - 1))}
           >
-            Prev
+            {labels.previousPage}
           </button>
           <button
             type="button"
@@ -134,14 +154,15 @@ export default function TableOutput({ table }: TableOutputProps) {
             disabled={safePage >= pageCount - 1}
             onClick={() => setPage((current) => Math.min(pageCount - 1, current + 1))}
           >
-            Next
+            {labels.nextPage}
           </button>
-        </div>
+        </fieldset>
       </div>
       {copyStatus ? (
         <p
           class={copyStatus.kind === 'error' ? 'error-state' : 'doc-table-output__status'}
           data-testid="table-copy-status"
+          aria-live={copyStatus.kind === 'error' ? 'assertive' : 'polite'}
           role={copyStatus.kind === 'error' ? 'alert' : 'status'}
         >
           {copyStatus.message}
@@ -186,12 +207,12 @@ export function tableToCsv(columns: readonly TableColumn[], rows: readonly unkno
   }
 }
 
-export function formatTableCell(value: unknown): string {
+export function formatTableCell(value: unknown, labels: RuntimeLabels = labelsForLanguage('en')): string {
   if (value === null) return 'null';
-  if (value === undefined) return 'missing';
+  if (value === undefined) return labels.tableMissingValue;
   if (typeof value === 'number') {
     return Number.isFinite(value)
-      ? new Intl.NumberFormat('en-US', { maximumSignificantDigits: 6 }).format(value)
+      ? new Intl.NumberFormat(labels.locale === 'ja' ? 'ja-JP' : 'en-US', { maximumSignificantDigits: 6 }).format(value)
       : String(value);
   }
   if (typeof value === 'boolean') return value ? 'true' : 'false';

--- a/packages/oxiquill/src/components/doc-runtime/manifest-hooks.ts
+++ b/packages/oxiquill/src/components/doc-runtime/manifest-hooks.ts
@@ -24,5 +24,11 @@ export function useManifestSnapshot() {
 }
 
 export function useRuntimeLabels() {
-  return useMemo(() => labelsForLanguage(globalThis.document?.documentElement.lang), []);
+  const [languageTag, setLanguageTag] = useState<string>();
+
+  useEffect(() => {
+    setLanguageTag(globalThis.document?.documentElement.lang);
+  }, []);
+
+  return useMemo(() => labelsForLanguage(languageTag), [languageTag]);
 }

--- a/packages/oxiquill/src/config/paths.mjs
+++ b/packages/oxiquill/src/config/paths.mjs
@@ -30,6 +30,7 @@ export function createOxiquillPaths(options = {}) {
     rustWasmPublicDir: directoryPath(options.rustWasmPublicDir ?? 'rust-wasm', publicAssetsDir),
     cellsModulePath: filePath('cells.ts', generatedDir),
     cellsJsonPath: filePath('cells.json', generatedDir),
+    runtimeOwnershipPath: filePath('runtime-ownership.json', generatedDir),
     runtimeVersionPath: filePath('runtime-version.ts', generatedDir)
   });
 }

--- a/packages/oxiquill/src/generator/doc-runtime-service.mjs
+++ b/packages/oxiquill/src/generator/doc-runtime-service.mjs
@@ -20,9 +20,22 @@ import { throwInteractiveCellDiagnostics, validateCellDependencies } from '../li
 import { defaultFileSystem, listFiles, writeIfChanged } from './doc-runtime/file-system.mjs';
 import { listHelperCrates } from './doc-runtime/helper-crate-service.mjs';
 import { normalizePath } from './doc-runtime/path-utils.mjs';
-import { copyPyodideAssets } from './doc-runtime/pyodide-assets.mjs';
-import { syncLicenseArtifacts } from './license-notices.mjs';
+import { copyPyodideAssets as defaultCopyPyodideAssets, requiredPyodideFiles } from './doc-runtime/pyodide-assets.mjs';
+import { syncLicenseArtifacts as defaultSyncLicenseArtifacts, syncRustBuildSupportFiles } from './license-notices.mjs';
 import { createRuntimeVersion, generateRuntimeVersionModule, summarizeCells } from './doc-runtime/runtime-summary.mjs';
+import { hashText, stableFingerprint } from './doc-runtime/hashing.mjs';
+import { vendoredPyodidePackageRoots } from './doc-runtime/constants.mjs';
+import { createRuntimePlan } from './doc-runtime/runtime-plan.mjs';
+import {
+  createRuntimeOwnedOutputs,
+  generateRuntimeOwnershipJson,
+  readRuntimeOwnership
+} from './doc-runtime/runtime-ownership.mjs';
+import { createDirectoryStage, discardDirectoryStage, replaceDirectory } from './doc-runtime/atomic-output.mjs';
+import {
+  buildHaskellWasm as defaultBuildHaskellWasm,
+  buildRustWasm as defaultBuildRustWasm
+} from './doc-runtime/wasm-build.mjs';
 
 export { copyFileIfChanged, listFiles, writeIfChanged } from './doc-runtime/file-system.mjs';
 export { listHelperCrates, readHelperManifests } from './doc-runtime/helper-crate-service.mjs';
@@ -61,6 +74,13 @@ export {
   packageRootFromModuleId,
   syncLicenseArtifacts
 } from './license-notices.mjs';
+export { createRuntimePlan } from './doc-runtime/runtime-plan.mjs';
+export {
+  createRuntimeOwnedOutputs,
+  generateRuntimeOwnershipJson,
+  readRuntimeOwnership,
+  validateRuntimeOwnership
+} from './doc-runtime/runtime-ownership.mjs';
 
 export function createDocRuntimePaths(rootOrOptions = process.cwd()) {
   const options =
@@ -93,12 +113,18 @@ export async function createDocRuntimeContext({
 }
 
 export async function syncDocRuntime({
+  buildHaskell = defaultBuildHaskellWasm,
+  buildRust = defaultBuildRustWasm,
   fileSystem = defaultFileSystem,
+  forceRustBuild = false,
   highlighter,
   helperCrates,
+  mode = undefined,
   paths,
-  syncLicenses = syncLicenseArtifacts,
-  syncPyodide = copyPyodideAssets
+  syncLicenses = defaultSyncLicenseArtifacts,
+  syncPyodide = defaultCopyPyodideAssets,
+  syncRustSupport = syncRustBuildSupportFiles,
+  tolerateHaskellBuildFailure = false
 }) {
   const cells = await collectCells({
     fileSystem,
@@ -107,29 +133,399 @@ export async function syncDocRuntime({
     paths
   });
   const haskellCells = cells.filter((cell) => cell.language === 'haskell');
+  const pythonCells = cells.filter((cell) => cell.language === 'python');
   const rustCells = cells.filter((cell) => cell.language === 'rust');
-
-  const writes = await Promise.all([
-    writeIfChanged(pathFromUrl(paths.cellsModulePath), generateCellsModule(cells), { fileSystem }),
-    writeIfChanged(pathFromUrl(paths.cellsJsonPath), generateCellsJson(cells), { fileSystem }),
-    writeIfChanged(pathInUrl(paths.haskellCellsDir, 'Main.hs'), generateHaskellMain(haskellCells), { fileSystem }),
-    writeIfChanged(pathInUrl(paths.rustCellsDir, 'Cargo.toml'), generateRustCargoToml(rustCells, helperCrates), {
-      fileSystem
-    }),
-    writeIfChanged(pathInUrl(paths.rustCellsDir, 'src/lib.rs'), generateRustLib(rustCells), { fileSystem })
-  ]);
-  const pyodideChanged = await syncPyodide({ fileSystem, paths });
-  const licensesChanged = await syncLicenses({ fileSystem, paths });
   const summary = summarizeCells(cells);
+  const generated = {
+    cellsJson: generateCellsJson(cells),
+    cellsModule: generateCellsModule(cells),
+    haskellMain: generateHaskellMain(haskellCells),
+    rustCargo: generateRustCargoToml(rustCells, helperCrates),
+    rustLib: generateRustLib(rustCells)
+  };
+  const desired = await createDesiredRuntime({
+    fileSystem,
+    generated,
+    paths,
+    pythonCellCount: pythonCells.length,
+    summary
+  });
+  const state = await readRuntimeOwnership({ fileSystem, paths });
+  const { outputComplete, outputPresent } = runtimeOutputState({ fileSystem, paths, state });
+  const plan = createRuntimePlan({
+    desired,
+    forceRustBuild,
+    mode,
+    outputComplete,
+    outputPresent,
+    state
+  });
+
+  if (!plan.hasChanges) {
+    const licensesChanged = await syncLicenses({
+      fileSystem,
+      includeRustBuildFiles: false,
+      paths
+    });
+    return runtimeResult({ licensesChanged, plan, summary });
+  }
+
+  await fileSystem.rm(paths.runtimeVersionPath, { force: true });
+  const stages = [];
+  let haskellBuildResult = { ok: true };
+
+  try {
+    const stagedPaths = { ...paths };
+    await stageLanguageOutputs({
+      fileSystem,
+      generated,
+      paths,
+      plan,
+      stagedPaths,
+      stages,
+      syncPyodide,
+      syncRustSupport
+    });
+
+    if (plan.languages.rust.public === 'build') {
+      await buildRust({ mode, paths: stagedPaths });
+    }
+    if (plan.languages.haskell.public === 'build') {
+      haskellBuildResult = await buildHaskell({
+        fileSystem,
+        haskellFingerprint: summary.haskellFingerprint,
+        mode,
+        paths: stagedPaths,
+        tolerateFailure: tolerateHaskellBuildFailure
+      });
+    }
+
+    const nextState = await createNextRuntimeState({
+      desired,
+      fileSystem,
+      haskellBuildResult,
+      mode,
+      paths,
+      plan,
+      stagedPaths,
+      state
+    });
+    const generatedStage = await createDirectoryStage(paths.generatedDir, { fileSystem });
+    stages.push({ stagePath: generatedStage, targetPath: paths.generatedDir, type: 'generated' });
+    await writeGeneratedRuntime({
+      fileSystem,
+      generated,
+      nextState,
+      paths: { ...paths, generatedDir: generatedStage },
+      ready: haskellBuildResult.ok,
+      summary
+    });
+
+    await promoteLanguageStages(stages, { fileSystem });
+    await removeStaleLanguageOutputs({ fileSystem, paths, plan });
+    const licensesChanged = await syncLicenses({
+      fileSystem,
+      includeRustBuildFiles: false,
+      paths
+    });
+    await replaceDirectory(generatedStage, paths.generatedDir, { fileSystem });
+
+    return runtimeResult({ haskellBuildResult, licensesChanged, plan, summary });
+  } finally {
+    await Promise.all(stages.map(({ stagePath }) => discardDirectoryStage(stagePath, { fileSystem })));
+  }
+}
+
+async function createDesiredRuntime({ fileSystem, generated, paths, pythonCellCount, summary }) {
+  const helperFingerprint =
+    summary.rustCellCount > 0 ? await fingerprintHelperSources({ fileSystem, paths }) : stableFingerprint([]);
+  const rustSourceFingerprint = hashText(`${generated.rustCargo}\0${generated.rustLib}`);
+  const haskellSourceFingerprint = hashText(generated.haskellMain);
+  const pythonAssetFingerprint =
+    pythonCellCount > 0 ? await fingerprintPyodideRecipe({ fileSystem, paths }) : stableFingerprint([]);
+
+  return Object.freeze({
+    manifestFingerprint: summary.manifestFingerprint,
+    rust: Object.freeze({
+      buildFingerprint: stableFingerprint({ helpers: helperFingerprint, source: rustSourceFingerprint }),
+      cellCount: summary.rustCellCount,
+      sourceFingerprint: rustSourceFingerprint
+    }),
+    python: Object.freeze({ assetFingerprint: pythonAssetFingerprint, cellCount: pythonCellCount }),
+    haskell: Object.freeze({
+      buildFingerprint: haskellSourceFingerprint,
+      cellCount: summary.haskellCellCount,
+      sourceFingerprint: haskellSourceFingerprint
+    })
+  });
+}
+
+function runtimeOutputState({ fileSystem, paths, state }) {
+  const outputPresent = {
+    generated: fileSystem.existsSync(paths.generatedDir),
+    rustSource: fileSystem.existsSync(paths.rustCellsDir),
+    rustPublic: fileSystem.existsSync(paths.rustWasmPublicDir),
+    pythonPublic: fileSystem.existsSync(paths.pyodidePublicDir),
+    haskellSource: fileSystem.existsSync(paths.haskellCellsDir),
+    haskellPublic: fileSystem.existsSync(paths.haskellWasmPublicDir)
+  };
+  return {
+    outputPresent,
+    outputComplete: {
+      generated:
+        Boolean(state) &&
+        fileSystem.existsSync(paths.cellsModulePath) &&
+        fileSystem.existsSync(paths.cellsJsonPath) &&
+        fileSystem.existsSync(paths.runtimeOwnershipPath) &&
+        (state.ready === false || fileSystem.existsSync(paths.runtimeVersionPath)),
+      rustSource:
+        outputPresent.rustSource &&
+        ['Cargo.toml', 'Cargo.lock', 'LICENSE-MIT', 'LICENSE-APACHE', 'src/lib.rs'].every((fileName) =>
+          fileSystem.existsSync(pathInUrl(paths.rustCellsDir, fileName))
+        ),
+      rustPublic: recordedFilesExist(state?.languages?.rust?.publicFiles, paths.rustWasmPublicDir, fileSystem),
+      pythonPublic: recordedFilesExist(state?.languages?.python?.publicFiles, paths.pyodidePublicDir, fileSystem),
+      haskellSource: outputPresent.haskellSource && fileSystem.existsSync(pathInUrl(paths.haskellCellsDir, 'Main.hs')),
+      haskellPublic: recordedFilesExist(state?.languages?.haskell?.publicFiles, paths.haskellWasmPublicDir, fileSystem)
+    }
+  };
+}
+
+async function stageLanguageOutputs({
+  fileSystem,
+  generated,
+  paths,
+  plan,
+  stagedPaths,
+  stages,
+  syncPyodide,
+  syncRustSupport
+}) {
+  if (plan.languages.rust.source === 'write' || plan.languages.rust.public === 'build') {
+    const stagePath = await addDirectoryStage('rustCellsDir', paths, stagedPaths, stages, { fileSystem });
+    await Promise.all([
+      writeIfChanged(pathInUrl(stagePath, 'Cargo.toml'), generated.rustCargo, { fileSystem }),
+      writeIfChanged(pathInUrl(stagePath, 'src/lib.rs'), generated.rustLib, { fileSystem }),
+      syncRustSupport({ fileSystem, paths: stagedPaths })
+    ]);
+  }
+  if (plan.languages.rust.public === 'build') {
+    await addDirectoryStage('rustWasmPublicDir', paths, stagedPaths, stages, { fileSystem });
+  }
+  if (plan.languages.python.public === 'copy') {
+    await addDirectoryStage('pyodidePublicDir', paths, stagedPaths, stages, { fileSystem });
+    await syncPyodide({ fileSystem, paths: stagedPaths });
+  }
+  if (plan.languages.haskell.source === 'write' || plan.languages.haskell.public === 'build') {
+    const stagePath = await addDirectoryStage('haskellCellsDir', paths, stagedPaths, stages, { fileSystem });
+    await writeIfChanged(pathInUrl(stagePath, 'Main.hs'), generated.haskellMain, { fileSystem });
+  }
+  if (plan.languages.haskell.public === 'build') {
+    await addDirectoryStage('haskellWasmPublicDir', paths, stagedPaths, stages, { fileSystem });
+  }
+}
+
+async function addDirectoryStage(pathName, paths, stagedPaths, stages, { fileSystem }) {
+  const targetPath = paths[pathName];
+  const stagePath = await createDirectoryStage(targetPath, { fileSystem });
+  stagedPaths[pathName] = stagePath;
+  stages.push({ stagePath, targetPath, type: 'language' });
+  return stagePath;
+}
+
+async function createNextRuntimeState({
+  desired,
+  fileSystem,
+  haskellBuildResult,
+  mode,
+  paths,
+  plan,
+  stagedPaths,
+  state
+}) {
+  const languages = {};
+  if (desired.rust.cellCount > 0) {
+    languages.rust = languageState({
+      buildFingerprint: desired.rust.buildFingerprint,
+      mode,
+      previous: state?.languages?.rust,
+      publicAction: plan.languages.rust.public,
+      publicFiles:
+        plan.languages.rust.public === 'build'
+          ? await listRelativeFiles(stagedPaths.rustWasmPublicDir, { fileSystem })
+          : undefined,
+      sourceFingerprint: desired.rust.sourceFingerprint,
+      status: 'ready'
+    });
+  }
+  if (desired.python.cellCount > 0) {
+    languages.python = {
+      assetFingerprint: desired.python.assetFingerprint,
+      publicFiles:
+        plan.languages.python.public === 'copy'
+          ? await listRelativeFiles(stagedPaths.pyodidePublicDir, { fileSystem })
+          : (state?.languages?.python?.publicFiles ?? [])
+    };
+  }
+  if (desired.haskell.cellCount > 0) {
+    languages.haskell = languageState({
+      buildFingerprint: desired.haskell.buildFingerprint,
+      mode,
+      previous: state?.languages?.haskell,
+      publicAction: plan.languages.haskell.public,
+      publicFiles:
+        plan.languages.haskell.public === 'build'
+          ? await listRelativeFiles(stagedPaths.haskellWasmPublicDir, { fileSystem })
+          : undefined,
+      sourceFingerprint: desired.haskell.sourceFingerprint,
+      status: haskellBuildResult.ok ? 'ready' : 'unavailable'
+    });
+  }
 
   return {
-    ...summary,
-    cellsChanged: writes[0] || writes[1],
-    haskellChanged: writes[2],
-    licensesChanged,
-    pyodideChanged,
-    rustChanged: writes[3] || writes[4]
+    schemaVersion: 1,
+    manifestFingerprint: desired.manifestFingerprint,
+    ready: haskellBuildResult.ok,
+    languages,
+    ownedOutputs: createRuntimeOwnedOutputs(paths).filter((entry) => desired[entry.language].cellCount > 0)
   };
+}
+
+function languageState({ buildFingerprint, mode, previous, publicAction, publicFiles, sourceFingerprint, status }) {
+  const next = { sourceFingerprint };
+  if (publicAction === 'build') {
+    return { ...next, buildFingerprint, mode, publicFiles, status };
+  }
+  if (publicAction === 'keep' && previous?.publicFiles?.length > 0) {
+    return {
+      ...next,
+      buildFingerprint: previous.buildFingerprint,
+      mode: previous.mode,
+      publicFiles: previous.publicFiles,
+      status: previous.status
+    };
+  }
+  return next;
+}
+
+async function writeGeneratedRuntime({ fileSystem, generated, nextState, paths, ready, summary }) {
+  await Promise.all([
+    writeIfChanged(pathInUrl(paths.generatedDir, 'cells.ts'), generated.cellsModule, { fileSystem }),
+    writeIfChanged(pathInUrl(paths.generatedDir, 'cells.json'), generated.cellsJson, { fileSystem }),
+    writeIfChanged(pathInUrl(paths.generatedDir, 'runtime-ownership.json'), generateRuntimeOwnershipJson(nextState), {
+      fileSystem
+    }),
+    ...(ready
+      ? [
+          writeIfChanged(
+            pathInUrl(paths.generatedDir, 'runtime-version.ts'),
+            generateRuntimeVersionModule(createRuntimeVersion(summary)),
+            { fileSystem }
+          )
+        ]
+      : [])
+  ]);
+}
+
+async function promoteLanguageStages(stages, { fileSystem }) {
+  for (const stage of stages.filter(({ type }) => type === 'language')) {
+    await replaceDirectory(stage.stagePath, stage.targetPath, { fileSystem });
+  }
+}
+
+async function removeStaleLanguageOutputs({ fileSystem, paths, plan }) {
+  const targets = [
+    [plan.languages.rust.source, paths.rustCellsDir],
+    [plan.languages.rust.public, paths.rustWasmPublicDir],
+    [plan.languages.python.public, paths.pyodidePublicDir],
+    [plan.languages.haskell.source, paths.haskellCellsDir],
+    [plan.languages.haskell.public, paths.haskellWasmPublicDir]
+  ];
+  await Promise.all(
+    targets
+      .filter(([action]) => action === 'remove')
+      .map(([, targetPath]) => fileSystem.rm(targetPath, { force: true, recursive: true }))
+  );
+}
+
+function runtimeResult({ haskellBuildResult, licensesChanged, plan, summary }) {
+  return {
+    ...summary,
+    cellsChanged: plan.generated === 'write',
+    haskellChanged: plan.languages.haskell.source !== 'keep',
+    haskellBuildResult,
+    licensesChanged,
+    plan,
+    pyodideChanged: plan.languages.python.public === 'copy',
+    rustChanged: plan.languages.rust.source !== 'keep'
+  };
+}
+
+async function listRelativeFiles(directory, { fileSystem }) {
+  const files = await listFiles(directory, { fileSystem });
+  return files.map((filePath) => normalizePath(path.relative(directory, filePath))).sort();
+}
+
+function recordedFilesExist(files, directory, fileSystem) {
+  return (
+    Array.isArray(files) &&
+    files.length > 0 &&
+    files.every(
+      (fileName) =>
+        typeof fileName === 'string' &&
+        fileName !== '' &&
+        !path.isAbsolute(fileName) &&
+        !normalizePath(fileName).split('/').includes('..') &&
+        fileSystem.existsSync(pathInUrl(directory, fileName))
+    )
+  );
+}
+
+async function fingerprintPyodideRecipe({ fileSystem, paths }) {
+  const packageJsonPath = pathInUrl(paths.frameworkRoot, 'package.json');
+  const packageJson = JSON.parse(await fileSystem.readFile(packageJsonPath, 'utf8'));
+  const pyodideVersion = packageJson.dependencies?.pyodide;
+  if (typeof pyodideVersion !== 'string' || pyodideVersion.trim() === '') {
+    throw new Error(`Oxiquill package metadata does not declare Pyodide: ${packageJsonPath}.`);
+  }
+
+  return stableFingerprint({
+    core: requiredPyodideFiles,
+    roots: vendoredPyodidePackageRoots,
+    version: pyodideVersion
+  });
+}
+
+async function fingerprintHelperSources({ fileSystem, paths }) {
+  const files = await listSelectedFiles(paths.cratesDir, { fileSystem });
+  const entries = await Promise.all(
+    files.map(async (filePath) => ({
+      content: await fileSystem.readFile(filePath, 'utf8'),
+      path: normalizePath(path.relative(paths.cratesDir, filePath))
+    }))
+  );
+  return stableFingerprint(entries);
+}
+
+async function listSelectedFiles(directory, { fileSystem }) {
+  let entries;
+  try {
+    entries = await fileSystem.readdir(directory, { withFileTypes: true });
+  } catch (error) {
+    if (error?.code === 'ENOENT') return [];
+    throw error;
+  }
+
+  const nested = await Promise.all(
+    entries
+      .filter((entry) => entry.name !== 'target' && entry.name !== '.git')
+      .map(async (entry) => {
+        const entryPath = path.join(directory, entry.name);
+        if (entry.isDirectory()) return listSelectedFiles(entryPath, { fileSystem });
+        return entry.isFile() && /(?:\.rs|\.toml|Cargo\.lock)$/u.test(entry.name) ? [entryPath] : [];
+      })
+  );
+  return nested.flat().sort();
 }
 
 export async function collectCells({ fileSystem = defaultFileSystem, helperCrates, highlighter, paths }) {

--- a/packages/oxiquill/src/generator/doc-runtime/atomic-output.mjs
+++ b/packages/oxiquill/src/generator/doc-runtime/atomic-output.mjs
@@ -1,0 +1,30 @@
+import { randomUUID } from 'node:crypto';
+import path from 'node:path';
+import { defaultFileSystem } from './file-system.mjs';
+
+export async function createDirectoryStage(targetPath, { fileSystem = defaultFileSystem } = {}) {
+  const stagePath = path.join(path.dirname(targetPath), `.${path.basename(targetPath)}.oxiquill-${randomUUID()}`);
+  await fileSystem.rm(stagePath, { force: true, recursive: true });
+  await fileSystem.mkdir(stagePath, { recursive: true });
+  return stagePath;
+}
+
+export async function replaceDirectory(stagePath, targetPath, { fileSystem = defaultFileSystem } = {}) {
+  const backupPath = `${stagePath}.previous`;
+  const targetExists = fileSystem.existsSync(targetPath);
+  await fileSystem.rm(backupPath, { force: true, recursive: true });
+
+  if (targetExists) await fileSystem.rename(targetPath, backupPath);
+  try {
+    await fileSystem.rename(stagePath, targetPath);
+  } catch (error) {
+    if (targetExists) await fileSystem.rename(backupPath, targetPath);
+    throw error;
+  }
+
+  await fileSystem.rm(backupPath, { force: true, recursive: true });
+}
+
+export async function discardDirectoryStage(stagePath, { fileSystem = defaultFileSystem } = {}) {
+  await fileSystem.rm(stagePath, { force: true, recursive: true });
+}

--- a/packages/oxiquill/src/generator/doc-runtime/constants.mjs
+++ b/packages/oxiquill/src/generator/doc-runtime/constants.mjs
@@ -1,6 +1,6 @@
 export const sourceThemes = {
-  light: 'github-light',
-  dark: 'github-dark'
+  light: 'github-light-high-contrast',
+  dark: 'github-dark-high-contrast'
 };
 
 export const vendoredPyodidePackageRoots = ['matplotlib', 'pandas'];

--- a/packages/oxiquill/src/generator/doc-runtime/file-system.mjs
+++ b/packages/oxiquill/src/generator/doc-runtime/file-system.mjs
@@ -1,5 +1,5 @@
 import { existsSync } from 'node:fs';
-import { copyFile, mkdir, readFile, readdir, rm, writeFile } from 'node:fs/promises';
+import { copyFile, mkdir, readFile, readdir, rename, rm, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { pathFromUrl } from '../../config/paths.mjs';
 import { hashBytes } from './hashing.mjs';
@@ -10,6 +10,7 @@ export const defaultFileSystem = {
   mkdir,
   readFile,
   readdir,
+  rename,
   rm,
   writeFile
 };

--- a/packages/oxiquill/src/generator/doc-runtime/pyodide-assets.mjs
+++ b/packages/oxiquill/src/generator/doc-runtime/pyodide-assets.mjs
@@ -6,7 +6,7 @@ import { copyFileIfChanged, defaultFileSystem, hasPackageContent } from './file-
 import { hashBytes } from './hashing.mjs';
 
 const require = createRequire(import.meta.url);
-const requiredPyodideFiles = [
+export const requiredPyodideFiles = [
   'pyodide.mjs',
   'pyodide.mjs.map',
   'pyodide.asm.mjs',

--- a/packages/oxiquill/src/generator/doc-runtime/runtime-ownership.mjs
+++ b/packages/oxiquill/src/generator/doc-runtime/runtime-ownership.mjs
@@ -1,0 +1,100 @@
+import path from 'node:path';
+import { assertPathWithin, canonicalPath, normalizePath } from '../../config/paths.mjs';
+import { defaultFileSystem } from './file-system.mjs';
+
+export const RUNTIME_OWNERSHIP_SCHEMA_VERSION = 1;
+
+export function createRuntimeOwnedOutputs(paths) {
+  return Object.freeze([
+    ownedOutput('rust', 'cache', paths.cacheDir, paths.rustCellsDir),
+    ownedOutput('rust', 'public', paths.publicAssetsDir, paths.rustWasmPublicDir),
+    ownedOutput('python', 'public', paths.publicAssetsDir, paths.pyodidePublicDir),
+    ownedOutput('haskell', 'cache', paths.cacheDir, paths.haskellCellsDir),
+    ownedOutput('haskell', 'public', paths.publicAssetsDir, paths.haskellWasmPublicDir)
+  ]);
+}
+
+export async function readRuntimeOwnership({ fileSystem = defaultFileSystem, paths }) {
+  let source;
+  try {
+    source = await fileSystem.readFile(paths.runtimeOwnershipPath, 'utf8');
+  } catch (error) {
+    if (error?.code === 'ENOENT') return undefined;
+    throw error;
+  }
+
+  let manifest;
+  try {
+    manifest = JSON.parse(source);
+  } catch (error) {
+    throw new Error(`Runtime ownership manifest is invalid JSON: ${paths.runtimeOwnershipPath}.`, { cause: error });
+  }
+
+  validateRuntimeOwnership(manifest, paths);
+  return manifest;
+}
+
+export function validateRuntimeOwnership(manifest, paths) {
+  if (
+    manifest?.schemaVersion !== RUNTIME_OWNERSHIP_SCHEMA_VERSION ||
+    typeof manifest.manifestFingerprint !== 'string' ||
+    !isRecord(manifest.languages) ||
+    !Array.isArray(manifest.ownedOutputs)
+  ) {
+    throw new Error('Runtime ownership manifest must use schemaVersion 1 and contain valid runtime state.');
+  }
+
+  const expected = new Map(createRuntimeOwnedOutputs(paths).map((entry) => [ownershipKey(entry), entry]));
+  for (const entry of manifest.ownedOutputs) {
+    if (!isOwnedOutput(entry)) throw new Error('Runtime ownership manifest contains an invalid owned output.');
+
+    const key = ownershipKey(entry);
+    const expectedEntry = expected.get(key);
+    if (!expectedEntry || expectedEntry.path !== entry.path) {
+      throw new Error(`Runtime ownership manifest contains an unexpected owned output: ${entry.path}.`);
+    }
+
+    resolveOwnedOutput(entry, paths);
+  }
+
+  return manifest;
+}
+
+export function resolveOwnedOutput(entry, paths) {
+  const root = entry.root === 'cache' ? paths.cacheDir : paths.publicAssetsDir;
+  const target = canonicalPath(path.resolve(root, entry.path));
+  assertPathWithin(root, target, `runtime ownership ${entry.language}`);
+  return target;
+}
+
+export function generateRuntimeOwnershipJson(manifest) {
+  return `${JSON.stringify(manifest, null, 2)}\n`;
+}
+
+function ownedOutput(language, root, rootPath, targetPath) {
+  const relativePath = normalizePath(path.relative(rootPath, targetPath));
+  if (relativePath === '' || relativePath === '..' || relativePath.startsWith('../')) {
+    throw new Error(`Runtime ${language} output must be a descendant of ${rootPath}.`);
+  }
+  return Object.freeze({ language, path: relativePath, root });
+}
+
+function ownershipKey(entry) {
+  return `${entry.language}:${entry.root}`;
+}
+
+function isOwnedOutput(entry) {
+  return (
+    isRecord(entry) &&
+    (entry.language === 'rust' || entry.language === 'python' || entry.language === 'haskell') &&
+    (entry.root === 'cache' || entry.root === 'public') &&
+    typeof entry.path === 'string' &&
+    entry.path !== '' &&
+    !path.isAbsolute(entry.path) &&
+    !normalizePath(entry.path).split('/').includes('..')
+  );
+}
+
+function isRecord(value) {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/packages/oxiquill/src/generator/doc-runtime/runtime-plan.mjs
+++ b/packages/oxiquill/src/generator/doc-runtime/runtime-plan.mjs
@@ -1,0 +1,110 @@
+export const runtimeLanguages = Object.freeze(['rust', 'python', 'haskell']);
+
+export function createRuntimePlan({ desired, forceRustBuild = false, mode, outputComplete, outputPresent, state }) {
+  const previous = state?.languages ?? {};
+  const rustSourceCurrent =
+    desired.rust.cellCount > 0 &&
+    previous.rust?.sourceFingerprint === desired.rust.sourceFingerprint &&
+    outputComplete.rustSource;
+  const rustBuildCurrent =
+    rustSourceCurrent &&
+    previous.rust?.buildFingerprint === desired.rust.buildFingerprint &&
+    previous.rust?.status === 'ready' &&
+    modeSatisfies(previous.rust?.mode, mode) &&
+    outputComplete.rustPublic;
+  const haskellSourceCurrent =
+    desired.haskell.cellCount > 0 &&
+    previous.haskell?.sourceFingerprint === desired.haskell.sourceFingerprint &&
+    outputComplete.haskellSource;
+  const haskellBuildCurrent =
+    haskellSourceCurrent &&
+    previous.haskell?.buildFingerprint === desired.haskell.buildFingerprint &&
+    previous.haskell?.status === 'ready' &&
+    modeSatisfies(previous.haskell?.mode, mode) &&
+    outputComplete.haskellPublic;
+  const pythonCurrent =
+    desired.python.cellCount > 0 &&
+    previous.python?.assetFingerprint === desired.python.assetFingerprint &&
+    outputComplete.pythonPublic;
+
+  const languages = {
+    rust: {
+      source:
+        desired.rust.cellCount === 0
+          ? outputPresent.rustSource || previous.rust
+            ? 'remove'
+            : 'keep'
+          : rustSourceCurrent && !forceRustBuild
+            ? 'keep'
+            : 'write',
+      public:
+        desired.rust.cellCount === 0
+          ? outputPresent.rustPublic || previous.rust?.publicFiles?.length > 0
+            ? 'remove'
+            : 'keep'
+          : mode == null
+            ? rustSourceCurrent
+              ? 'keep'
+              : 'remove'
+            : rustBuildCurrent && !forceRustBuild
+              ? 'keep'
+              : 'build'
+    },
+    python: {
+      public:
+        desired.python.cellCount === 0
+          ? outputPresent.pythonPublic || previous.python
+            ? 'remove'
+            : 'keep'
+          : pythonCurrent
+            ? 'keep'
+            : 'copy'
+    },
+    haskell: {
+      source:
+        desired.haskell.cellCount === 0
+          ? outputPresent.haskellSource || previous.haskell
+            ? 'remove'
+            : 'keep'
+          : haskellSourceCurrent
+            ? 'keep'
+            : 'write',
+      public:
+        desired.haskell.cellCount === 0
+          ? outputPresent.haskellPublic || previous.haskell?.publicFiles?.length > 0
+            ? 'remove'
+            : 'keep'
+          : mode == null
+            ? haskellSourceCurrent
+              ? 'keep'
+              : 'remove'
+            : haskellBuildCurrent
+              ? 'keep'
+              : 'build'
+    }
+  };
+  const languageChanges = Object.values(languages).some((actions) =>
+    Object.values(actions).some((action) => action !== 'keep')
+  );
+  const generatedChanged =
+    !outputComplete.generated ||
+    state?.manifestFingerprint !== desired.manifestFingerprint ||
+    state?.schemaVersion !== 1 ||
+    languageChanges;
+
+  return Object.freeze({
+    generated: generatedChanged ? 'write' : 'keep',
+    hasChanges: generatedChanged || languageChanges,
+    languages: Object.freeze({
+      rust: Object.freeze(languages.rust),
+      python: Object.freeze(languages.python),
+      haskell: Object.freeze(languages.haskell)
+    })
+  });
+}
+
+function modeSatisfies(actual, requested) {
+  if (requested == null) return true;
+  if (requested === 'dev') return actual === 'dev' || actual === 'build';
+  return actual === 'build';
+}

--- a/packages/oxiquill/src/generator/doc-runtime/runtime-summary.mjs
+++ b/packages/oxiquill/src/generator/doc-runtime/runtime-summary.mjs
@@ -2,6 +2,7 @@ import { hashText, stableFingerprint } from './hashing.mjs';
 
 export function summarizeCells(cells) {
   const rustCells = cells.filter((cell) => cell.language === 'rust');
+  const pythonCells = cells.filter((cell) => cell.language === 'python');
   const haskellCells = cells.filter((cell) => cell.language === 'haskell');
 
   return {
@@ -15,6 +16,14 @@ export function summarizeCells(cells) {
       }))
     ),
     manifestFingerprint: stableFingerprint(cells),
+    pythonCellCount: pythonCells.length,
+    pythonFingerprint: stableFingerprint(
+      pythonCells.map((cell) => ({
+        id: cell.id,
+        packages: cell.packages,
+        source: cell.source
+      }))
+    ),
     rustCellCount: rustCells.length,
     rustFingerprint: stableFingerprint(
       rustCells.map((cell) => ({
@@ -42,7 +51,6 @@ export function shouldBuildHaskellWasm({ current, force = false, previous }) {
 
 export function createRuntimeVersion(summary) {
   return stableFingerprint({
-    readyAt: Date.now(),
     haskell: hashText(summary?.haskellFingerprint ?? ''),
     manifest: hashText(summary?.manifestFingerprint ?? ''),
     rust: hashText(summary?.rustFingerprint ?? '')

--- a/packages/oxiquill/src/generator/license-notices.mjs
+++ b/packages/oxiquill/src/generator/license-notices.mjs
@@ -214,6 +214,7 @@ export function generateThirdPartyLicenseReport(notices) {
 
 export async function syncLicenseArtifacts({
   fileSystem = defaultFileSystem,
+  includeRustBuildFiles = true,
   licenseDataDir = defaultLicenseDataDir,
   moduleGroups = new Map(),
   outputDirectory = /** @type {string | undefined} */ (undefined),
@@ -230,20 +231,8 @@ export async function syncLicenseArtifacts({
     )
   );
 
-  if (!outputDirectory) {
-    copied.push(
-      ...(await Promise.all(
-        ownLicenseCopies.map(([fileName, sourcePath]) =>
-          copyFileIfChanged(sourcePath, pathInUrl(paths.rustCellsDir, fileName), { fileSystem })
-        )
-      ))
-    );
-    const rustLockPath = pathInUrl(paths.rustCellsDir, 'Cargo.lock');
-    if (!fileSystem.existsSync(rustLockPath)) {
-      copied.push(
-        await copyFileIfChanged(path.join(licenseDataDir, 'rust/runtime-Cargo.lock'), rustLockPath, { fileSystem })
-      );
-    }
+  if (!outputDirectory && includeRustBuildFiles) {
+    copied.push(...(await syncRustBuildSupportFiles({ fileSystem, licenseDataDir, paths })));
   }
 
   const [runtimeNotices, bundleNotices] = await Promise.all([
@@ -261,6 +250,29 @@ export async function syncLicenseArtifacts({
   );
 
   return copied.some(Boolean) || reportChanged;
+}
+
+export async function syncRustBuildSupportFiles({
+  fileSystem = defaultFileSystem,
+  licenseDataDir = defaultLicenseDataDir,
+  paths
+}) {
+  const copies = await Promise.all([
+    copyFileIfChanged(pathInUrl(paths.frameworkRoot, 'LICENSE-MIT'), pathInUrl(paths.rustCellsDir, 'LICENSE-MIT'), {
+      fileSystem
+    }),
+    copyFileIfChanged(
+      pathInUrl(paths.frameworkRoot, 'LICENSE-APACHE'),
+      pathInUrl(paths.rustCellsDir, 'LICENSE-APACHE'),
+      { fileSystem }
+    ),
+    copyFileIfChanged(
+      path.join(licenseDataDir, 'rust/runtime-Cargo.lock'),
+      pathInUrl(paths.rustCellsDir, 'Cargo.lock'),
+      { fileSystem }
+    )
+  ]);
+  return copies;
 }
 
 async function readPackageLicenseText(packageRoot, license, { fileSystem, licenseDataDir, name, version }) {

--- a/packages/oxiquill/src/generator/postprocess-rust-wasm.mjs
+++ b/packages/oxiquill/src/generator/postprocess-rust-wasm.mjs
@@ -10,6 +10,9 @@ const defaultFileSystem = {
 export async function postprocessRustWasm({ fileSystem = defaultFileSystem, rustWasmDir }) {
   await Promise.all([
     fileSystem.rm(path.join(rustWasmDir, '.gitignore'), { force: true }),
+    fileSystem.rm(path.join(rustWasmDir, 'doc_rust_cells.d.ts'), { force: true }),
+    fileSystem.rm(path.join(rustWasmDir, 'doc_rust_cells_bg.wasm.d.ts'), { force: true }),
+    fileSystem.rm(path.join(rustWasmDir, 'package.json'), { force: true }),
     stripUnusedWasmPackState(path.join(rustWasmDir, 'doc_rust_cells.js'), { fileSystem })
   ]);
 }

--- a/packages/oxiquill/src/generator/watch-doc-runtime.mjs
+++ b/packages/oxiquill/src/generator/watch-doc-runtime.mjs
@@ -3,16 +3,7 @@ import { pathToFileURL } from 'node:url';
 import { parseConfigOption } from '../cli/config-option.mjs';
 import { pathFromUrl } from '../config/paths.mjs';
 import { loadOxiquillProjectConfig } from '../config/project-config.mjs';
-import {
-  buildHaskellWasm,
-  buildRustWasm,
-  createDocRuntimeContext,
-  markRuntimeReady,
-  shouldBuildHaskellWasm,
-  shouldBuildWasm,
-  syncLicenseArtifacts,
-  syncDocRuntime
-} from './doc-runtime-service.mjs';
+import { createDocRuntimeContext, syncDocRuntime } from './doc-runtime-service.mjs';
 import {
   classifyChangedPath,
   createRuntimeWatchPaths,
@@ -24,15 +15,9 @@ import {
 } from './doc-runtime-watch-core.mjs';
 
 const defaultServices = {
-  buildHaskellWasm,
-  buildRustWasm,
   createDocRuntimeContext,
   loadProjectConfig: loadOxiquillProjectConfig,
-  markRuntimeReady,
-  shouldBuildHaskellWasm,
-  shouldBuildWasm,
   syncDocRuntime,
-  syncLicenseArtifacts,
   watch: chokidar.watch
 };
 
@@ -56,12 +41,15 @@ export async function watchDocRuntime({ projectConfig, serviceOverrides = {}, sk
   const { paths } = projectConfig;
   const initialContext = await services.createDocRuntimeContext({ paths });
   const workspaceRoot = pathFromUrl(initialContext.paths.workspaceRoot);
-  let previous;
   let changeKinds = skipInitial ? new Set() : new Set(['docs']);
 
   if (skipInitial) {
-    previous = await services.syncDocRuntime(initialContext);
-    console.log(`[runtime] baseline ready: ${previous.cellCount} interactive cell(s)`);
+    const baseline = await services.syncDocRuntime({
+      ...initialContext,
+      mode: 'dev',
+      tolerateHaskellBuildFailure: true
+    });
+    console.log(`[runtime] baseline ready: ${baseline.cellCount} interactive cell(s)`);
   }
 
   async function syncRuntime() {
@@ -72,29 +60,23 @@ export async function watchDocRuntime({ projectConfig, serviceOverrides = {}, sk
     const context = await services.createDocRuntimeContext({ paths, highlighter: initialContext.highlighter });
 
     console.log(`[runtime] syncing after ${describeChangeKinds(currentKinds)}`);
-    const current = await services.syncDocRuntime(context);
+    const current = await services.syncDocRuntime({
+      ...context,
+      forceRustBuild: currentKinds.has('crate'),
+      mode: 'dev',
+      tolerateHaskellBuildFailure: true
+    });
 
-    if (services.shouldBuildWasm({ changeKinds: currentKinds, current, previous })) {
-      console.log('[runtime] rebuilding Rust/Wasm cells');
-      await services.buildRustWasm({ mode: 'dev', paths: context.paths });
+    if (current.plan.languages.rust.public === 'build') {
+      console.log('[runtime] rebuilt Rust/Wasm cells');
     }
-    if (services.shouldBuildHaskellWasm({ current, previous })) {
-      console.log('[runtime] rebuilding Haskell/WASI cells');
-      const result = await services.buildHaskellWasm({
-        haskellFingerprint: current.haskellFingerprint,
-        mode: 'dev',
-        paths: context.paths,
-        tolerateFailure: true
-      });
-      if (!result.ok) {
-        console.warn(`[runtime] Haskell/WASI runtime unavailable: ${result.error.message}`);
-      }
+    if (current.plan.languages.haskell.public === 'build') {
+      console.log('[runtime] rebuilt Haskell/WASI cells');
+    }
+    if (current.haskellBuildResult && !current.haskellBuildResult.ok) {
+      console.warn(`[runtime] Haskell/WASI runtime unavailable: ${current.haskellBuildResult.error.message}`);
     }
 
-    await services.syncLicenseArtifacts({ paths: context.paths });
-
-    await services.markRuntimeReady({ paths: context.paths, summary: current });
-    previous = current;
     console.log(`[runtime] ready: ${current.cellCount} interactive cell(s)`);
   }
 

--- a/packages/oxiquill/src/lib/doc-runtime/cell-authoring.mjs
+++ b/packages/oxiquill/src/lib/doc-runtime/cell-authoring.mjs
@@ -28,7 +28,7 @@ export const supportedPyodidePackages = [
 ];
 
 const cellFields = new Set(['id', 'title', 'run', 'inputs', 'packages', 'crates', 'timeoutMs', 'showSource']);
-const inputFields = new Set(['type', 'label', 'value', 'min', 'max', 'step', 'integer', 'options']);
+const inputFields = new Set(['type', 'label', 'description', 'value', 'min', 'max', 'step', 'integer', 'options']);
 const optionFields = new Set(['label', 'value']);
 const localIdPattern = /^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$/u;
 const inputNamePattern = /^[a-z][a-z0-9_]*$/u;
@@ -320,6 +320,7 @@ function normalizeInput(name, value, context, diagnostics) {
   diagnostics.push(...unknownFieldDiagnostics(value, inputFields, context, `${inputPath}.`));
   const type = normalizeInputType(value, inputPath, context, diagnostics);
   const label = normalizeInputLabel(value, name, inputPath, context, diagnostics);
+  const description = normalizeInputDescription(value, inputPath, context, diagnostics);
   const integer = normalizeInputInteger(value, type, inputPath, context, diagnostics);
   const inputValue = normalizeInputValue(value, type, inputPath, context, diagnostics);
   const min = normalizeInputNumber(value, 'min', type, inputPath, context, diagnostics);
@@ -330,7 +331,18 @@ function normalizeInput(name, value, context, diagnostics) {
   validateNumericConstraints({ integer, max, min, step, type, value: inputValue }, inputPath, context, diagnostics);
   validateOptionDefault(type, inputValue, options, inputPath, context, diagnostics);
 
-  return { name, type, label, value: inputValue, min, max, step, integer, options };
+  return {
+    name,
+    type,
+    label,
+    ...(description ? { description } : {}),
+    value: inputValue,
+    min,
+    max,
+    step,
+    integer,
+    options
+  };
 }
 
 function normalizeInputType(value, inputPath, context, diagnostics) {
@@ -342,9 +354,16 @@ function normalizeInputType(value, inputPath, context, diagnostics) {
 
 function normalizeInputLabel(value, name, inputPath, context, diagnostics) {
   if (!hasOwn(value, 'label')) return name;
-  if (typeof value.label === 'string') return value.label;
-  diagnostics.push(diagnostic(context, `${inputPath}.label`, 'Expected a string.'));
+  if (typeof value.label === 'string' && value.label.trim() !== '') return value.label.trim();
+  diagnostics.push(diagnostic(context, `${inputPath}.label`, 'Expected a non-empty string.'));
   return name;
+}
+
+function normalizeInputDescription(value, inputPath, context, diagnostics) {
+  if (!hasOwn(value, 'description')) return undefined;
+  if (typeof value.description === 'string' && value.description.trim() !== '') return value.description.trim();
+  diagnostics.push(diagnostic(context, `${inputPath}.description`, 'Expected a non-empty string.'));
+  return undefined;
 }
 
 function normalizeInputInteger(value, type, inputPath, context, diagnostics) {

--- a/packages/oxiquill/src/lib/doc-runtime/interactive-cell-model.ts
+++ b/packages/oxiquill/src/lib/doc-runtime/interactive-cell-model.ts
@@ -1,40 +1,9 @@
+import type { RuntimeLabels } from './runtime-localization.js';
+import { labelsForLanguage } from './runtime-localization.js';
 import type { CellManifest, InputSpec, InputValues, RunMode } from './types.js';
 
-export type RuntimeLocale = 'en' | 'ja';
-
-export type RuntimeLabels = {
-  hideCode: string;
-  idleButton: string;
-  idleReactive: string;
-  run: string;
-  running: string;
-  runningCell: string;
-  showCode: string;
-  unknownCell: (cellId: string) => string;
-};
-
-const runtimeLabels = {
-  en: {
-    hideCode: 'Hide code',
-    idleButton: 'Run the cell to show its output.',
-    idleReactive: 'Waiting for the runtime to start.',
-    run: 'Run',
-    running: 'Running',
-    runningCell: 'Running cell...',
-    showCode: 'Show code',
-    unknownCell: (cellId: string) => `Unknown interactive cell: ${cellId}`
-  },
-  ja: {
-    hideCode: 'コードを隠す',
-    idleButton: 'セルを実行すると出力が表示されます。',
-    idleReactive: 'ランタイムの起動を待っています。',
-    run: '実行',
-    running: '実行中',
-    runningCell: 'セルを実行中...',
-    showCode: 'コードを表示',
-    unknownCell: (cellId: string) => `不明な実行可能セル: ${cellId}`
-  }
-} satisfies Record<RuntimeLocale, RuntimeLabels>;
+export { labelsForLanguage, localeFromLanguage } from './runtime-localization.js';
+export type { RuntimeLabels, RuntimeLocale } from './runtime-localization.js';
 
 export function initialValues(inputs: readonly InputSpec[]): InputValues {
   return Object.fromEntries(inputs.map((input) => [input.name, input.value]));
@@ -52,15 +21,10 @@ export function shouldShowInputControls(runMode: RunMode): boolean {
   return runMode !== 'autorun';
 }
 
-export function labelsForLanguage(languageTag?: string): RuntimeLabels {
-  return runtimeLabels[localeFromLanguage(languageTag)];
-}
-
-export function localeFromLanguage(languageTag?: string): RuntimeLocale {
-  return languageTag?.toLowerCase().startsWith('ja') ? 'ja' : 'en';
-}
-
-export function idleOutputMessage(runMode: CellManifest['run'], labels: RuntimeLabels = runtimeLabels.en): string {
+export function idleOutputMessage(
+  runMode: CellManifest['run'],
+  labels: RuntimeLabels = labelsForLanguage('en')
+): string {
   return runMode === 'reactive' || runMode === 'autorun' ? labels.idleReactive : labels.idleButton;
 }
 

--- a/packages/oxiquill/src/lib/doc-runtime/runtime-localization.ts
+++ b/packages/oxiquill/src/lib/doc-runtime/runtime-localization.ts
@@ -1,0 +1,257 @@
+export type RuntimeLocale = 'en' | 'ja';
+
+export type ChartKind = 'area' | 'bar' | 'heatmap' | 'histogram' | 'line' | 'scatter';
+export type MermaidDiagramKind =
+  'class' | 'diagram' | 'entityRelationship' | 'flowchart' | 'journey' | 'sequence' | 'state' | 'timeline';
+
+export type ChartSummaryDetails = {
+  dataCount: number;
+  seriesCount: number;
+  seriesNames: string;
+  xRange?: string;
+  yRange?: string;
+};
+
+export type RuntimeLabels = {
+  locale: RuntimeLocale;
+  artifactError: (index: number, detail: string) => string;
+  artifactRenderError: (index: number, detail: string) => string;
+  cellActions: string;
+  cellCompleted: string;
+  cellCompletedWithoutOutput: string;
+  cellInputs: string;
+  cellOutput: (title: string) => string;
+  cellRunningAnnouncement: string;
+  chartCaption: string;
+  chartLoadError: (detail: string) => string;
+  chartLoading: string;
+  chartSummary: (details: ChartSummaryDetails) => string;
+  chartTitle: (kind: ChartKind) => string;
+  clipboardUnavailable: string;
+  copyCsv: string;
+  copyCsvError: (detail: string) => string;
+  copyCsvSuccess: string;
+  copyingCsv: string;
+  diagnosticDetail: (detail: string) => string;
+  executionError: (detail: string) => string;
+  executionErrorLabel: string;
+  hideCode: string;
+  htmlOutput: string;
+  idleButton: string;
+  idleReactive: string;
+  imageOutput: string;
+  inputMaximum: (maximum: number) => string;
+  inputMinimum: (minimum: number) => string;
+  inputNumber: string;
+  inputStep: string;
+  mermaidDescription: (source: string) => string;
+  mermaidError: (detail: string) => string;
+  mermaidLoading: string;
+  mermaidTitle: (kind: MermaidDiagramKind) => string;
+  nextPage: string;
+  noChartData: string;
+  outputTruncated: string;
+  previousPage: string;
+  rowsPerPage: string;
+  rowsRange: (first: number, last: number, total: number, truncated: boolean) => string;
+  run: string;
+  runtimeLanguage: (language: 'haskell' | 'python' | 'rust') => string;
+  running: string;
+  runningCell: string;
+  showCode: string;
+  tableControls: string;
+  tableMissingValue: string;
+  tableOutput: string;
+  unknownCell: (cellId: string) => string;
+};
+
+const chartTitles = {
+  en: {
+    area: 'Area chart',
+    bar: 'Bar chart',
+    heatmap: 'Heatmap',
+    histogram: 'Histogram',
+    line: 'Line chart',
+    scatter: 'Scatter chart'
+  },
+  ja: {
+    area: '面グラフ',
+    bar: '棒グラフ',
+    heatmap: 'ヒートマップ',
+    histogram: 'ヒストグラム',
+    line: '折れ線グラフ',
+    scatter: '散布図'
+  }
+} satisfies Record<RuntimeLocale, Record<ChartKind, string>>;
+
+const mermaidTitles = {
+  en: {
+    class: 'Mermaid class diagram',
+    diagram: 'Mermaid diagram',
+    entityRelationship: 'Mermaid entity relationship diagram',
+    flowchart: 'Mermaid flowchart',
+    journey: 'Mermaid journey diagram',
+    sequence: 'Mermaid sequence diagram',
+    state: 'Mermaid state diagram',
+    timeline: 'Mermaid timeline'
+  },
+  ja: {
+    class: 'Mermaid クラス図',
+    diagram: 'Mermaid 図',
+    entityRelationship: 'Mermaid ER 図',
+    flowchart: 'Mermaid フローチャート',
+    journey: 'Mermaid ジャーニー図',
+    sequence: 'Mermaid シーケンス図',
+    state: 'Mermaid 状態遷移図',
+    timeline: 'Mermaid タイムライン'
+  }
+} satisfies Record<RuntimeLocale, Record<MermaidDiagramKind, string>>;
+
+const runtimeLabels = {
+  en: {
+    locale: 'en',
+    artifactError: (index, detail) => `Artifact ${index}: ${detail}`,
+    artifactRenderError: (index, detail) => `Artifact ${index} failed to render: ${detail}`,
+    cellActions: 'Cell actions',
+    cellCompleted: 'Cell completed.',
+    cellCompletedWithoutOutput: 'Cell completed without output.',
+    cellInputs: 'Cell inputs',
+    cellOutput: (title) => `Output for ${title}`,
+    cellRunningAnnouncement: 'Cell execution started.',
+    chartCaption: 'Chart data summary',
+    chartLoadError: (detail) => `Chart renderer could not be loaded: ${detail}`,
+    chartLoading: 'Loading chart renderer...',
+    chartSummary: ({ dataCount, seriesCount, seriesNames, xRange, yRange }) =>
+      `Series: ${seriesCount}${seriesNames ? ` (${seriesNames})` : ''}. Data items: ${dataCount}.${xRange ? ` X range: ${xRange}.` : ''}${yRange ? ` Y range: ${yRange}.` : ''}`,
+    chartTitle: (kind) => chartTitles.en[kind],
+    clipboardUnavailable: 'Clipboard access is unavailable.',
+    copyCsv: 'Copy visible rows as CSV',
+    copyCsvError: (detail) => `Unable to copy CSV: ${detail}`,
+    copyCsvSuccess: 'Copied visible rows as CSV.',
+    copyingCsv: 'Copying CSV…',
+    diagnosticDetail: (detail) => detail,
+    executionError: (detail) => `Cell execution failed: ${detail}`,
+    executionErrorLabel: 'Cell execution failed:',
+    hideCode: 'Hide code',
+    htmlOutput: 'HTML output',
+    idleButton: 'Run the cell to show its output.',
+    idleReactive: 'Waiting for the runtime to start.',
+    imageOutput: 'Image output',
+    inputMaximum: (maximum) => `Enter a value no greater than ${maximum}.`,
+    inputMinimum: (minimum) => `Enter a value of at least ${minimum}.`,
+    inputNumber: 'Enter a number.',
+    inputStep: 'Enter a value that matches the allowed step.',
+    mermaidDescription: (source) => `Diagram source: ${boundedDescription(source)}`,
+    mermaidError: (detail) => `Mermaid diagram could not be rendered: ${detail}`,
+    mermaidLoading: 'Rendering diagram...',
+    mermaidTitle: (kind) => mermaidTitles.en[kind],
+    nextPage: 'Next page',
+    noChartData: 'The chart contains no data.',
+    outputTruncated: 'Output truncated.',
+    previousPage: 'Previous page',
+    rowsPerPage: 'Rows per page',
+    rowsRange: (first, last, total, truncated) => `Rows ${first}-${last} of ${total}${truncated ? ' (truncated)' : ''}`,
+    run: 'Run',
+    runtimeLanguage: runtimeLanguageLabel,
+    running: 'Running',
+    runningCell: 'Running cell...',
+    showCode: 'Show code',
+    tableControls: 'Table controls',
+    tableMissingValue: 'missing',
+    tableOutput: 'Data table',
+    unknownCell: (cellId) => `Unknown interactive cell: ${cellId}`
+  },
+  ja: {
+    locale: 'ja',
+    artifactError: (index, detail) => `成果物 ${index}: ${detail}`,
+    artifactRenderError: (index, detail) => `成果物 ${index} を表示できませんでした: ${detail}`,
+    cellActions: 'セルの操作',
+    cellCompleted: 'セルの実行が完了しました。',
+    cellCompletedWithoutOutput: 'セルの実行が完了しました。出力はありません。',
+    cellInputs: 'セルの入力',
+    cellOutput: (title) => `${title} の出力`,
+    cellRunningAnnouncement: 'セルの実行を開始しました。',
+    chartCaption: 'グラフデータの概要',
+    chartLoadError: (detail) => `グラフ表示を読み込めませんでした: ${detail}`,
+    chartLoading: 'グラフ表示を読み込んでいます…',
+    chartSummary: ({ dataCount, seriesCount, seriesNames, xRange, yRange }) =>
+      `系列数: ${seriesCount}${seriesNames ? `（${seriesNames}）` : ''}。データ数: ${dataCount}。${xRange ? `X の範囲: ${xRange}。` : ''}${yRange ? `Y の範囲: ${yRange}。` : ''}`,
+    chartTitle: (kind) => chartTitles.ja[kind],
+    clipboardUnavailable: 'クリップボードを利用できません。',
+    copyCsv: '表示中の行を CSV としてコピー',
+    copyCsvError: (detail) => `CSV をコピーできませんでした: ${translateDiagnostic(detail)}`,
+    copyCsvSuccess: '表示中の行を CSV としてコピーしました。',
+    copyingCsv: 'CSV をコピーしています…',
+    diagnosticDetail: translateDiagnostic,
+    executionError: (detail) => `セルの実行に失敗しました: ${translateDiagnostic(detail)}`,
+    executionErrorLabel: 'セルの実行に失敗しました:',
+    hideCode: 'コードを隠す',
+    htmlOutput: 'HTML 出力',
+    idleButton: 'セルを実行すると出力が表示されます。',
+    idleReactive: 'ランタイムの起動を待っています。',
+    imageOutput: '画像出力',
+    inputMaximum: (maximum) => `${maximum} 以下の値を入力してください。`,
+    inputMinimum: (minimum) => `${minimum} 以上の値を入力してください。`,
+    inputNumber: '数値を入力してください。',
+    inputStep: '指定された間隔に合う値を入力してください。',
+    mermaidDescription: (source) => `図のソース: ${boundedDescription(source)}`,
+    mermaidError: (detail) => `Mermaid 図を表示できませんでした: ${translateDiagnostic(detail)}`,
+    mermaidLoading: '図を表示しています…',
+    mermaidTitle: (kind) => mermaidTitles.ja[kind],
+    nextPage: '次のページ',
+    noChartData: 'グラフにデータがありません。',
+    outputTruncated: '出力は省略されています。',
+    previousPage: '前のページ',
+    rowsPerPage: '1ページあたりの行数',
+    rowsRange: (first, last, total, truncated) => `${total} 行中 ${first}–${last} 行${truncated ? '（省略あり）' : ''}`,
+    run: '実行',
+    runtimeLanguage: runtimeLanguageLabel,
+    running: '実行中…',
+    runningCell: 'セルを実行中…',
+    showCode: 'コードを表示',
+    tableControls: '表の操作',
+    tableMissingValue: '値なし',
+    tableOutput: 'データ表',
+    unknownCell: (cellId) => `不明な実行可能セル: ${cellId}`
+  }
+} satisfies Record<RuntimeLocale, RuntimeLabels>;
+
+export function labelsForLanguage(languageTag?: string): RuntimeLabels {
+  return runtimeLabels[localeFromLanguage(languageTag)];
+}
+
+export function localeFromLanguage(languageTag?: string): RuntimeLocale {
+  const primarySubtag = languageTag?.trim().split('-')[0]?.toLowerCase();
+  return primarySubtag === 'ja' ? 'ja' : 'en';
+}
+
+function boundedDescription(source: string): string {
+  const normalized = source.replace(/\s+/gu, ' ').trim();
+  return normalized.length <= 1_000 ? normalized : `${normalized.slice(0, 997)}…`;
+}
+
+function runtimeLanguageLabel(language: 'haskell' | 'python' | 'rust'): string {
+  switch (language) {
+    case 'rust':
+      return 'Rust + Wasm';
+    case 'python':
+      return 'Python + Pyodide';
+    case 'haskell':
+      return 'Haskell + WASI';
+  }
+}
+
+function translateDiagnostic(detail: string): string {
+  const artifactLimit = /^Artifact limit exceeded: received (\d+), maximum (\d+)\.$/u.exec(detail);
+  if (artifactLimit) {
+    return `成果物の上限を超えました。${artifactLimit[1]} 件を受け取りましたが、上限は ${artifactLimit[2]} 件です。`;
+  }
+  if (detail.includes('exceeds the remaining 16 MiB run limit')) {
+    return '実行あたり 16 MiB の残り上限を超えています。';
+  }
+  const chartLimit = /^Chart data item limit exceeded: received (\d+), maximum (\d+)\.$/u.exec(detail);
+  if (chartLimit) {
+    return `グラフデータの上限を超えました。${chartLimit[1]} 件を受け取りましたが、上限は ${chartLimit[2]} 件です。`;
+  }
+  return detail;
+}

--- a/packages/oxiquill/src/lib/doc-runtime/runtime-localization.ts
+++ b/packages/oxiquill/src/lib/doc-runtime/runtime-localization.ts
@@ -60,8 +60,11 @@ export type RuntimeLabels = {
   runningCell: string;
   showCode: string;
   tableControls: string;
+  tableCellTypeError: (type: string) => string;
+  tableFiniteNumberError: string;
   tableMissingValue: string;
   tableOutput: string;
+  tableRowWidthError: (row: number, received: number, expected: number) => string;
   unknownCell: (cellId: string) => string;
 };
 
@@ -157,8 +160,11 @@ const runtimeLabels = {
     runningCell: 'Running cell...',
     showCode: 'Show code',
     tableControls: 'Table controls',
+    tableCellTypeError: (type) => `Unsupported validated table cell type: ${type}.`,
+    tableFiniteNumberError: 'Validated table cells must contain finite numbers.',
     tableMissingValue: 'missing',
     tableOutput: 'Data table',
+    tableRowWidthError: (row, received, expected) => `Row ${row} has ${received} cells; expected ${expected}.`,
     unknownCell: (cellId) => `Unknown interactive cell: ${cellId}`
   },
   ja: {
@@ -210,8 +216,12 @@ const runtimeLabels = {
     runningCell: 'セルを実行中…',
     showCode: 'コードを表示',
     tableControls: '表の操作',
+    tableCellTypeError: (type) => `検証済み表セルの型 ${type} には対応していません。`,
+    tableFiniteNumberError: '検証済み表セルには有限の数値が必要です。',
     tableMissingValue: '値なし',
     tableOutput: 'データ表',
+    tableRowWidthError: (row, received, expected) =>
+      `${row} 行目のセルは ${received} 個ですが、${expected} 個である必要があります。`,
     unknownCell: (cellId) => `不明な実行可能セル: ${cellId}`
   }
 } satisfies Record<RuntimeLocale, RuntimeLabels>;
@@ -242,6 +252,10 @@ function runtimeLanguageLabel(language: 'haskell' | 'python' | 'rust'): string {
 }
 
 function translateDiagnostic(detail: string): string {
+  const timeout = /^(.*) timed out after (\d+)ms$/u.exec(detail);
+  if (timeout) {
+    return `${timeout[1]} は ${timeout[2]} ミリ秒でタイムアウトしました。`;
+  }
   const artifactLimit = /^Artifact limit exceeded: received (\d+), maximum (\d+)\.$/u.exec(detail);
   if (artifactLimit) {
     return `成果物の上限を超えました。${artifactLimit[1]} 件を受け取りましたが、上限は ${artifactLimit[2]} 件です。`;

--- a/packages/oxiquill/src/lib/doc-runtime/types.ts
+++ b/packages/oxiquill/src/lib/doc-runtime/types.ts
@@ -11,6 +11,7 @@ export interface InputSpec {
   name: string;
   type: InputType;
   label: string;
+  description?: string;
   value: string | number | boolean;
   min?: number;
   max?: number;

--- a/packages/oxiquill/src/styles/custom.css
+++ b/packages/oxiquill/src/styles/custom.css
@@ -3,6 +3,29 @@
   --rn-panel-bg: color-mix(in srgb, var(--sl-color-bg), var(--sl-color-gray-6) 14%);
   --rn-accent: #0f766e;
   --rn-danger: #b91c1c;
+  --rn-focus: var(--sl-color-text-accent);
+}
+
+.doc-visually-hidden {
+  position: absolute !important;
+  width: 1px !important;
+  height: 1px !important;
+  padding: 0 !important;
+  margin: -1px !important;
+  overflow: hidden !important;
+  clip: rect(0, 0, 0, 0) !important;
+  white-space: nowrap !important;
+  border: 0 !important;
+}
+
+.doc-cell button:focus-visible,
+.doc-cell input:focus-visible,
+.doc-cell select:focus-visible,
+.doc-cell textarea:focus-visible,
+.doc-table-output button:focus-visible,
+.doc-table-output select:focus-visible {
+  outline: 3px solid var(--rn-focus);
+  outline-offset: 3px;
 }
 
 .doc-cell,
@@ -126,6 +149,10 @@
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 0.85rem;
+  min-width: 0;
+  margin: 0;
+  padding: 0;
+  border: 0;
 }
 
 .doc-input {
@@ -137,12 +164,24 @@
   border: 0;
 }
 
-.doc-input span,
-.doc-input legend {
+.doc-input label,
+.doc-input legend,
+.doc-input__label-row {
   display: flex;
   justify-content: space-between;
   gap: 0.5rem;
   font-size: 0.9rem;
+}
+
+.doc-input__label-row output {
+  font-weight: 650;
+}
+
+.doc-input__description,
+.doc-input__validation {
+  margin: 0;
+  color: var(--sl-color-gray-2);
+  font-size: 0.8rem;
 }
 
 .doc-input input:not([type='checkbox']):not([type='radio']),
@@ -184,6 +223,30 @@
 .doc-cell__outputs {
   display: grid;
   gap: 0.85rem;
+}
+
+.doc-cell__output-region {
+  display: grid;
+  gap: 0.85rem;
+}
+
+.doc-chart-output {
+  display: grid;
+  gap: 0.45rem;
+  min-width: 0;
+  margin: 0;
+}
+
+.doc-chart-output figcaption {
+  display: grid;
+  gap: 0.2rem;
+}
+
+.doc-chart-output figcaption span,
+.doc-chart-output__summary {
+  margin: 0;
+  color: var(--sl-color-gray-2);
+  font-size: 0.85rem;
 }
 
 .doc-plot {
@@ -304,6 +367,10 @@
   justify-content: space-between;
   gap: 0.6rem;
   flex-wrap: wrap;
+  min-width: 0;
+  margin: 0;
+  padding: 0;
+  border: 0;
 }
 
 .doc-table-output__controls label {

--- a/packages/oxiquill/src/styles/custom.css
+++ b/packages/oxiquill/src/styles/custom.css
@@ -95,7 +95,9 @@
   cursor: pointer;
 }
 
-.run-button:disabled {
+.run-button:disabled,
+.run-button[aria-disabled='true'],
+.doc-table-output button[aria-disabled='true'] {
   cursor: wait;
   opacity: 0.72;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@arethetypeswrong/cli':
         specifier: 0.18.5
         version: 0.18.5
+      '@axe-core/playwright':
+        specifier: 4.13.0
+        version: 4.13.0(playwright-core@1.61.1)
       '@bjorn3/browser_wasi_shim':
         specifier: 0.4.2
         version: 0.4.2
@@ -318,6 +321,11 @@ packages:
 
   '@astrojs/yaml2ts@0.2.4':
     resolution: {integrity: sha512-8oddpOae35pJsXPQXhTkM0ypfKPskVsh2bCxRtbf7e+/Epw2nReakFYpLKjZMEr75CsoF203PMnCocpfz0s69A==}
+
+  '@axe-core/playwright@4.13.0':
+    resolution: {integrity: sha512-6YLx+kxXu5GJceG4ozFg+33a2EMTdjYwWGloJ3sb9Kta5pp+ZNS53uxGVog5JetIY8s++P5UrtX+cri+u0VAVg==}
+    peerDependencies:
+      playwright-core: '>= 1.0.0'
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
@@ -1713,6 +1721,10 @@ packages:
   available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
+
+  axe-core@4.13.0:
+    resolution: {integrity: sha512-UzGt8zg7Ny8djbYMhxl2zuEevVa7r2gJjYY5Lwr1xM7+XU2nd6CkIWFTVcCIbAP63vSz71NaVyyuSk9lHKcy0A==}
+    engines: {node: '>=4'}
 
   axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
@@ -4785,6 +4797,11 @@ snapshots:
     dependencies:
       yaml: 2.9.0
 
+  '@axe-core/playwright@4.13.0(playwright-core@1.61.1)':
+    dependencies:
+      axe-core: 4.13.0
+      playwright-core: 1.61.1
+
   '@babel/code-frame@7.29.0':
     dependencies:
       '@babel/helper-validator-identifier': 7.28.5
@@ -6242,6 +6259,8 @@ snapshots:
   available-typed-arrays@1.0.7:
     dependencies:
       possible-typed-array-names: 1.1.0
+
+  axe-core@4.13.0: {}
 
   axobject-query@4.1.0: {}
 

--- a/tests/e2e/accessibility.spec.ts
+++ b/tests/e2e/accessibility.spec.ts
@@ -1,0 +1,103 @@
+import AxeBuilder from '@axe-core/playwright';
+import { expect, test } from '@playwright/test';
+import type { Locator, Page } from '@playwright/test';
+
+const wcag22AATags = ['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa', 'wcag22a', 'wcag22aa'];
+
+test.describe('runtime accessibility', () => {
+  test('interactive cells expose localized semantics and support keyboard-only execution', async ({
+    browserName,
+    page
+  }) => {
+    test.setTimeout(180_000);
+
+    await page.goto('/features/interactive-cells/');
+    const englishCell = page.getByTestId('cell-features__interactive-cells__run-mode-button');
+    await hydrateCell(englishCell);
+
+    const englishInput = englishCell.getByRole('spinbutton', { name: 'Input value' });
+    await expect(englishInput).toHaveAccessibleDescription('Choose an integer from 1 through 10.');
+    await englishInput.focus();
+    await englishInput.press('ArrowUp');
+    await expect(englishInput).toHaveValue('4');
+
+    const sourceToggle = englishCell.getByRole('button', { name: 'Hide code' });
+    await sourceToggle.focus();
+    await sourceToggle.press('Enter');
+    const collapsedSourceToggle = englishCell.getByRole('button', { name: 'Show code' });
+    await expect(collapsedSourceToggle).toHaveAttribute('aria-expanded', 'false');
+    await expect(collapsedSourceToggle).toBeFocused();
+
+    const runButton = englishCell.getByRole('button', { name: 'Run' });
+    await runButton.focus();
+    await runButton.press('Enter');
+    await expect(englishCell.getByTestId('run-output')).toContainText('button value = 4');
+    await expect(runButton).toBeFocused();
+    await expectNoWcag22AAViolations(page, browserName);
+
+    await page.goto('/ja/features/interactive-cells/');
+    const japaneseCell = page.getByTestId('cell-ja__features__interactive-cells__run-mode-button');
+    await hydrateCell(japaneseCell);
+    await expect(japaneseCell.getByRole('button', { name: '実行' })).toBeVisible();
+    await expect(japaneseCell.getByRole('region', { name: 'Explicit button execution の出力' })).toBeVisible({
+      timeout: 10_000
+    });
+    await expectNoWcag22AAViolations(page, browserName);
+  });
+
+  test('rich outputs provide accessible chart and table equivalents in both locales', async ({ browserName, page }) => {
+    test.setTimeout(240_000);
+
+    for (const example of [
+      {
+        path: '/features/rich-output/',
+        cellId: 'cell-features__rich-output__rust-rich-outputs',
+        runLabel: 'Run',
+        tableLabel: 'Data table'
+      },
+      {
+        path: '/ja/features/rich-output/',
+        cellId: 'cell-ja__features__rich-output__rust-rich-outputs',
+        runLabel: '実行',
+        tableLabel: 'データ表'
+      }
+    ]) {
+      await page.goto(example.path);
+      const cell = page.getByTestId(example.cellId);
+      await hydrateCell(cell);
+      await cell.getByRole('button', { name: example.runLabel }).press('Enter');
+      await expect(cell.getByRole('table', { name: example.tableLabel }).first()).toBeVisible();
+      await expect(cell.getByRole('figure').first()).toHaveAccessibleDescription(/Data items|データ数/u);
+      await expect(cell.getByTestId('doc-plot').first()).toHaveAttribute('aria-hidden', 'true');
+      await expectNoWcag22AAViolations(page, browserName);
+    }
+  });
+
+  test('Mermaid diagrams expose a localized image name and description', async ({ browserName, page }) => {
+    for (const example of [
+      { path: '/features/diagrams/', name: /Mermaid (?:flowchart|diagram)/u, description: /Diagram source:/u },
+      { path: '/ja/features/diagrams/', name: /Mermaid (?:フローチャート|図)/u, description: /図のソース:/u }
+    ]) {
+      await page.goto(example.path);
+      const diagram = page.getByRole('img', { name: example.name }).first();
+      await diagram.scrollIntoViewIfNeeded();
+      await expect(diagram).toHaveAccessibleDescription(example.description);
+      await expect(diagram.locator('svg')).toHaveAttribute('aria-hidden', 'true');
+      await expectNoWcag22AAViolations(page, browserName);
+    }
+  });
+});
+
+async function expectNoWcag22AAViolations(page: Page, browserName: string): Promise<void> {
+  const builder = new AxeBuilder({ page }).withTags(wcag22AATags);
+  if (browserName === 'webkit') builder.setLegacyMode();
+  const results = await builder.analyze();
+  const summary = results.violations.map(({ help, id, nodes }) => ({ help, id, nodes: nodes.length }));
+  expect(results.violations, JSON.stringify(summary, null, 2)).toEqual([]);
+}
+
+async function hydrateCell(cell: Locator): Promise<void> {
+  await cell.scrollIntoViewIfNeeded();
+  const island = cell.locator('xpath=ancestor::astro-island');
+  await expect.poll(() => island.getAttribute('ssr')).toBeNull();
+}

--- a/tests/e2e/interactive.spec.ts
+++ b/tests/e2e/interactive.spec.ts
@@ -107,7 +107,7 @@ test('button, reactive, and autorun cells follow their execution contracts', asy
 
   const button = page.getByTestId('cell-features__interactive-cells__run-mode-button');
   await hydrateCell(button);
-  await expect(button.getByLabel('value')).toBeVisible();
+  await expect(button.getByLabel('Input value')).toBeVisible();
   await expect(button.getByRole('button', { name: 'Run' })).toBeVisible();
   await page.waitForTimeout(200);
   expect(await workerMessagesForCell(page, 'features__interactive-cells__run-mode-button')).toHaveLength(0);

--- a/tests/package/consumer-smoke.mjs
+++ b/tests/package/consumer-smoke.mjs
@@ -95,6 +95,29 @@ try {
   packageJson.scripts['wasm:dev'] = 'oxiquill docgen --wasm dev';
   await writeFile(packageJsonPath, `${JSON.stringify(packageJson, null, 2)}\n`);
   await writeFile(path.join(projectRoot, 'package-api.ts'), packageApiSource);
+  run(packageManager, ['install'], consumerRoot);
+  run(
+    packageManager,
+    packageManager === 'npm' ? ['exec', '--', 'oxiquill', 'help'] : ['exec', 'oxiquill', 'help'],
+    consumerRoot
+  );
+  run(
+    'node',
+    ['--input-type=module', '--eval', "await import('oxiquill'); await import('oxiquill/astro');"],
+    consumerRoot
+  );
+  const packedCliPath = path.join(consumerRoot, 'node_modules/oxiquill/dist/cli/index.mjs');
+  const nodeOnlyEnvironment = createNodeOnlyEnvironment();
+  run(process.execPath, [packedCliPath, 'check'], consumerRoot, false, nodeOnlyEnvironment);
+  run(process.execPath, [packedCliPath, 'build'], consumerRoot, false, nodeOnlyEnvironment);
+
+  await assertFile(path.join(projectRoot, 'state cache/generated runtime/cells.json'));
+  await assertMissing(path.join(projectRoot, 'state cache/rust-cells'));
+  await assertMissing(path.join(projectRoot, 'state cache/haskell-cells'));
+  await assertMissing(path.join(projectRoot, 'static files/oxiquill assets/python runtime'));
+  await assertMissing(path.join(projectRoot, 'static files/oxiquill assets/rust runtime'));
+  await assertMissing(path.join(projectRoot, 'static files/oxiquill assets/haskell runtime'));
+
   await appendFile(
     path.join(projectRoot, 'written docs/index.mdx'),
     [
@@ -114,17 +137,6 @@ try {
     ].join('\n')
   );
 
-  run(packageManager, ['install'], consumerRoot);
-  run(
-    packageManager,
-    packageManager === 'npm' ? ['exec', '--', 'oxiquill', 'help'] : ['exec', 'oxiquill', 'help'],
-    consumerRoot
-  );
-  run(
-    'node',
-    ['--input-type=module', '--eval', "await import('oxiquill'); await import('oxiquill/astro');"],
-    consumerRoot
-  );
   run(packageManager, ['run', 'check'], consumerRoot);
   run(packageManager, ['run', 'wasm:dev'], consumerRoot);
   run(packageManager, ['run', 'build'], consumerRoot);
@@ -162,6 +174,10 @@ try {
     'packed consumer emitted an oversized client chunk'
   );
   await assertFile(path.join(projectRoot, 'static files/oxiquill assets/rust runtime/doc_rust_cells_bg.wasm'));
+  for (const fileName of ['doc_rust_cells.d.ts', 'doc_rust_cells_bg.wasm.d.ts', 'package.json']) {
+    await assertMissing(path.join(projectRoot, 'static files/oxiquill assets/rust runtime', fileName));
+    await assertMissing(path.join(projectRoot, 'built site/oxiquill assets/rust runtime', fileName));
+  }
   await assertFile(path.join(projectRoot, 'state cache/generated runtime/cells.json'));
 
   run(packageManager, ['run', 'clean'], consumerRoot);
@@ -175,19 +191,28 @@ try {
   await rm(temporaryRoot, { force: true, recursive: true });
 }
 
-function run(command, args, cwd, capture = false) {
+function run(command, args, cwd, capture = false, environment = process.env) {
   const isWindowsPackageManager = process.platform === 'win32' && (command === 'npm' || command === 'pnpm');
   const executable = isWindowsPackageManager ? (process.env.ComSpec ?? 'cmd.exe') : command;
   const commandArgs = isWindowsPackageManager ? ['/d', '/s', '/c', `${command}.cmd`, ...args] : args;
   const result = spawnSync(executable, commandArgs, {
     cwd,
     encoding: 'utf8',
-    env: process.env,
+    env: environment,
     stdio: capture ? ['ignore', 'pipe', 'pipe'] : 'inherit'
   });
   assert.ifError(result.error);
   assert.equal(result.status, 0, capture ? result.stderr || result.stdout : `${command} failed`);
   return result;
+}
+
+function createNodeOnlyEnvironment() {
+  const environment = { ...process.env };
+  const pathKey = Object.keys(environment).find((key) => key.toUpperCase() === 'PATH') ?? 'PATH';
+  environment[pathKey] = path.dirname(process.execPath);
+  environment.OXIQUILL_NODE = process.execPath;
+  delete environment.OXIQUILL_HASKELL_GHC;
+  return environment;
 }
 
 async function assertFile(filePath) {

--- a/tests/unit/cli.test.mjs
+++ b/tests/unit/cli.test.mjs
@@ -59,7 +59,8 @@ beforeEach(() => {
   cliMocks.syncDocRuntime.mockResolvedValue({
     cellCount: 1,
     haskellCellCount: 1,
-    haskellFingerprint: 'haskell-fingerprint'
+    haskellFingerprint: 'haskell-fingerprint',
+    rustCellCount: 1
   });
   cliMocks.buildHaskellWasm.mockResolvedValue({ ok: true });
 });
@@ -179,10 +180,11 @@ describe('oxiquill CLI', () => {
   it('preserves case-insensitive PATH keys in the framework environment', () => {
     const nodePath = fakeNodeExecutable(path.join(testRoot, 'node', 'bin'));
     const toolPath = path.join(testRoot, 'tools', 'bin');
-    const env = frameworkEnv(actualPaths, { env: { Path: toolPath }, nodePath });
+    const env = frameworkEnv(actualPaths, { env: { Path: toolPath }, nodePath, runtimeOwner: 'cli' });
 
     expect(env.Path).toBe(`${path.dirname(nodePath)}${path.delimiter}${toolPath}`);
     expect(env.PATH).toBeUndefined();
+    expect(env.OXIQUILL_RUNTIME_OWNER).toBe('cli');
   });
 
   it('uses a later PATH node for Astro when the current node cannot load native addons', () => {
@@ -275,14 +277,14 @@ describe('oxiquill CLI', () => {
     await runCli('docgen', [], { cwd: repoRoot });
     expect(cliMocks.syncDocRuntime).toHaveBeenCalledTimes(1);
     expect(cliMocks.buildRustWasm).not.toHaveBeenCalled();
-    expect(cliMocks.markRuntimeReady).toHaveBeenCalledTimes(1);
+    expect(cliMocks.syncDocRuntime).toHaveBeenLastCalledWith(
+      expect.objectContaining({ mode: undefined, tolerateHaskellBuildFailure: false })
+    );
 
     await runCli('docgen', ['--wasm', 'dev'], { cwd: repoRoot });
-    expect(cliMocks.buildRustWasm).toHaveBeenCalledWith(expect.objectContaining({ mode: 'dev' }));
-    expect(cliMocks.buildHaskellWasm).toHaveBeenCalledWith(
-      expect.objectContaining({ haskellFingerprint: 'haskell-fingerprint', mode: 'dev' })
+    expect(cliMocks.syncDocRuntime).toHaveBeenLastCalledWith(
+      expect.objectContaining({ mode: 'dev', tolerateHaskellBuildFailure: false })
     );
-    expect(cliMocks.syncLicenseArtifacts).toHaveBeenCalledTimes(1);
     expect(log).toHaveBeenCalledWith('Generated 1 interactive cell(s).');
   });
 
@@ -304,8 +306,19 @@ describe('oxiquill CLI', () => {
       ['test', '--node', path.join(repoRoot, '.oxiquill', 'rust-cells')],
       { cwd: repoRoot }
     );
-    expect(cliMocks.buildRustWasm).toHaveBeenCalledWith(expect.objectContaining({ mode: 'dev' }));
+    expect(cliMocks.syncDocRuntime).toHaveBeenCalledWith(expect.objectContaining({ mode: 'dev' }));
     expect(log).toHaveBeenCalled();
+  });
+
+  it('skips wasm-pack tests when the manifest contains no Rust cells', async () => {
+    cliMocks.syncDocRuntime.mockResolvedValue({ cellCount: 0, rustCellCount: 0 });
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const runCommand = vi.fn(async () => undefined);
+
+    await runCli('test-wasm', [], { cwd: repoRoot, runCommand });
+
+    expect(runCommand).not.toHaveBeenCalledWith('wasm-pack', expect.anything(), expect.anything());
+    expect(log).toHaveBeenCalledWith('[runtime] no Rust cells; skipping wasm-pack test');
   });
 
   it('reports missing CLI entrypoints and unusable Node overrides', () => {

--- a/tests/unit/components.test.tsx
+++ b/tests/unit/components.test.tsx
@@ -42,6 +42,7 @@ vi.mock('../../packages/oxiquill/src/lib/doc-runtime/runtime-client', () => ({
   runInteractiveCell: runtimeMocks.runInteractiveCell
 }));
 
+await import('./mocks/mermaid');
 const { default: InteractiveCell } = await import('../../packages/oxiquill/src/components/doc-runtime/InteractiveCell');
 const {
   default: MermaidDiagram,

--- a/tests/unit/components.test.tsx
+++ b/tests/unit/components.test.tsx
@@ -5,6 +5,7 @@ import {
   validateOutputArtifacts,
   type ValidatedImageArtifact
 } from '../../packages/oxiquill/src/lib/doc-runtime/output-artifact-validation';
+import { labelsForLanguage } from '../../packages/oxiquill/src/lib/doc-runtime/runtime-localization';
 import { chart, echartsInit, echartsUse, mermaidInitialize, mermaidRender } from './mocks/external-runtime';
 
 type ManifestSnapshot = {
@@ -42,15 +43,18 @@ vi.mock('../../packages/oxiquill/src/lib/doc-runtime/runtime-client', () => ({
 }));
 
 const { default: InteractiveCell } = await import('../../packages/oxiquill/src/components/doc-runtime/InteractiveCell');
-const { default: MermaidDiagram, getMermaidColorScheme } =
-  await import('../../packages/oxiquill/src/components/doc-runtime/MermaidDiagram');
+const {
+  default: MermaidDiagram,
+  getMermaidColorScheme,
+  mermaidDiagramKind
+} = await import('../../packages/oxiquill/src/components/doc-runtime/MermaidDiagram');
 const {
   default: OutputRenderer,
   imageArtifactSource,
   LazyChartOutput
 } = await import('../../packages/oxiquill/src/components/doc-runtime/OutputRenderer');
 const chartOutputModule = await import('../../packages/oxiquill/src/components/doc-runtime/ChartOutput');
-const { chartSpecToEChartsOptions } = chartOutputModule;
+const { chartDataSummary, chartSpecToEChartsOptions } = chartOutputModule;
 const {
   default: TableOutput,
   formatTableCell,
@@ -268,15 +272,126 @@ describe('InteractiveCell', () => {
     expect(secondCompact).toBeChecked();
   });
 
+  it('uses visible input labels as accessible names and associates optional descriptions', () => {
+    setManifestCells([
+      makeCell({
+        inputs: [
+          {
+            name: 'internal_value',
+            type: 'number',
+            label: 'Visible value',
+            description: 'Choose a value from zero through ten.',
+            value: 2,
+            min: 0,
+            max: 10,
+            step: 1,
+            options: []
+          },
+          {
+            name: 'internal_range',
+            type: 'range',
+            label: 'Visible range',
+            description: 'Adjust the sample range.',
+            value: 1.5,
+            min: 0,
+            max: 4,
+            step: 0.5,
+            options: []
+          }
+        ]
+      })
+    ]);
+
+    render(<InteractiveCell cellId="cell-one" />);
+
+    const number = screen.getByRole('spinbutton', { name: 'Visible value' });
+    expect(number).toHaveAttribute('id', 'doc-input-cell-one-internal_value');
+    expect(number).toHaveAccessibleDescription('Choose a value from zero through ten.');
+    expect(screen.queryByRole('spinbutton', { name: 'internal_value' })).not.toBeInTheDocument();
+
+    const range = screen.getByRole('slider', { name: 'Visible range' });
+    expect(range).toHaveAttribute('id', 'doc-input-cell-one-internal_range');
+    expect(range).toHaveAttribute(
+      'aria-describedby',
+      'doc-input-cell-one-internal_range-description doc-input-cell-one-internal_range-value'
+    );
+    expect(screen.getByTestId('internal_range-value')).toHaveAttribute('for', 'doc-input-cell-one-internal_range');
+  });
+
+  it('reports numeric validation with localized error semantics', () => {
+    document.documentElement.lang = 'ja';
+    setManifestCells([
+      makeCell({
+        inputs: [
+          {
+            name: 'count',
+            type: 'number',
+            label: '回数',
+            value: 2,
+            min: 1,
+            max: 10,
+            step: 1,
+            options: []
+          }
+        ]
+      })
+    ]);
+
+    render(<InteractiveCell cellId="cell-one" />);
+    const input = screen.getByRole('spinbutton', { name: '回数' });
+    fireEvent.input(input, { target: { value: '0' } });
+
+    expect(input).toHaveAttribute('aria-invalid', 'true');
+    expect(input).toHaveAttribute('aria-errormessage', 'doc-input-cell-one-count-validation');
+    expect(screen.getByRole('alert')).toHaveTextContent('1 以上の値を入力してください。');
+  });
+
   it('shows running and error states', async () => {
     setManifestCells([makeCell()]);
     mocks.runInteractiveCell.mockRejectedValue(new Error('failed'));
 
     render(<InteractiveCell cellId="cell-one" />);
-    fireEvent.click(screen.getByRole('button', { name: 'Run' }));
+    const runButton = screen.getByRole('button', { name: 'Run' });
+    runButton.focus();
+    fireEvent.click(runButton);
 
     expect(screen.getByText('Running cell...')).toBeVisible();
-    await waitFor(() => expect(screen.getByText('failed')).toBeVisible());
+    expect(within(screen.getByRole('region', { name: 'Output for Cell one' })).getByRole('status')).toHaveTextContent(
+      'Cell execution started.'
+    );
+    expect(screen.getByRole('button', { name: 'Running' })).toHaveAttribute('aria-disabled', 'true');
+    expect(screen.getByRole('button', { name: 'Running' })).toHaveAttribute('aria-busy', 'true');
+    expect(screen.getByRole('button', { name: 'Running' })).toHaveFocus();
+    await waitFor(() => expect(screen.getByRole('alert')).toHaveTextContent('Cell execution failed: failed'));
+    expect(screen.getByRole('button', { name: 'Run' })).toHaveFocus();
+  });
+
+  it('announces successful completion politely without moving focus', async () => {
+    const execution = createDeferredResult();
+    mocks.runInteractiveCell.mockReturnValue(execution.promise);
+    setManifestCells([makeCell()]);
+
+    render(<InteractiveCell cellId="cell-one" />);
+    const runButton = screen.getByRole('button', { name: 'Run' });
+    runButton.focus();
+    fireEvent.click(runButton);
+
+    await act(async () => {
+      execution.resolve({
+        stdout: 'done',
+        plots: [],
+        outputs: [{ kind: 'text', stream: 'stdout', content: 'done' }]
+      });
+      await execution.promise;
+    });
+
+    await waitFor(() =>
+      expect(within(screen.getByRole('region', { name: 'Output for Cell one' })).getByRole('status')).toHaveTextContent(
+        'Cell completed.'
+      )
+    );
+    expect(screen.getByRole('button', { name: 'Run' })).toHaveFocus();
+    expect(screen.getByTestId('run-output')).toHaveTextContent('done');
   });
 
   it('coerces non-Error failures to strings', async () => {
@@ -287,6 +402,23 @@ describe('InteractiveCell', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Run' }));
 
     await waitFor(() => expect(screen.getByText('string failure')).toBeVisible());
+  });
+
+  it('announces localized timeout failures as an alert', async () => {
+    document.documentElement.lang = 'ja';
+    setManifestCells([makeCell()]);
+    mocks.runInteractiveCell.mockRejectedValue(new Error('Cell one timed out after 1000ms'));
+
+    render(<InteractiveCell cellId="cell-one" />);
+    await waitFor(() => expect(screen.getByRole('button', { name: '実行' })).toBeVisible());
+    fireEvent.click(screen.getByRole('button', { name: '実行' }));
+
+    await waitFor(() =>
+      expect(screen.getByRole('alert')).toHaveTextContent(
+        'セルの実行に失敗しました: Cell one は 1000 ミリ秒でタイムアウトしました。'
+      )
+    );
+    expect(screen.getAllByRole('alert')).toHaveLength(1);
   });
 
   it('runs autorun exactly once per cell and runtime version without rendering execution controls', async () => {
@@ -514,10 +646,14 @@ describe('MermaidDiagram', () => {
       bindFunctions: vi.fn()
     });
 
-    const { rerender } = render(<MermaidDiagram diagramId="one" source="flowchart LR\nA-->B" />);
+    const { rerender } = render(<MermaidDiagram diagramId="one" source={'flowchart LR\nA-->B'} />);
 
     await waitFor(() => expect(screen.getByTestId('mermaid-diagram')).toHaveAttribute('data-state', 'ready'));
     expect(screen.getByText('diagram')).toBeVisible();
+    const graphic = screen.getByRole('img', { name: 'Mermaid flowchart' });
+    expect(graphic).toHaveAccessibleDescription('Diagram source: flowchart LR A-->B');
+    expect(graphic.querySelector('svg')).toHaveAttribute('aria-hidden', 'true');
+    expect(graphic.querySelector('svg')).toHaveAttribute('focusable', 'false');
     expect(mocks.mermaidInitialize).toHaveBeenCalledTimes(1);
     expect(mocks.mermaidInitialize).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -528,9 +664,27 @@ describe('MermaidDiagram', () => {
       })
     );
 
-    rerender(<MermaidDiagram diagramId="one" source="flowchart LR\nA-->C" />);
+    rerender(<MermaidDiagram diagramId="one" source={'flowchart LR\nA-->C'} />);
     await waitFor(() => expect(mocks.mermaidRender).toHaveBeenCalledTimes(2));
     expect(mocks.mermaidInitialize).toHaveBeenCalledTimes(1);
+  });
+
+  it('localizes Mermaid semantics and identifies supported diagram kinds', async () => {
+    document.documentElement.lang = 'ja-JP';
+    mocks.mermaidRender.mockResolvedValue({ svg: '<svg><text>sequence</text></svg>' });
+
+    render(<MermaidDiagram diagramId="sequence" source={'sequenceDiagram\nAlice->>Bob: Hello'} />);
+
+    await waitFor(() => expect(screen.getByTestId('mermaid-diagram')).toHaveAttribute('data-state', 'ready'));
+    expect(screen.getByRole('img', { name: 'Mermaid シーケンス図' })).toHaveAccessibleDescription(
+      '図のソース: sequenceDiagram Alice->>Bob: Hello'
+    );
+    expect(mermaidDiagramKind('%% comment\nstateDiagram-v2')).toBe('state');
+    expect(mermaidDiagramKind('classDiagram')).toBe('class');
+    expect(mermaidDiagramKind('erDiagram')).toBe('entityRelationship');
+    expect(mermaidDiagramKind('journey')).toBe('journey');
+    expect(mermaidDiagramKind('timeline')).toBe('timeline');
+    expect(mermaidDiagramKind('unknown')).toBe('diagram');
   });
 
   it('renders when theme observation is unavailable', async () => {
@@ -808,6 +962,32 @@ describe('ChartOutput options', () => {
       legend: { top: 4 }
     });
   });
+
+  it('summarizes chart series and ranges in the selected locale', () => {
+    const spec = {
+      kind: 'line' as const,
+      series: [
+        { name: 'alpha', points: [[0, 2]] as const },
+        {
+          name: 'beta',
+          points: [
+            [1, -3],
+            [2, 7]
+          ] as const
+        }
+      ]
+    };
+
+    expect(chartDataSummary(spec, labelsForLanguage('en'))).toBe(
+      'Series: 2 (alpha, beta). Data items: 3. X range: 0–2. Y range: -3–7.'
+    );
+    expect(chartDataSummary(spec, labelsForLanguage('ja'))).toBe(
+      '系列数: 2（alpha, beta）。データ数: 3。X の範囲: 0–2。Y の範囲: -3–7。'
+    );
+    expect(chartDataSummary({ kind: 'bar', categories: [], series: [] }, labelsForLanguage('en'))).toBe(
+      'The chart contains no data.'
+    );
+  });
 });
 
 describe('OutputRenderer', () => {
@@ -930,6 +1110,39 @@ describe('OutputRenderer', () => {
     expect(screen.getByTestId('run-output')).toBeVisible();
     expect(screen.getByTestId('artifact-truncated')).toHaveTextContent('Output truncated.');
   });
+
+  it('renders a textual chart equivalent and hides the canvas surface from accessibility APIs', async () => {
+    render(
+      <OutputRenderer
+        idPrefix="semantic-output"
+        outputs={validateOutputArtifacts([
+          {
+            kind: 'chart',
+            title: 'Response time',
+            caption: 'Measured during the sample run.',
+            spec: {
+              kind: 'line',
+              series: [
+                {
+                  name: 'milliseconds',
+                  points: [
+                    [0, 12],
+                    [1, 18]
+                  ]
+                }
+              ]
+            }
+          }
+        ])}
+      />
+    );
+
+    await waitFor(() => expect(screen.getByTestId('doc-plot')).toBeVisible());
+    const figure = screen.getByRole('figure', { name: 'Response time' });
+    expect(figure).toHaveAccessibleDescription(/Series: 1 \(milliseconds\)\. Data items: 2\./u);
+    expect(screen.getByText('Measured during the sample run.')).toBeVisible();
+    expect(screen.getByTestId('doc-plot')).toHaveAttribute('aria-hidden', 'true');
+  });
 });
 
 describe('TableOutput', () => {
@@ -1034,6 +1247,69 @@ describe('TableOutput', () => {
     expect(screen.getByRole('alert')).toHaveTextContent('Clipboard access is unavailable.');
   });
 
+  it('keeps asynchronous copy state perceivable and preserves the copy button focus', async () => {
+    let resolveCopy: () => void = () => undefined;
+    const copy = new Promise<void>((resolve) => {
+      resolveCopy = resolve;
+    });
+    const writeText = vi.fn(() => copy);
+    Object.defineProperty(globalThis.navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText }
+    });
+    render(
+      <TableOutput
+        table={{
+          kind: 'table',
+          columns: [{ key: 'value', label: 'Value' }],
+          rows: [['safe']]
+        }}
+      />
+    );
+
+    const copyButton = screen.getByTestId('table-copy-csv');
+    copyButton.focus();
+    fireEvent.click(copyButton);
+    fireEvent.click(copyButton);
+
+    expect(copyButton).toHaveAttribute('aria-busy', 'true');
+    expect(copyButton).toHaveAttribute('aria-disabled', 'true');
+    expect(copyButton).toHaveFocus();
+    expect(screen.getByRole('status')).toHaveTextContent('Copying CSV…');
+    expect(writeText).toHaveBeenCalledOnce();
+
+    resolveCopy();
+    await waitFor(() => expect(screen.getByRole('status')).toHaveTextContent('Copied visible rows as CSV.'));
+    expect(copyButton).toHaveFocus();
+  });
+
+  it('uses Japanese table controls, ranges, missing values, and copy feedback', async () => {
+    const writeText = vi.fn();
+    Object.defineProperty(globalThis.navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText }
+    });
+    render(
+      <TableOutput
+        labels={labelsForLanguage('ja')}
+        table={{
+          kind: 'table',
+          columns: [{ key: 'value', label: '値' }],
+          rows: [[undefined]]
+        }}
+      />
+    );
+
+    expect(screen.getByRole('table', { name: 'データ表' })).toBeVisible();
+    expect(screen.getByText('1 行中 1–1 行')).toBeVisible();
+    expect(screen.getByText('値なし')).toBeVisible();
+    expect(screen.getByLabelText('1ページあたりの行数')).toBeVisible();
+    fireEvent.click(screen.getByRole('button', { name: '表示中の行を CSV としてコピー' }));
+    await waitFor(() =>
+      expect(screen.getByRole('status')).toHaveTextContent('表示中の行を CSV としてコピーしました。')
+    );
+  });
+
   it('renders empty tables with a stable row range', () => {
     render(
       <TableOutput
@@ -1115,6 +1391,10 @@ describe('TableOutput', () => {
     expect(tableToCsv([{ key: 'a', label: 'A' }], [[1, 2]])).toEqual({
       ok: false,
       error: 'Row 1 has 2 cells; expected 1.'
+    });
+    expect(tableToCsv([{ key: 'a', label: 'A' }], [[1, 2]], labelsForLanguage('ja'))).toEqual({
+      ok: false,
+      error: '1 行目のセルは 2 個ですが、1 個である必要があります。'
     });
   });
 });

--- a/tests/unit/doc-runtime-core.test.mjs
+++ b/tests/unit/doc-runtime-core.test.mjs
@@ -163,6 +163,17 @@ describe('doc runtime core', () => {
       '//| id: bad\n//| inputs:\n//|   count: { label: 2, value: text }',
       'inputs.count.label'
     ],
+    ['empty input label', '//| id: bad\n//| inputs:\n//|   count: { label: "  ", value: text }', 'inputs.count.label'],
+    [
+      'wrong input description type',
+      '//| id: bad\n//| inputs:\n//|   count: { description: 2, value: text }',
+      'inputs.count.description'
+    ],
+    [
+      'empty input description',
+      '//| id: bad\n//| inputs:\n//|   count: { description: "  ", value: text }',
+      'inputs.count.description'
+    ],
     [
       'wrong integer flag type',
       '//| id: bad\n//| inputs:\n//|   count: { type: number, integer: yes, value: 1 }',
@@ -250,7 +261,7 @@ describe('doc runtime core', () => {
       '#| id: inputs',
       '#| packages: [pandas, matplotlib]',
       '#| inputs:',
-      '#|   plain: {}',
+      '#|   plain: { label: Plain value, description: A public input description. }',
       '#|   enabled: { type: checkbox }',
       '#|   count: { type: number, integer: true, value: 2, min: 1, max: 3, step: 1 }',
       '#|   mode: { type: select, value: b, options: [a, { label: Bee, value: b }] }',
@@ -265,7 +276,8 @@ describe('doc runtime core', () => {
       {
         name: 'plain',
         type: 'text',
-        label: 'plain',
+        label: 'Plain value',
+        description: 'A public input description.',
         value: '',
         min: undefined,
         max: undefined,

--- a/tests/unit/doc-runtime-service.test.mjs
+++ b/tests/unit/doc-runtime-service.test.mjs
@@ -219,7 +219,7 @@ describe('doc runtime service', () => {
 
     expect(removals).toEqual(
       ['.gitignore', 'doc_rust_cells.d.ts', 'doc_rust_cells_bg.wasm.d.ts', 'package.json'].map((fileName) => [
-        repoPath('pkg', fileName),
+        memoryPath(repoPath('pkg', fileName)),
         { force: true }
       ])
     );

--- a/tests/unit/doc-runtime-service.test.mjs
+++ b/tests/unit/doc-runtime-service.test.mjs
@@ -1,5 +1,5 @@
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import {
   postprocessRustWasm,
   removeUnusedWasmPackState,
@@ -124,10 +124,33 @@ function createMemoryFileSystem(initialFiles = {}) {
         };
       });
     },
-    rm: async (filePath) => {
+    rename: async (sourcePath, targetPath) => {
+      const normalizedSource = memoryPath(sourcePath);
+      const normalizedTarget = memoryPath(targetPath);
+      ensureParents(normalizedTarget);
+      for (const [filePath, content] of Array.from(files)) {
+        if (filePath !== normalizedSource && !filePath.startsWith(`${normalizedSource}/`)) continue;
+        files.delete(filePath);
+        files.set(`${normalizedTarget}${filePath.slice(normalizedSource.length)}`, content);
+      }
+      for (const directory of Array.from(directories)) {
+        if (directory !== normalizedSource && !directory.startsWith(`${normalizedSource}/`)) continue;
+        directories.delete(directory);
+        directories.add(`${normalizedTarget}${directory.slice(normalizedSource.length)}`);
+      }
+    },
+    rm: async (filePath, options = {}) => {
       const normalizedPath = memoryPath(filePath);
       files.delete(normalizedPath);
       directories.delete(normalizedPath);
+      if (options.recursive) {
+        for (const candidate of Array.from(files.keys())) {
+          if (candidate.startsWith(`${normalizedPath}/`)) files.delete(candidate);
+        }
+        for (const candidate of Array.from(directories)) {
+          if (candidate.startsWith(`${normalizedPath}/`)) directories.delete(candidate);
+        }
+      }
       removals.push(normalizedPath);
     },
     writeFile: async (filePath, content) => {
@@ -194,7 +217,12 @@ describe('doc runtime service', () => {
 
     await postprocessRustWasm({ fileSystem, rustWasmDir: '/repo/pkg' });
 
-    expect(removals).toEqual([['/repo/pkg/.gitignore', { force: true }]]);
+    expect(removals).toEqual(
+      ['.gitignore', 'doc_rust_cells.d.ts', 'doc_rust_cells_bg.wasm.d.ts', 'package.json'].map((fileName) => [
+        repoPath('pkg', fileName),
+        { force: true }
+      ])
+    );
     expect(writes).toHaveLength(1);
     expect(files.get('/repo/pkg/doc_rust_cells.js')).not.toContain('wasmInstance');
 
@@ -707,6 +735,13 @@ describe('doc runtime service', () => {
       paths,
       root: '/repo'
     });
+    const syncRustSupport = async ({ fileSystem: runtimeFileSystem, paths: runtimePaths }) => {
+      await Promise.all(
+        ['Cargo.lock', 'LICENSE-MIT', 'LICENSE-APACHE'].map((fileName) =>
+          runtimeFileSystem.writeFile(path.join(runtimePaths.rustCellsDir, fileName), fileName)
+        )
+      );
+    };
 
     const first = await syncDocRuntime({
       fileSystem,
@@ -715,7 +750,8 @@ describe('doc runtime service', () => {
       paths,
       root: '/repo',
       syncLicenses: async () => false,
-      syncPyodide: async () => false
+      syncPyodide: async () => false,
+      syncRustSupport
     });
 
     expect(first).toMatchObject({
@@ -727,14 +763,15 @@ describe('doc runtime service', () => {
       rustCellCount: 1,
       rustChanged: true
     });
-    expect(fileSystem.writes.sort()).toEqual(
-      [
+    expect(Array.from(fileSystem.files.keys())).toEqual(
+      expect.arrayContaining([
         '/repo/.oxiquill/generated/cells.ts',
-        '/repo/.oxiquill/haskell-cells/Main.hs',
         '/repo/.oxiquill/generated/cells.json',
+        '/repo/.oxiquill/generated/runtime-ownership.json',
         '/repo/.oxiquill/rust-cells/Cargo.toml',
-        '/repo/.oxiquill/rust-cells/src/lib.rs'
-      ].sort()
+        '/repo/.oxiquill/rust-cells/src/lib.rs',
+        '/repo/.oxiquill/haskell-cells/Main.hs'
+      ])
     );
 
     await expect(markRuntimeReady({ fileSystem, paths, summary: first, version: 'ready-1' })).resolves.toBe(true);
@@ -765,13 +802,162 @@ describe('doc runtime service', () => {
         paths,
         root: '/repo',
         syncLicenses: async () => false,
-        syncPyodide: async () => false
+        syncPyodide: async () => false,
+        syncRustSupport
       })
     ).resolves.toMatchObject({
       cellsChanged: false,
       rustChanged: false
     });
     expect(fileSystem.writes).toEqual([]);
+  });
+
+  it('keeps a zero-cell project free of language runtimes and tool invocations', async () => {
+    const paths = createDocRuntimePaths('/repo');
+    const fileSystem = createMemoryFileSystem({
+      '/repo/content/docs/index.mdx': '# Static documentation'
+    });
+    const buildRust = vi.fn();
+    const buildHaskell = vi.fn();
+    const syncPyodide = vi.fn();
+
+    const result = await syncDocRuntime({
+      buildHaskell,
+      buildRust,
+      fileSystem,
+      helperCrates: new Map(),
+      highlighter,
+      mode: 'build',
+      paths,
+      syncLicenses: async () => false,
+      syncPyodide
+    });
+
+    expect(result).toMatchObject({ cellCount: 0, haskellCellCount: 0, pythonCellCount: 0, rustCellCount: 0 });
+    expect(buildRust).not.toHaveBeenCalled();
+    expect(buildHaskell).not.toHaveBeenCalled();
+    expect(syncPyodide).not.toHaveBeenCalled();
+    expect(fileSystem.existsSync('/repo/.oxiquill/rust-cells')).toBe(false);
+    expect(fileSystem.existsSync('/repo/public/oxiquill/pyodide')).toBe(false);
+    expect(fileSystem.existsSync('/repo/.oxiquill/haskell-cells')).toBe(false);
+    expect(fileSystem.existsSync('/repo/.oxiquill/generated/runtime-version.ts')).toBe(true);
+  });
+
+  it('copies only Python assets, skips an unchanged rerun, and removes stale Python output safely', async () => {
+    const paths = createDocRuntimePaths({ frameworkRoot: '/repo/framework', workspaceRoot: '/repo' });
+    const fileSystem = createMemoryFileSystem({
+      '/repo/framework/package.json': '{"dependencies":{"pyodide":"314.0.6"}}',
+      '/repo/content/docs/index.mdx': '```python\n#| id: py\nprint("python")\n```',
+      '/repo/public/oxiquill/licenses/keep.txt': 'notice'
+    });
+    const buildRust = vi.fn();
+    const buildHaskell = vi.fn();
+    const syncPyodide = vi.fn(async ({ fileSystem: runtimeFileSystem, paths: runtimePaths }) => {
+      await runtimeFileSystem.writeFile(path.join(runtimePaths.pyodidePublicDir, 'pyodide.mjs'), 'python');
+    });
+    const options = {
+      buildHaskell,
+      buildRust,
+      fileSystem,
+      helperCrates: new Map(),
+      highlighter,
+      mode: 'build',
+      paths,
+      syncLicenses: async () => false,
+      syncPyodide
+    };
+
+    await syncDocRuntime(options);
+    expect(syncPyodide).toHaveBeenCalledOnce();
+    expect(buildRust).not.toHaveBeenCalled();
+    expect(buildHaskell).not.toHaveBeenCalled();
+
+    fileSystem.writes.length = 0;
+    await syncDocRuntime(options);
+    expect(syncPyodide).toHaveBeenCalledOnce();
+    expect(fileSystem.writes).toEqual([]);
+
+    await fileSystem.writeFile('/repo/content/docs/index.mdx', '# Python removed');
+    await syncDocRuntime(options);
+    expect(fileSystem.existsSync('/repo/public/oxiquill/pyodide')).toBe(false);
+    expect(fileSystem.existsSync('/repo/public/oxiquill/licenses/keep.txt')).toBe(true);
+  });
+
+  it('builds Rust once for unchanged inputs and preserves old output without a ready marker on failure', async () => {
+    const paths = createDocRuntimePaths('/repo');
+    const fileSystem = createMemoryFileSystem({
+      '/repo/content/docs/index.mdx': '```rust\n//| id: rust\n//| crates: []\nprintln!("one");\n```'
+    });
+    const syncRustSupport = async ({ fileSystem: runtimeFileSystem, paths: runtimePaths }) => {
+      await Promise.all(
+        ['Cargo.lock', 'LICENSE-MIT', 'LICENSE-APACHE'].map((fileName) =>
+          runtimeFileSystem.writeFile(path.join(runtimePaths.rustCellsDir, fileName), fileName)
+        )
+      );
+    };
+    const buildRust = vi.fn(async ({ paths: runtimePaths }) => {
+      await Promise.all([
+        fileSystem.writeFile(path.join(runtimePaths.rustWasmPublicDir, 'doc_rust_cells.js'), 'old js'),
+        fileSystem.writeFile(path.join(runtimePaths.rustWasmPublicDir, 'doc_rust_cells_bg.wasm'), 'old wasm')
+      ]);
+    });
+    const options = {
+      buildHaskell: vi.fn(),
+      buildRust,
+      fileSystem,
+      helperCrates: new Map(),
+      highlighter,
+      mode: 'build',
+      paths,
+      syncLicenses: async () => false,
+      syncPyodide: vi.fn(),
+      syncRustSupport
+    };
+
+    await syncDocRuntime(options);
+    await syncDocRuntime(options);
+    expect(buildRust).toHaveBeenCalledOnce();
+
+    await fileSystem.writeFile(
+      '/repo/content/docs/index.mdx',
+      '```rust\n//| id: rust\n//| crates: []\nprintln!("two");\n```'
+    );
+    buildRust.mockImplementationOnce(async () => {
+      throw new Error('wasm-pack failed');
+    });
+
+    await expect(syncDocRuntime(options)).rejects.toThrow('wasm-pack failed');
+    expect(fileSystem.files.get('/repo/public/oxiquill/rust-wasm/doc_rust_cells.js').toString()).toBe('old js');
+    expect(fileSystem.existsSync('/repo/.oxiquill/generated/runtime-version.ts')).toBe(false);
+  });
+
+  it('publishes Haskell output only for Haskell cells and withholds readiness after a tolerated failure', async () => {
+    const paths = createDocRuntimePaths('/repo');
+    const fileSystem = createMemoryFileSystem({
+      '/repo/content/docs/index.mdx': '```haskell\n--| id: hs\nputStrLn "haskell"\n```'
+    });
+    const buildHaskell = vi.fn(async ({ fileSystem: runtimeFileSystem, paths: runtimePaths }) => {
+      await runtimeFileSystem.writeFile(path.join(runtimePaths.haskellWasmPublicDir, 'status.json'), 'unavailable');
+      return { error: new Error('compiler failed'), ok: false };
+    });
+
+    const result = await syncDocRuntime({
+      buildHaskell,
+      buildRust: vi.fn(),
+      fileSystem,
+      helperCrates: new Map(),
+      highlighter,
+      mode: 'dev',
+      paths,
+      syncLicenses: async () => false,
+      syncPyodide: vi.fn(),
+      tolerateHaskellBuildFailure: true
+    });
+
+    expect(buildHaskell).toHaveBeenCalledOnce();
+    expect(result.haskellBuildResult).toMatchObject({ ok: false });
+    expect(fileSystem.existsSync('/repo/public/oxiquill/haskell-wasm/status.json')).toBe(true);
+    expect(fileSystem.existsSync('/repo/.oxiquill/generated/runtime-version.ts')).toBe(false);
   });
 
   it('summarizes cells, decides when Wasm is needed, and builds with injected commands', async () => {

--- a/tests/unit/interactive-cell-model.test.ts
+++ b/tests/unit/interactive-cell-model.test.ts
@@ -49,9 +49,23 @@ describe('interactive cell model', () => {
   it('resolves localized runtime labels', () => {
     expect(localeFromLanguage('en-US')).toBe('en');
     expect(localeFromLanguage('ja-JP')).toBe('ja');
+    expect(localeFromLanguage(' JA-jpan-JP ')).toBe('ja');
+    expect(localeFromLanguage('javanese')).toBe('en');
+    expect(localeFromLanguage('fr-FR')).toBe('en');
+    expect(localeFromLanguage('')).toBe('en');
+    expect(localeFromLanguage()).toBe('en');
     expect(labelsForLanguage('ja').run).toBe('実行');
     expect(idleOutputMessage('reactive', labelsForLanguage('ja'))).toBe('ランタイムの起動を待っています。');
     expect(labelsForLanguage('ja').unknownCell('missing')).toBe('不明な実行可能セル: missing');
+    expect(labelsForLanguage('fr').run).toBe('Run');
+    expect(labelsForLanguage('fr')).toBe(labelsForLanguage('en'));
+    expect(Object.values(labelsForLanguage('unknown')).every((label) => label !== undefined)).toBe(true);
+    expect(labelsForLanguage('ja').diagnosticDetail('Artifact limit exceeded: received 17, maximum 16.')).toBe(
+      '成果物の上限を超えました。17 件を受け取りましたが、上限は 16 件です。'
+    );
+    expect(labelsForLanguage('ja').diagnosticDetail('Sample cell timed out after 1000ms')).toBe(
+      'Sample cell は 1000 ミリ秒でタイムアウトしました。'
+    );
   });
 
   it('coerces numeric input values and keeps text values', () => {

--- a/tests/unit/release-workflow.test.mjs
+++ b/tests/unit/release-workflow.test.mjs
@@ -173,6 +173,7 @@ describe('workflow supply-chain policy', () => {
     expect(publishSource).toContain('id-token: write');
     expect(source.match(/id-token: write/gu)).toHaveLength(1);
     expect(publishSource).toContain('name: npm-publish');
+    expect(publishSource).toContain("needs.verify.outputs.release_version != '0.3.0'");
     expect(publishSource).toContain('npm stage publish');
     expect(source).not.toMatch(/\bNPM_TOKEN\b|\bNODE_AUTH_TOKEN\b/u);
     expect(source).not.toMatch(/run:\s+npm publish/u);

--- a/tests/unit/release-workflow.test.mjs
+++ b/tests/unit/release-workflow.test.mjs
@@ -1,0 +1,244 @@
+// @vitest-environment node
+
+import { createHash } from 'node:crypto';
+import { mkdtemp, readFile, readdir, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  assertNoOpenReleaseBlockers,
+  assertReleaseIdentity,
+  assertTagOnMain,
+  fetchOpenReleaseBlockers
+} from '../../.github/scripts/verify-release.mjs';
+import {
+  assertPackManifest,
+  assertPublishEnvironment,
+  CHECKSUM_FILE,
+  MANIFEST_FILE,
+  verifyReleaseArchive
+} from '../../.github/scripts/release-archive.mjs';
+
+const repositoryRoot = fileURLToPath(new URL('../..', import.meta.url));
+const temporaryDirectories = [];
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  await Promise.all(temporaryDirectories.splice(0).map((directory) => rm(directory, { force: true, recursive: true })));
+});
+
+describe('release identity verification', () => {
+  it('accepts an exact stable tag and matching package versions', () => {
+    expect(() =>
+      assertReleaseIdentity({
+        packageVersion: '1.2.3',
+        releasePrerelease: false,
+        rootVersion: '1.2.3',
+        tag: 'v1.2.3'
+      })
+    ).not.toThrow();
+  });
+
+  it.each([
+    [{ packageVersion: '1.2.3', releasePrerelease: false, rootVersion: '1.2.3', tag: '1.2.3' }, 'must match'],
+    [{ packageVersion: '1.2.3', releasePrerelease: true, rootVersion: '1.2.3', tag: 'v1.2.3' }, 'Prerelease'],
+    [
+      { packageVersion: '1.2.3', releasePrerelease: false, rootVersion: '1.2.4', tag: 'v1.2.3' },
+      'root package version'
+    ],
+    [
+      { packageVersion: '1.2.4', releasePrerelease: false, rootVersion: '1.2.3', tag: 'v1.2.3' },
+      'oxiquill package version'
+    ]
+  ])('rejects an invalid release identity', (input, message) => {
+    expect(() => assertReleaseIdentity(input)).toThrow(message);
+  });
+
+  it('rejects a substituted checkout and a tag outside main', () => {
+    expect(() =>
+      assertTagOnMain({ headCommit: 'a'.repeat(40), isAncestor: true, tag: 'v1.2.3', tagCommit: 'b'.repeat(40) })
+    ).toThrow('does not match');
+    expect(() =>
+      assertTagOnMain({ headCommit: 'a'.repeat(40), isAncestor: false, tag: 'v1.2.3', tagCommit: 'a'.repeat(40) })
+    ).toThrow('not contained in origin/main');
+  });
+
+  it('fails when the release milestone contains an open blocker', () => {
+    expect(() => assertNoOpenReleaseBlockers([{ number: 59, title: 'Harden releases' }])).toThrow(
+      '#59 Harden releases'
+    );
+    expect(() => assertNoOpenReleaseBlockers([])).not.toThrow();
+  });
+
+  it('loads milestone blockers and excludes pull requests', async () => {
+    const fetchImplementation = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse([{ number: 7, title: 'npm release readiness' }]))
+      .mockResolvedValueOnce(
+        jsonResponse([
+          { html_url: 'https://github.test/issues/59', number: 59, title: 'Blocker' },
+          { number: 60, pull_request: {}, title: 'Pull request' }
+        ])
+      );
+
+    await expect(
+      fetchOpenReleaseBlockers({ fetchImplementation, repository: 'kakune/oxiquill', token: 'token' })
+    ).resolves.toEqual([{ number: 59, title: 'Blocker', url: 'https://github.test/issues/59' }]);
+    expect(fetchImplementation).toHaveBeenCalledTimes(2);
+    expect(fetchImplementation.mock.calls[0][1].headers.Authorization).toBe('Bearer token');
+  });
+
+  it('fails closed when GitHub cannot verify release blockers', async () => {
+    const fetchImplementation = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 503,
+      text: async () => 'unavailable'
+    });
+    await expect(fetchOpenReleaseBlockers({ fetchImplementation, repository: 'kakune/oxiquill' })).rejects.toThrow(
+      'GitHub API request failed with 503'
+    );
+  });
+});
+
+describe('release archive verification', () => {
+  it('accepts the exact archive, complete manifest, checksum, and OIDC environment', async () => {
+    const directory = await createArtifact();
+    await expect(
+      verifyReleaseArchive(directory, '1.2.3', {
+        environment: oidcEnvironment(),
+        outputFile: null,
+        requireOidc: true
+      })
+    ).resolves.toMatchObject({ archivePath: path.join(directory, 'oxiquill-1.2.3.tgz') });
+  });
+
+  it('rejects a changed archive and unexpected artifact files', async () => {
+    const changedArchive = await createArtifact();
+    await writeFile(path.join(changedArchive, 'oxiquill-1.2.3.tgz'), 'changed');
+    await expect(verifyReleaseArchive(changedArchive, '1.2.3', { outputFile: null })).rejects.toThrow(
+      'SHA-256 mismatch'
+    );
+
+    const extraFile = await createArtifact();
+    await writeFile(path.join(extraFile, 'substitute.tgz'), 'substitute');
+    await expect(verifyReleaseArchive(extraFile, '1.2.3', { outputFile: null })).rejects.toThrow('unexpected files');
+  });
+
+  it('rejects incomplete, duplicate, and unsafe npm manifests', () => {
+    const pack = packManifest(Buffer.from('archive'));
+    expect(() => assertPackManifest({ ...pack, entryCount: 0 }, { name: 'oxiquill', version: '1.2.3' })).toThrow(
+      'every archive entry'
+    );
+    expect(() => assertPackManifest({ ...pack, files: [...pack.files, pack.files[0]], entryCount: 2 }, pack)).toThrow(
+      'duplicate path'
+    );
+    expect(() =>
+      assertPackManifest(
+        { ...pack, files: [{ ...pack.files[0], path: '../package.json' }] },
+        { name: 'oxiquill', version: '1.2.3' }
+      )
+    ).toThrow('invalid file entry');
+  });
+
+  it('requires OIDC and forbids long-lived npm credentials', () => {
+    expect(() => assertPublishEnvironment({})).toThrow('ACTIONS_ID_TOKEN_REQUEST_URL');
+    expect(() => assertPublishEnvironment({ ...oidcEnvironment(), NODE_AUTH_TOKEN: 'secret' })).toThrow(
+      'NODE_AUTH_TOKEN'
+    );
+    expect(() => assertPublishEnvironment(oidcEnvironment())).not.toThrow();
+  });
+});
+
+describe('workflow supply-chain policy', () => {
+  it('pins every remote action to a full commit SHA with a version comment', async () => {
+    const workflowDirectory = path.join(repositoryRoot, '.github/workflows');
+    const workflowNames = (await readdir(workflowDirectory)).filter((name) => /\.ya?ml$/u.test(name));
+
+    for (const workflowName of workflowNames) {
+      const source = await readFile(path.join(workflowDirectory, workflowName), 'utf8');
+      const usesLines = source.split('\n').filter((line) => /^\s*uses:/u.test(line));
+      expect(usesLines.length).toBeGreaterThan(0);
+      for (const line of usesLines) {
+        expect(line).toMatch(/^\s*uses:\s+[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+@[0-9a-f]{40}\s+#\s+v\d/u);
+      }
+    }
+  });
+
+  it('keeps release OIDC and staged publishing isolated to the protected publish job', async () => {
+    const source = await readFile(path.join(repositoryRoot, '.github/workflows/npm-publish.yml'), 'utf8');
+    const [verifySource, publishSource] = source.split('\n  publish:\n');
+
+    expect(verifySource).not.toContain('id-token: write');
+    expect(publishSource).toContain('id-token: write');
+    expect(source.match(/id-token: write/gu)).toHaveLength(1);
+    expect(publishSource).toContain('name: npm-publish');
+    expect(publishSource).toContain('npm stage publish');
+    expect(source).not.toMatch(/\bNPM_TOKEN\b|\bNODE_AUTH_TOKEN\b/u);
+    expect(source).not.toMatch(/run:\s+npm publish/u);
+  });
+
+  it('never pipes mutable remote installer content into an interpreter', async () => {
+    const workflowDirectory = path.join(repositoryRoot, '.github/workflows');
+    const sources = await Promise.all(
+      (await readdir(workflowDirectory))
+        .filter((name) => /\.ya?ml$/u.test(name))
+        .map((name) => readFile(path.join(workflowDirectory, name), 'utf8'))
+    );
+    const installer = await readFile(path.join(repositoryRoot, '.github/scripts/install-ghc-wasm.sh'), 'utf8');
+
+    expect(sources.join('\n')).not.toContain('/master/bootstrap.sh');
+    expect(sources.join('\n')).not.toMatch(/curl[^\n]*\|/u);
+    expect(installer).toContain('GHC_WASM_ARCHIVE_SHA256');
+    expect(installer).toContain('ghc-wasm archive SHA-256 mismatch');
+    expect(installer).toContain('--output "$archive"');
+  });
+});
+
+async function createArtifact() {
+  const directory = await mkdtemp(path.join(os.tmpdir(), 'oxiquill-release-'));
+  temporaryDirectories.push(directory);
+  const archive = Buffer.from('verified archive');
+  const pack = packManifest(archive);
+  const archiveSha256 = digest('sha256', archive, 'hex');
+
+  await writeFile(path.join(directory, pack.filename), archive);
+  await writeFile(
+    path.join(directory, MANIFEST_FILE),
+    `${JSON.stringify({ archiveSha256, pack, schemaVersion: 1 }, null, 2)}\n`
+  );
+  await writeFile(path.join(directory, CHECKSUM_FILE), `${archiveSha256}  ${pack.filename}\n`);
+  return directory;
+}
+
+function packManifest(archive) {
+  return {
+    entryCount: 1,
+    filename: 'oxiquill-1.2.3.tgz',
+    files: [{ mode: 0o644, path: 'package.json', size: 2 }],
+    integrity: `sha512-${digest('sha512', archive, 'base64')}`,
+    name: 'oxiquill',
+    shasum: digest('sha1', archive, 'hex'),
+    version: '1.2.3'
+  };
+}
+
+function digest(algorithm, value, encoding) {
+  return createHash(algorithm).update(value).digest(encoding);
+}
+
+function jsonResponse(value) {
+  return {
+    json: async () => value,
+    ok: true,
+    status: 200,
+    text: async () => JSON.stringify(value)
+  };
+}
+
+function oidcEnvironment() {
+  return {
+    ACTIONS_ID_TOKEN_REQUEST_TOKEN: 'request-token',
+    ACTIONS_ID_TOKEN_REQUEST_URL: 'https://github.test/oidc'
+  };
+}

--- a/tests/unit/release-workflow.test.mjs
+++ b/tests/unit/release-workflow.test.mjs
@@ -151,6 +151,13 @@ describe('release archive verification', () => {
 });
 
 describe('workflow supply-chain policy', () => {
+  it('selects packed consumer scripts without shell-specific expansion', async () => {
+    const source = await readFile(path.join(repositoryRoot, '.github/workflows/ci.yml'), 'utf8');
+
+    expect(source).toContain('pnpm "test:consumer:${{ matrix.package-manager }}"');
+    expect(source).not.toContain('${PACKAGE_MANAGER}');
+  });
+
   it('pins every remote action to a full commit SHA with a version comment', async () => {
     const workflowDirectory = path.join(repositoryRoot, '.github/workflows');
     const workflowNames = (await readdir(workflowDirectory)).filter((name) => /\.ya?ml$/u.test(name));

--- a/tests/unit/runtime-plan.test.mjs
+++ b/tests/unit/runtime-plan.test.mjs
@@ -1,0 +1,139 @@
+// @vitest-environment node
+
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { createOxiquillPaths } from '../../packages/oxiquill/src/config/paths.mjs';
+import {
+  createRuntimeOwnedOutputs,
+  createRuntimePlan,
+  validateRuntimeOwnership
+} from '../../packages/oxiquill/src/generator/doc-runtime-service.mjs';
+
+const desired = {
+  manifestFingerprint: 'manifest',
+  rust: { buildFingerprint: 'rust-build', cellCount: 0, sourceFingerprint: 'rust-source' },
+  python: { assetFingerprint: 'python-assets', cellCount: 0 },
+  haskell: { buildFingerprint: 'haskell-build', cellCount: 0, sourceFingerprint: 'haskell-source' }
+};
+const emptyOutputs = {
+  generated: false,
+  rustSource: false,
+  rustPublic: false,
+  pythonPublic: false,
+  haskellSource: false,
+  haskellPublic: false
+};
+
+function plan(options = {}) {
+  return createRuntimePlan({
+    desired,
+    mode: 'dev',
+    outputComplete: emptyOutputs,
+    outputPresent: emptyOutputs,
+    ...options
+  });
+}
+
+describe('runtime generation plan', () => {
+  it('keeps every language absent for a new zero-cell project', () => {
+    expect(plan()).toMatchObject({
+      generated: 'write',
+      languages: {
+        rust: { public: 'keep', source: 'keep' },
+        python: { public: 'keep' },
+        haskell: { public: 'keep', source: 'keep' }
+      }
+    });
+  });
+
+  it.each([
+    ['rust', { rust: { ...desired.rust, cellCount: 1 } }, { public: 'build', source: 'write' }],
+    ['python', { python: { ...desired.python, cellCount: 1 } }, { public: 'copy' }],
+    ['haskell', { haskell: { ...desired.haskell, cellCount: 1 } }, { public: 'build', source: 'write' }]
+  ])('requests only the %s runtime for a one-language manifest', (language, override, expected) => {
+    const selected = plan({ desired: { ...desired, ...override } });
+    expect(selected.languages[language]).toEqual(expected);
+    expect(
+      Object.entries(selected.languages)
+        .filter(([candidate]) => candidate !== language)
+        .flatMap(([, actions]) => Object.values(actions))
+    ).toEqual(expect.arrayContaining(['keep']));
+  });
+
+  it('removes stale owned output when the last cell disappears', () => {
+    const state = {
+      schemaVersion: 1,
+      manifestFingerprint: 'old',
+      languages: {
+        rust: {
+          buildFingerprint: 'old-build',
+          mode: 'dev',
+          publicFiles: ['doc_rust_cells.js'],
+          sourceFingerprint: 'old-source',
+          status: 'ready'
+        }
+      }
+    };
+    const selected = plan({
+      outputPresent: { ...emptyOutputs, rustPublic: true, rustSource: true },
+      state
+    });
+
+    expect(selected.languages.rust).toEqual({ public: 'remove', source: 'remove' });
+  });
+
+  it('performs no work for complete unchanged outputs and upgrades dev output for a production build', () => {
+    const rustDesired = { ...desired, rust: { ...desired.rust, cellCount: 1 } };
+    const state = {
+      schemaVersion: 1,
+      manifestFingerprint: 'manifest',
+      languages: {
+        rust: {
+          buildFingerprint: 'rust-build',
+          mode: 'dev',
+          publicFiles: ['doc_rust_cells.js'],
+          sourceFingerprint: 'rust-source',
+          status: 'ready'
+        }
+      }
+    };
+    const complete = { ...emptyOutputs, generated: true, rustPublic: true, rustSource: true };
+
+    expect(plan({ desired: rustDesired, outputComplete: complete, outputPresent: complete, state })).toMatchObject({
+      generated: 'keep',
+      hasChanges: false
+    });
+    expect(
+      plan({ desired: rustDesired, mode: 'build', outputComplete: complete, outputPresent: complete, state }).languages
+        .rust.public
+    ).toBe('build');
+  });
+});
+
+describe('runtime ownership manifest', () => {
+  it('owns only exact configured language descendants and excludes licenses', () => {
+    const paths = createOxiquillPaths({ workspaceRoot: path.resolve('/repo') });
+    const ownedOutputs = createRuntimeOwnedOutputs(paths);
+    const manifest = {
+      schemaVersion: 1,
+      manifestFingerprint: 'manifest',
+      languages: {},
+      ownedOutputs
+    };
+
+    expect(() => validateRuntimeOwnership(manifest, paths)).not.toThrow();
+    expect(ownedOutputs.map(({ path: ownedPath }) => ownedPath)).not.toContain('licenses');
+  });
+
+  it.each(['../outside', '/absolute', ''])('rejects unsafe cleanup path %j', (unsafePath) => {
+    const paths = createOxiquillPaths({ workspaceRoot: path.resolve('/repo') });
+    const manifest = {
+      schemaVersion: 1,
+      manifestFingerprint: 'manifest',
+      languages: {},
+      ownedOutputs: [{ language: 'rust', root: 'cache', path: unsafePath }]
+    };
+
+    expect(() => validateRuntimeOwnership(manifest, paths)).toThrow(/owned output|unexpected/u);
+  });
+});

--- a/tests/unit/watch-doc-runtime.test.mjs
+++ b/tests/unit/watch-doc-runtime.test.mjs
@@ -22,18 +22,19 @@ describe('runtime watcher entrypoint', () => {
         return watcher;
       })
     };
-    const initial = { cellCount: 1, haskellFingerprint: 'old', rustFingerprint: 'old' };
-    const current = { cellCount: 2, haskellFingerprint: 'new', rustFingerprint: 'new' };
+    const initial = {
+      cellCount: 1,
+      plan: { languages: { haskell: { public: 'keep' }, rust: { public: 'keep' } } }
+    };
+    const current = {
+      cellCount: 2,
+      haskellBuildResult: { ok: false, error: new Error('compiler failed') },
+      plan: { languages: { haskell: { public: 'build' }, rust: { public: 'build' } } }
+    };
     const services = {
-      buildHaskellWasm: vi.fn(async () => ({ ok: false, error: new Error('compiler failed') })),
-      buildRustWasm: vi.fn(async () => undefined),
       createDocRuntimeContext: vi.fn(async () => ({ highlighter: {}, paths })),
       loadProjectConfig: vi.fn(async () => ({ paths })),
-      markRuntimeReady: vi.fn(async () => undefined),
-      shouldBuildHaskellWasm: vi.fn(() => true),
-      shouldBuildWasm: vi.fn(() => true),
       syncDocRuntime: vi.fn().mockResolvedValueOnce(initial).mockResolvedValueOnce(current),
-      syncLicenseArtifacts: vi.fn(async () => undefined),
       watch: vi.fn(() => watcher)
     };
     const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
@@ -52,15 +53,14 @@ describe('runtime watcher entrypoint', () => {
     handlers.get('all')('change', path.join(root, 'examples/docs-site/content/docs/index.mdx'));
     await flushMicrotasks();
 
-    expect(services.buildRustWasm).toHaveBeenCalledWith({ mode: 'dev', paths });
-    expect(services.buildHaskellWasm).toHaveBeenCalledWith({
-      haskellFingerprint: 'new',
-      mode: 'dev',
-      paths,
-      tolerateFailure: true
-    });
-    expect(services.syncLicenseArtifacts).toHaveBeenCalledWith({ paths });
-    expect(services.markRuntimeReady).toHaveBeenCalledWith({ paths, summary: current });
+    expect(services.syncDocRuntime).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        forceRustBuild: false,
+        mode: 'dev',
+        paths,
+        tolerateHaskellBuildFailure: true
+      })
+    );
     expect(warning).toHaveBeenCalledWith('[runtime] Haskell/WASI runtime unavailable: compiler failed');
     expect(log).toHaveBeenCalledWith('[runtime] watching MDX, Rust, and Haskell cell sources');
   });
@@ -68,15 +68,12 @@ describe('runtime watcher entrypoint', () => {
   it('queues an initial documentation sync when no baseline is requested', async () => {
     const watcher = { on: vi.fn(() => watcher) };
     const services = {
-      buildHaskellWasm: vi.fn(),
-      buildRustWasm: vi.fn(),
       createDocRuntimeContext: vi.fn(async () => ({ highlighter: {}, paths })),
       loadProjectConfig: vi.fn(async () => ({ paths })),
-      markRuntimeReady: vi.fn(async () => undefined),
-      shouldBuildHaskellWasm: vi.fn(() => false),
-      shouldBuildWasm: vi.fn(() => false),
-      syncDocRuntime: vi.fn(async () => ({ cellCount: 0, haskellFingerprint: '', rustFingerprint: '' })),
-      syncLicenseArtifacts: vi.fn(async () => undefined),
+      syncDocRuntime: vi.fn(async () => ({
+        cellCount: 0,
+        plan: { languages: { haskell: { public: 'keep' }, rust: { public: 'keep' } } }
+      })),
       watch: vi.fn(() => watcher)
     };
     vi.spyOn(console, 'log').mockImplementation(() => undefined);
@@ -85,9 +82,9 @@ describe('runtime watcher entrypoint', () => {
     await flushMicrotasks();
 
     expect(services.syncDocRuntime).toHaveBeenCalledTimes(1);
-    expect(services.buildRustWasm).not.toHaveBeenCalled();
-    expect(services.buildHaskellWasm).not.toHaveBeenCalled();
-    expect(services.markRuntimeReady).toHaveBeenCalled();
+    expect(services.syncDocRuntime).toHaveBeenCalledWith(
+      expect.objectContaining({ mode: 'dev', tolerateHaskellBuildFailure: true })
+    );
   });
 });
 


### PR DESCRIPTION
## Summary

- make runtime generation conditional, idempotent, atomically published, and safe when language cells are removed
- localize the interactive runtime in English and Japanese and add keyboard, live-region, chart, table, and Mermaid accessibility coverage
- pin workflow supply-chain inputs and add verified staged npm publishing with documented bootstrap and release gates

## Validation

- pnpm check
- pnpm test

Closes #52
Closes #57
Closes #59