### PR TITLE
Complete reproducible runtimes and CLI release readiness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,6 +176,16 @@ jobs:
         with:
           fallback: none
           tool: wasm-pack@0.15.0
+      - name: Cache ghc-wasm
+        if: runner.os != 'Windows'
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
+        with:
+          path: ~/.ghc-wasm
+          key: ghc-wasm-${{ runner.os }}-${{ runner.arch }}-${{ env.GHC_WASM_FLAVOUR }}-${{ env.GHC_WASM_REVISION }}-${{ env.GHC_WASM_ARCHIVE_SHA256 }}
+      - name: Install ghc-wasm
+        if: runner.os != 'Windows'
+        shell: bash
+        run: bash .github/scripts/install-ghc-wasm.sh
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Test packed consumer

--- a/packages/oxiquill/scripts/copy-package-assets.mjs
+++ b/packages/oxiquill/scripts/copy-package-assets.mjs
@@ -22,4 +22,7 @@ await Promise.all(
 await cp(path.join(packageRoot, 'src/generator/license-data'), path.join(packageRoot, 'dist/generator/license-data'), {
   recursive: true
 });
+await cp(path.join(packageRoot, 'src/generator/runtime-data'), path.join(packageRoot, 'dist/generator/runtime-data'), {
+  recursive: true
+});
 await chmod(path.join(packageRoot, 'dist/cli/index.mjs'), 0o755);

--- a/packages/oxiquill/scripts/copy-package-assets.mjs
+++ b/packages/oxiquill/scripts/copy-package-assets.mjs
@@ -25,4 +25,11 @@ await cp(path.join(packageRoot, 'src/generator/license-data'), path.join(package
 await cp(path.join(packageRoot, 'src/generator/runtime-data'), path.join(packageRoot, 'dist/generator/runtime-data'), {
   recursive: true
 });
+await cp(path.resolve(packageRoot, '../../templates/basic'), path.join(packageRoot, 'dist/cli/starter/v1'), {
+  recursive: true
+});
+await copyFile(
+  path.resolve(packageRoot, '../../templates/basic/.gitignore'),
+  path.join(packageRoot, 'dist/cli/starter/v1/gitignore')
+);
 await chmod(path.join(packageRoot, 'dist/cli/index.mjs'), 0o755);

--- a/packages/oxiquill/src/astro/index.ts
+++ b/packages/oxiquill/src/astro/index.ts
@@ -98,6 +98,11 @@ export interface OxiquillFrameworkOptions<StarlightOptions extends object = obje
   starlight: IntegrationFactory<StarlightOptions>;
 }
 
+export interface OxiquillPythonOptions {
+  offline?: boolean;
+  packageMirror?: string | URL;
+}
+
 interface OxiquillStarlightOptions {
   components?: Record<string, string>;
   customCss?: string[];
@@ -116,6 +121,7 @@ export interface OxiquillConfig<StarlightOptions extends object = object> extend
   integrations?: AstroIntegrations;
   markdown?: AstroMarkdownConfig;
   paths?: OxiquillPathOptions;
+  python?: OxiquillPythonOptions;
   sidebar?: StarlightOption<StarlightOptions, 'sidebar', unknown>;
   starlight?: Partial<StarlightOptions>;
   title?: StarlightOption<StarlightOptions, 'title', string>;
@@ -126,11 +132,13 @@ export interface OxiquillIntegrationOptions {
   base?: BaseAstroUserConfig['base'];
   markdown?: AstroMarkdownConfig;
   paths?: OxiquillPathOptions;
+  python?: OxiquillPythonOptions;
   vite?: ViteUserConfig;
 }
 
 const createDocRuntimeContextForPaths = createDocRuntimeContext as unknown as (options: {
   paths: OxiquillPaths;
+  pythonOptions?: Readonly<{ offline: boolean; packageMirror?: string }>;
 }) => Promise<DocRuntimeContext>;
 const syncDocRuntimeForBuild = syncDocRuntime as unknown as (
   options: DocRuntimeContext & { mode: 'build' }
@@ -146,6 +154,7 @@ export function defineOxiquillConfig<StarlightOptions extends object>(
     integrations = [],
     markdown = {},
     paths,
+    python,
     description,
     sidebar,
     starlight: starlightOptions = {},
@@ -166,7 +175,7 @@ export function defineOxiquillConfig<StarlightOptions extends object>(
     ...starlightOptions
   } as OxiquillStarlightOptions;
 
-  const integration = createOxiquillIntegration({ base, markdown, paths, vite }, explicitAstroPaths);
+  const integration = createOxiquillIntegration({ base, markdown, paths, python, vite }, explicitAstroPaths);
   const effectiveRoot = explicitAstroPaths.root ?? paths?.workspaceRoot;
   const effectivePublicDir = explicitAstroPaths.publicDir ?? paths?.publicDir ?? 'public';
   const effectiveCacheDir = explicitAstroPaths.cacheDir ?? paths?.cacheDir ?? '.oxiquill';
@@ -220,17 +229,19 @@ export function oxiquillIntegration({
   base,
   markdown = {},
   paths: pathOptions,
+  python,
   vite = {}
 }: OxiquillIntegrationOptions = {}): AstroIntegration {
-  return createOxiquillIntegration({ base, markdown, paths: pathOptions, vite });
+  return createOxiquillIntegration({ base, markdown, paths: pathOptions, python, vite });
 }
 
 function createOxiquillIntegration(
-  { base, markdown = {}, paths: pathOptions, vite = {} }: OxiquillIntegrationOptions = {},
+  { base, markdown = {}, paths: pathOptions, python, vite = {} }: OxiquillIntegrationOptions = {},
   astroOptions: Record<string, string | URL> = {}
 ): AstroIntegration {
-  const metadata = createOxiquillIntegrationMetadata({ astro: astroOptions, paths: pathOptions });
+  const metadata = createOxiquillIntegrationMetadata({ astro: astroOptions, paths: pathOptions, python });
   let paths: OxiquillPaths | undefined;
+  let pythonOptions: Readonly<{ offline: boolean; packageMirror?: string }> | undefined;
   const bundledModules = createBundledModuleCollector();
   const browserBundle = createBrowserBundleCollector();
 
@@ -245,6 +256,7 @@ function createOxiquillIntegration(
           integrationMetadata: metadata
         });
         paths = projectConfig.paths;
+        pythonOptions = projectConfig.python;
         addWatchFile(paths.docsDir);
         addWatchFile(paths.cratesDir);
 
@@ -291,7 +303,7 @@ function createOxiquillIntegration(
         browserBundle.reset();
         if (process.env.OXIQUILL_RUNTIME_OWNER === 'cli') return;
 
-        const context = await createDocRuntimeContextForPaths({ paths });
+        const context = await createDocRuntimeContextForPaths({ paths, pythonOptions });
         await syncDocRuntimeForBuild({ ...context, mode: 'build' });
       },
       'astro:build:done': async ({ dir }) => {

--- a/packages/oxiquill/src/cli/arguments.mjs
+++ b/packages/oxiquill/src/cli/arguments.mjs
@@ -1,0 +1,402 @@
+import { parseArgs } from 'node:util';
+
+const globalOptionDefinitions = Object.freeze({
+  debug: option('boolean', '--debug', 'Show stack and cause details when a command fails.'),
+  help: option('boolean', '--help, -h', 'Show global or command-specific help.', { short: 'h' }),
+  version: option('boolean', '--version', 'Print the installed Oxiquill version.')
+});
+
+const configOptionDefinition = option('string', '--config <path>', 'Use a specific Astro/Oxiquill configuration file.');
+
+const astroDevOptions = Object.freeze({
+  'allowed-hosts': optionalStringOption(
+    '--allowed-hosts [hosts]',
+    'Allow a comma-separated host list, or every host when no value is given.'
+  ),
+  background: option('boolean', '--background', 'Start Astro in the background.'),
+  force: option('boolean', '--force', 'Clear the content cache before starting.'),
+  host: optionalStringOption('--host [address]', 'Listen on every address or a selected address.'),
+  'ignore-lock': option('boolean', '--ignore-lock', "Start without checking or writing Astro's lock file."),
+  mode: option('string', '--mode <name>', 'Set the Astro development mode.'),
+  open: optionalStringOption('--open [path]', 'Open the site, optionally at a selected path.'),
+  port: option('string', '--port <number>', 'Set the development server port.')
+});
+
+const commandDefinitions = Object.freeze({
+  init: command('init [directory]', 'Create the versioned static starter.', { positionalLimit: 1 }),
+  dev: command('dev [options] [-- <astro-options>]', 'Generate runtimes and start the development server.', {
+    astro: true,
+    options: astroDevOptions,
+    project: true
+  }),
+  'dev:runtime': command('dev:runtime [options]', 'Run only the runtime and source watcher.', {
+    options: {
+      'skip-initial': option('boolean', '--skip-initial', 'Skip the initial runtime synchronization.')
+    },
+    project: true
+  }),
+  'dev:astro': command('dev:astro [options] [-- <astro-options>]', 'Run only the Astro development server.', {
+    astro: true,
+    options: astroDevOptions,
+    project: true
+  }),
+  preview: command('preview [options] [-- <astro-options>]', 'Preview the existing production build.', {
+    astro: true,
+    options: {
+      'allowed-hosts': optionalStringOption(
+        '--allowed-hosts [hosts]',
+        'Allow a comma-separated host list, or every host when no value is given.'
+      ),
+      background: option('boolean', '--background', 'Start Astro in the background.'),
+      host: optionalStringOption('--host [address]', 'Listen on every address or a selected address.'),
+      open: optionalStringOption('--open [path]', 'Open the site, optionally at a selected path.'),
+      port: option('string', '--port <number>', 'Set the preview server port.')
+    },
+    project: true
+  }),
+  build: command('build [options] [-- <astro-options>]', 'Generate runtimes, check, and build the site.', {
+    astro: true,
+    options: {
+      devOutput: option('boolean', '--devOutput', 'Emit development-style output.'),
+      force: option('boolean', '--force', 'Clear the content cache before building.'),
+      mode: option('string', '--mode <name>', 'Set the Astro build mode.'),
+      outDir: option('string', '--outDir <directory>', 'Set the Astro output directory.')
+    },
+    project: true
+  }),
+  check: command('check [options] [-- <check-options>]', 'Generate runtimes and run Astro diagnostics.', {
+    astro: true,
+    options: {
+      minimumFailingSeverity: option(
+        'string',
+        '--minimumFailingSeverity <level>',
+        'Set the minimum failing severity: error, warning, or hint.',
+        { choices: ['error', 'warning', 'hint'] }
+      ),
+      minimumSeverity: option(
+        'string',
+        '--minimumSeverity <level>',
+        'Set the minimum displayed severity: error, warning, or hint.',
+        { choices: ['error', 'warning', 'hint'] }
+      ),
+      preserveWatchOutput: option(
+        'boolean',
+        '--preserveWatchOutput',
+        'Keep previous diagnostics visible while watching.'
+      ),
+      tsconfig: option('string', '--tsconfig <path>', 'Use a selected tsconfig or jsconfig file.'),
+      watch: option('boolean', '--watch, -w', 'Watch files and rerun diagnostics.', { short: 'w' })
+    },
+    project: true
+  }),
+  docgen: command('docgen [options]', 'Synchronize the interactive-cell manifest and optional runtimes.', {
+    options: {
+      wasm: option('string', '--wasm <mode>', 'Build language runtimes in dev or build mode.', {
+        choices: ['dev', 'build']
+      })
+    },
+    project: true
+  }),
+  clean: command('clean [options]', 'Remove resolved Oxiquill-owned generated output.', { project: true }),
+  'test-rust': command('test-rust [options]', 'Test optional Rust helper crates.', { project: true }),
+  'test-rust-coverage': command('test-rust-coverage [options]', 'Test Rust helper crates with coverage thresholds.', {
+    project: true
+  }),
+  'lint-rust': command('lint-rust [options]', 'Lint optional Rust helper crates.', { project: true }),
+  'doc-rust': command('doc-rust [options]', 'Build optional Rust helper-crate documentation.', { project: true }),
+  'test-wasm': command('test-wasm [options]', 'Generate and test compiled Wasm runtimes.', { project: true })
+});
+
+const globalUsage = 'Usage: oxiquill <command> [options]';
+
+export class CliUsageError extends Error {
+  constructor(message, commandName, options = {}) {
+    super(message, options);
+    this.name = 'CliUsageError';
+    this.usage = formatCliHelp(commandName);
+  }
+}
+
+export function parseCliArguments(args = []) {
+  const commandIndex = findCommandIndex(args);
+  const commandName = commandIndex === -1 ? undefined : args[commandIndex];
+
+  if (commandName !== undefined && commandName !== 'help' && !commandDefinitions[commandName]) {
+    throw new CliUsageError(`Unknown oxiquill command ${JSON.stringify(commandName)}.`);
+  }
+
+  const definition = commandName === 'help' ? helpCommandDefinition() : commandDefinitions[commandName];
+  const commandArgs =
+    commandIndex === -1 ? [...args] : [...args.slice(0, commandIndex), ...args.slice(commandIndex + 1)];
+  const terminatorIndex = commandArgs.indexOf('--');
+  const beforeTerminator = terminatorIndex === -1 ? commandArgs : commandArgs.slice(0, terminatorIndex);
+  const afterTerminator = terminatorIndex === -1 ? [] : commandArgs.slice(terminatorIndex + 1);
+
+  if (terminatorIndex !== -1 && !definition?.astro) {
+    throw new CliUsageError('The -- argument separator is only supported by Astro forwarding commands.', commandName);
+  }
+
+  const optionDefinitions = {
+    ...globalOptionDefinitions,
+    ...(definition?.project ? { config: configOptionDefinition } : {}),
+    ...definition?.options
+  };
+  const normalizedArgs = normalizeOptionalStringOptions(beforeTerminator, optionDefinitions, commandName);
+  const parsed = parseStrict(normalizedArgs, optionDefinitions, commandName);
+  const forwardedParsed =
+    terminatorIndex === -1
+      ? undefined
+      : parseStrict(
+          normalizeOptionalStringOptions(afterTerminator, definition.options, commandName),
+          definition.options,
+          commandName
+        );
+
+  validateOptionChoices(parsed.values, optionDefinitions, commandName);
+  if (forwardedParsed) {
+    validateOptionChoices(forwardedParsed.values, definition.options, commandName);
+    if (forwardedParsed.positionals.length > 0) {
+      throw new CliUsageError(
+        `${commandName} does not accept positional Astro arguments: ${forwardedParsed.positionals
+          .map(JSON.stringify)
+          .join(', ')}.`,
+        commandName
+      );
+    }
+  }
+  validateConfigOccurrences(beforeTerminator, commandName);
+
+  const values = { ...parsed.values, ...forwardedParsed?.values };
+
+  if (values.version) return Object.freeze({ action: 'version' });
+
+  if (commandName === 'help') {
+    if (parsed.positionals.length > 1) {
+      throw new CliUsageError('The help command accepts at most one command name.', 'help');
+    }
+    const topic = parsed.positionals[0];
+    if (topic !== undefined && !commandDefinitions[topic]) {
+      throw new CliUsageError(`Unknown oxiquill command ${JSON.stringify(topic)}.`);
+    }
+    return Object.freeze({ action: 'help', commandName: topic });
+  }
+
+  if (commandName === undefined) {
+    if (parsed.positionals.length > 0) throw new CliUsageError('Unexpected positional arguments.');
+    return Object.freeze({ action: 'help' });
+  }
+
+  if (values.help) return Object.freeze({ action: 'help', commandName });
+  const positionalLimit = definition.positionalLimit ?? 0;
+  if (parsed.positionals.length > positionalLimit) {
+    const unexpected = parsed.positionals.slice(positionalLimit);
+    throw new CliUsageError(
+      `${commandName} received unexpected positional arguments: ${unexpected.map(JSON.stringify).join(', ')}.`,
+      commandName
+    );
+  }
+
+  const forwardedArgs = definition.astro ? [...stripGlobalOptions(beforeTerminator), ...afterTerminator] : [];
+
+  return Object.freeze({
+    action: 'run',
+    commandArgs: Object.freeze(forwardedArgs),
+    commandName,
+    configFile: values.config,
+    positionals: Object.freeze(parsed.positionals),
+    values: Object.freeze(values)
+  });
+}
+
+export function formatCliHelp(commandName) {
+  if (commandName === 'help') {
+    return [
+      'Usage: oxiquill help [command]',
+      '',
+      'Show global help or help for one command.',
+      '',
+      formatOptionTable(globalOptionDefinitions)
+    ].join('\n');
+  }
+
+  if (commandName !== undefined) {
+    const definition = commandDefinitions[commandName];
+    if (!definition) return formatCliHelp();
+    const options = {
+      ...globalOptionDefinitions,
+      ...(definition.project ? { config: configOptionDefinition } : {}),
+      ...definition.options
+    };
+    return [`Usage: oxiquill ${definition.usage}`, '', definition.description, '', formatOptionTable(options)].join(
+      '\n'
+    );
+  }
+
+  const commandRows = Object.entries(commandDefinitions).map(([name, definition]) => [name, definition.description]);
+  return [
+    globalUsage,
+    '       oxiquill --help',
+    '       oxiquill --version',
+    '',
+    'Commands:',
+    formatRows(commandRows),
+    '',
+    formatOptionTable(globalOptionDefinitions),
+    '',
+    'Run `oxiquill help <command>` for command-specific options.'
+  ].join('\n');
+}
+
+export function debugRequested(args) {
+  const terminatorIndex = args.indexOf('--');
+  const relevantArgs = terminatorIndex === -1 ? args : args.slice(0, terminatorIndex);
+  return relevantArgs.includes('--debug');
+}
+
+export function formatCliError(error, { debug = false } = {}) {
+  const message = debug ? detailedError(error) : conciseError(error);
+  return error instanceof CliUsageError ? `${message}\n\n${error.usage}` : message;
+}
+
+function command(usage, description, { astro = false, options = {}, positionalLimit = 0, project = false } = {}) {
+  return Object.freeze({ astro, description, options: Object.freeze(options), positionalLimit, project, usage });
+}
+
+function option(type, label, description, { choices, short } = {}) {
+  return Object.freeze({ choices, description, label, short, type });
+}
+
+function optionalStringOption(label, description) {
+  return Object.freeze({ description, label, optionalString: true, type: 'string' });
+}
+
+function helpCommandDefinition() {
+  return command('help [command]', 'Show global or command-specific help.', { options: {}, project: false });
+}
+
+function findCommandIndex(args) {
+  for (let index = 0; index < args.length; index += 1) {
+    const argument = args[index];
+    if (argument === '--') throw new CliUsageError('A command is required before --.');
+    if (argument === '--config') {
+      index += 1;
+      continue;
+    }
+    if (argument.startsWith('--config=') || ['--debug', '--help', '-h', '--version'].includes(argument)) continue;
+    if (argument.startsWith('-')) throw new CliUsageError(`Unknown option ${JSON.stringify(argument)}.`);
+    return index;
+  }
+  return -1;
+}
+
+function parseStrict(args, definitions, commandName) {
+  const options = Object.fromEntries(
+    Object.entries(definitions).flatMap(([name, definition]) => {
+      const entries = [[name, { type: definition.type, ...(definition.short ? { short: definition.short } : {}) }]];
+      if (definition.optionalString) entries.push([optionalBooleanName(name), { type: 'boolean' }]);
+      return entries;
+    })
+  );
+
+  try {
+    return parseArgs({ allowPositionals: true, args, options, strict: true });
+  } catch (error) {
+    throw new CliUsageError(error instanceof Error ? error.message : String(error), commandName, { cause: error });
+  }
+}
+
+function normalizeOptionalStringOptions(args, definitions, commandName) {
+  const optionalNames = new Set(
+    Object.entries(definitions)
+      .filter(([, definition]) => definition.optionalString)
+      .map(([name]) => name)
+  );
+  const normalized = [];
+
+  for (let index = 0; index < args.length; index += 1) {
+    const argument = args[index];
+    const name = argument.startsWith('--') ? argument.slice(2).split('=', 1)[0] : undefined;
+    if (!name || !optionalNames.has(name)) {
+      normalized.push(argument);
+      continue;
+    }
+    if (argument.includes('=')) {
+      if (argument.endsWith('=')) {
+        throw new CliUsageError(`${argument.slice(0, -1)} requires a non-empty value after =.`, commandName);
+      }
+      normalized.push(argument);
+      continue;
+    }
+
+    const next = args[index + 1];
+    if (next !== undefined && !next.startsWith('-')) {
+      normalized.push(argument, next);
+      index += 1;
+    } else {
+      normalized.push(`--${optionalBooleanName(name)}`);
+    }
+  }
+
+  return normalized;
+}
+
+function optionalBooleanName(name) {
+  return `${name}-default`;
+}
+
+function validateOptionChoices(values, definitions, commandName) {
+  for (const [name, definition] of Object.entries(definitions)) {
+    const value = values[name];
+    if (value === undefined || !definition.choices || definition.choices.includes(value)) continue;
+    throw new CliUsageError(
+      `${definition.label.split(' ', 1)[0]} must be one of: ${definition.choices.join(', ')}.`,
+      commandName
+    );
+  }
+}
+
+function validateConfigOccurrences(args, commandName) {
+  const count = args.filter((argument) => argument === '--config' || argument.startsWith('--config=')).length;
+  if (count > 1) throw new CliUsageError('--config may only be specified once.', commandName);
+}
+
+function stripGlobalOptions(args) {
+  const result = [];
+  for (let index = 0; index < args.length; index += 1) {
+    const argument = args[index];
+    if (['--debug', '--help', '-h', '--version'].includes(argument) || argument.startsWith('--config=')) continue;
+    if (argument === '--config') {
+      index += 1;
+      continue;
+    }
+    result.push(argument);
+  }
+  return result;
+}
+
+function formatOptionTable(definitions) {
+  return [
+    'Options:',
+    formatRows(Object.values(definitions).map(({ description, label }) => [label, description]))
+  ].join('\n');
+}
+
+function formatRows(rows) {
+  const width = Math.max(...rows.map(([label]) => label.length));
+  return rows.map(([label, description]) => `  ${label.padEnd(width)}  ${description}`).join('\n');
+}
+
+function conciseError(error) {
+  return `Error: ${error instanceof Error ? error.message : String(error)}`;
+}
+
+function detailedError(error) {
+  if (!(error instanceof Error)) return String(error);
+  const details = [error.stack ?? `${error.name}: ${error.message}`];
+  let cause = error.cause;
+  while (cause !== undefined) {
+    details.push(`Caused by: ${cause instanceof Error ? (cause.stack ?? cause.message) : String(cause)}`);
+    cause = cause instanceof Error ? cause.cause : undefined;
+  }
+  return details.join('\n');
+}

--- a/packages/oxiquill/src/cli/commands.mjs
+++ b/packages/oxiquill/src/cli/commands.mjs
@@ -8,6 +8,7 @@ import { loadOxiquillProjectConfig } from '../config/project-config.mjs';
 import { createDocRuntimeContext, syncDocRuntime } from '../generator/doc-runtime-service.mjs';
 import { cleanOxiquillWorkspace } from '../generator/clean.mjs';
 import { runHelperCargo } from '../generator/run-helper-cargo.mjs';
+import { testGeneratedHaskellCells } from '../generator/doc-runtime/haskell-runtime-test.mjs';
 import { parseConfigOption } from './config-option.mjs';
 
 const projectCommands = new Set([
@@ -108,15 +109,27 @@ export async function runCli(
     case 'doc-rust':
       await runHelperCargo({ argv: ['doc', '--no-deps'], paths });
       return;
-    case 'test-wasm':
-      if ((await generateRuntime({ projectConfig, wasmMode: 'dev' })).rustCellCount === 0) {
+    case 'test-wasm': {
+      const summary = await generateRuntime({ projectConfig, wasmMode: 'dev' });
+      if (summary.rustCellCount === 0) {
         console.log('[runtime] no Rust cells; skipping wasm-pack test');
-        return;
+      } else {
+        await runCommand('wasm-pack', ['test', '--node', pathFromUrl(paths.rustCellsDir), '--locked'], {
+          cwd: pathFromUrl(paths.workspaceRoot)
+        });
       }
-      await runCommand('wasm-pack', ['test', '--node', pathFromUrl(paths.rustCellsDir)], {
-        cwd: pathFromUrl(paths.workspaceRoot)
-      });
+
+      if (summary.haskellCellCount === 0) {
+        console.log('[runtime] no Haskell cells; skipping Haskell/WASI test');
+      } else {
+        const result = await testGeneratedHaskellCells({
+          expectedFingerprint: summary.haskellFingerprint,
+          paths
+        });
+        console.log(`[runtime] tested ${result.cellCount} generated Haskell cell(s)`);
+      }
       return;
+    }
   }
 }
 

--- a/packages/oxiquill/src/cli/commands.mjs
+++ b/packages/oxiquill/src/cli/commands.mjs
@@ -9,43 +9,37 @@ import { createDocRuntimeContext, syncDocRuntime } from '../generator/doc-runtim
 import { cleanOxiquillWorkspace } from '../generator/clean.mjs';
 import { runHelperCargo } from '../generator/run-helper-cargo.mjs';
 import { testGeneratedHaskellCells } from '../generator/doc-runtime/haskell-runtime-test.mjs';
-import { parseConfigOption } from './config-option.mjs';
+import { formatCliHelp, parseCliArguments } from './arguments.mjs';
+import { initializeProject } from './init.mjs';
 
-const projectCommands = new Set([
-  'dev',
-  'dev:runtime',
-  'dev:astro',
-  'preview',
-  'build',
-  'check',
-  'docgen',
-  'clean',
-  'test-rust',
-  'test-rust-coverage',
-  'lint-rust',
-  'doc-rust',
-  'test-wasm'
-]);
-
-export async function runCli(
-  command,
-  args = [],
-  {
+export async function runCli(commandOrArgs = [], argsOrOptions = {}, legacyOptions = {}) {
+  const { args, options } = normalizeRunCliArguments(commandOrArgs, argsOrOptions, legacyOptions);
+  const {
     cwd = process.cwd(),
+    initialize = initializeProject,
+    loadPackageVersion = installedPackageVersion,
     loadProjectConfig = loadOxiquillProjectConfig,
+    log = console.log,
     runCommand = runCommandWithInheritedStdio,
     selectNode = frameworkNode
-  } = {}
-) {
-  if (command === 'help' || command === '--help' || command === '-h') {
-    printHelp();
+  } = options;
+  const parsed = parseCliArguments(args);
+
+  if (parsed.action === 'help') {
+    log(formatCliHelp(parsed.commandName));
     return;
   }
-  if (!projectCommands.has(command)) {
-    throw new Error(`Unknown oxiquill command "${command}".`);
+  if (parsed.action === 'version') {
+    log(await loadPackageVersion());
+    return;
   }
 
-  const { commandArgs, configFile } = parseConfigOption(args);
+  const { commandArgs, commandName: command, configFile, positionals, values } = parsed;
+  if (command === 'init') {
+    await initialize({ cwd, directory: positionals[0], log });
+    return;
+  }
+
   const projectConfig = await loadProjectConfig({ cwd, configFile });
   const paths = projectConfig.paths;
   const astroArgs = [...projectConfig.astroConfigArgs, ...commandArgs];
@@ -53,13 +47,13 @@ export async function runCli(
   switch (command) {
     case 'dev':
       await generateRuntime({ projectConfig, tolerateHaskellBuildFailure: true, wasmMode: 'dev' });
-      await runDevServer({ args: astroArgs, projectConfig, selectNode });
+      await runDevServer({ args: astroArgs, projectConfig, runCommand, selectNode });
       return;
     case 'dev:runtime': {
       const { watchDocRuntime } = await import('../generator/watch-doc-runtime.mjs');
       await watchDocRuntime({
         projectConfig,
-        skipInitial: commandArgs.includes('--skip-initial')
+        skipInitial: values['skip-initial'] === true
       });
       return;
     }
@@ -79,7 +73,7 @@ export async function runCli(
       await runOxiquillCheck(projectConfig, commandArgs, { runCommand, selectNode });
       return;
     case 'docgen':
-      await generateRuntime({ projectConfig, wasmMode: parseWasmMode(commandArgs) });
+      await generateRuntime({ projectConfig, wasmMode: values.wasm });
       return;
     case 'clean':
       await cleanOxiquillWorkspace({ paths });
@@ -133,6 +127,16 @@ export async function runCli(
   }
 }
 
+function normalizeRunCliArguments(commandOrArgs, argsOrOptions, legacyOptions) {
+  if (typeof commandOrArgs === 'string') {
+    return {
+      args: [commandOrArgs, ...(Array.isArray(argsOrOptions) ? argsOrOptions : [])],
+      options: legacyOptions
+    };
+  }
+  return { args: commandOrArgs, options: argsOrOptions };
+}
+
 async function generateRuntime({ projectConfig, tolerateHaskellBuildFailure = false, wasmMode }) {
   const { paths } = projectConfig;
   const context = await createDocRuntimeContext({ paths, pythonOptions: projectConfig.python });
@@ -151,31 +155,20 @@ function warnToleratedHaskellBuildFailure(result) {
   console.warn(`[runtime] Haskell/WASI runtime unavailable: ${result.error.message}`);
 }
 
-async function runDevServer({ args, projectConfig, selectNode }) {
+async function runDevServer({ args, projectConfig, runCommand, selectNode }) {
   const { paths } = projectConfig;
   const nodePath = selectNode(paths);
   const env = frameworkEnv(paths, { nodePath });
   const { watchDocRuntime } = await import('../generator/watch-doc-runtime.mjs');
   const watcher = await watchDocRuntime({ projectConfig, skipInitial: true });
-  const child = spawn(nodePath, [frameworkBinScript(paths, 'astro'), 'dev', ...args], {
-    cwd: projectConfig.cwd,
-    env,
-    stdio: 'inherit'
-  });
 
   try {
-    await new Promise((resolve, reject) => {
-      child.on('error', reject);
-      child.on('exit', (code, signal) => {
-        if (code === 0 || signal === 'SIGTERM') {
-          resolve();
-        } else {
-          reject(new Error(`dev child exited with ${signal ?? code}`));
-        }
-      });
+    await runCommand(nodePath, [frameworkBinScript(paths, 'astro'), 'dev', ...args], {
+      cwd: projectConfig.cwd,
+      env,
+      successfulSignals: ['SIGTERM']
     });
   } finally {
-    if (!child.killed) child.kill('SIGTERM');
     await watcher.close();
   }
 }
@@ -333,22 +326,6 @@ export function frameworkEnv(paths, { env = process.env, nodePath, runtimeOwner 
   return nextEnv;
 }
 
-function parseWasmMode(args) {
-  const wasmIndex = args.indexOf('--wasm');
-  if (wasmIndex === -1) return undefined;
-
-  const mode = args[wasmIndex + 1];
-  if (mode === 'dev' || mode === 'build') return mode;
-
-  throw new Error('--wasm must be followed by "dev" or "build".');
-}
-
-function printHelp() {
-  console.log(
-    'Usage: oxiquill <dev|build|check|docgen|clean|test-rust|lint-rust|doc-rust|test-wasm> [--config <path>]'
-  );
-}
-
 function runCommandWithInheritedStdio(command, args, options) {
   return new Promise((resolve, reject) => {
     const child = spawn(command, args, {
@@ -359,13 +336,18 @@ function runCommandWithInheritedStdio(command, args, options) {
 
     child.on('error', reject);
     child.on('exit', (code, signal) => {
-      if (code === 0) {
+      if (code === 0 || options.successfulSignals?.includes(signal)) {
         resolve();
       } else {
         reject(new Error(`${command} exited with ${signal ?? code}`));
       }
     });
   });
+}
+
+async function installedPackageVersion() {
+  const packageJson = JSON.parse(readFileSync(new URL('../../package.json', import.meta.url), 'utf8'));
+  return packageJson.version;
 }
 
 export function isCliEntrypoint(argvPath = process.argv[1], moduleUrl = import.meta.url) {

--- a/packages/oxiquill/src/cli/commands.mjs
+++ b/packages/oxiquill/src/cli/commands.mjs
@@ -122,7 +122,7 @@ export async function runCli(
 
 async function generateRuntime({ projectConfig, tolerateHaskellBuildFailure = false, wasmMode }) {
   const { paths } = projectConfig;
-  const context = await createDocRuntimeContext({ paths });
+  const context = await createDocRuntimeContext({ paths, pythonOptions: projectConfig.python });
   const summary = await syncDocRuntime({
     ...context,
     mode: wasmMode,

--- a/packages/oxiquill/src/cli/index.mjs
+++ b/packages/oxiquill/src/cli/index.mjs
@@ -2,15 +2,15 @@
 export { isCliEntrypoint, runCli } from './commands.mjs';
 
 import { isCliEntrypoint, runCli } from './commands.mjs';
+import { debugRequested, formatCliError } from './arguments.mjs';
 
 if (isCliEntrypoint(process.argv[1], import.meta.url)) {
-  const command = process.argv[2] ?? 'help';
-  const args = process.argv.slice(3);
+  const args = process.argv.slice(2);
 
   try {
-    await runCli(command, args);
+    await runCli(args);
   } catch (error) {
-    console.error(error);
+    console.error(formatCliError(error, { debug: debugRequested(args) }));
     process.exitCode = 1;
   }
 }

--- a/packages/oxiquill/src/cli/init.mjs
+++ b/packages/oxiquill/src/cli/init.mjs
@@ -1,0 +1,205 @@
+import {
+  lstat as fsLstat,
+  mkdir as fsMkdir,
+  readFile as fsReadFile,
+  readdir as fsReaddir,
+  rm as fsRm,
+  rmdir as fsRmdir,
+  writeFile as fsWriteFile
+} from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+export const starterFiles = Object.freeze([
+  '.gitignore',
+  'README.md',
+  'astro.config.mjs',
+  'content.config.ts',
+  'content/docs/index.mdx',
+  'crates/.gitkeep',
+  'package.json',
+  'pnpm-workspace.yaml',
+  'public/favicon.svg',
+  'tsconfig.json'
+]);
+
+const fallbackPackageName = 'oxiquill-docs';
+const reservedPackageNames = new Set(['favicon.ico', 'node_modules']);
+const defaultFileSystem = Object.freeze({
+  lstat: fsLstat,
+  mkdir: fsMkdir,
+  readFile: fsReadFile,
+  readdir: fsReaddir,
+  rm: fsRm,
+  rmdir: fsRmdir,
+  writeFile: fsWriteFile
+});
+
+export async function initializeProject({
+  cwd = process.cwd(),
+  directory,
+  fileSystem: fileSystemOverrides = {},
+  files = starterFiles,
+  log = console.log,
+  starterRoot = fileURLToPath(new URL('./starter/v1/', import.meta.url))
+} = {}) {
+  const fileSystem = { ...defaultFileSystem, ...fileSystemOverrides };
+  const targetPath = path.resolve(cwd, directory ?? '.');
+  const packageName = packageNameFromTarget(targetPath);
+  const starter = await loadStarter({ fileSystem, files, packageName, starterRoot, targetPath });
+  const targetExisted = await assertEmptyTarget(targetPath, fileSystem);
+  const createdFiles = [];
+  const createdDirectories = [];
+
+  try {
+    if (!targetExisted) {
+      await fileSystem.mkdir(targetPath);
+      createdDirectories.push(targetPath);
+    }
+
+    for (const { content, target } of starter) {
+      await createParentDirectories(path.dirname(target), targetPath, createdDirectories, fileSystem);
+      await fileSystem.writeFile(target, content, { flag: 'wx' });
+      createdFiles.push(target);
+    }
+  } catch (error) {
+    await rollbackCreation({ createdDirectories, createdFiles, fileSystem });
+    throw new Error(`Could not initialize an Oxiquill project in ${targetPath}: ${errorMessage(error)}`, {
+      cause: error
+    });
+  }
+
+  printNextSteps({ cwd, log, targetPath });
+  return Object.freeze({ packageName, targetPath });
+}
+
+export function packageNameFromTarget(target) {
+  const basename =
+    String(target)
+      .replace(/[\\/]+$/gu, '')
+      .split(/[\\/]/u)
+      .at(-1) ?? '';
+  const normalized = basename
+    .normalize('NFKD')
+    .replace(/\p{Mark}+/gu, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9._-]+/gu, '-')
+    .replace(/^[._-]+|[._-]+$/gu, '')
+    .slice(0, 214)
+    .replace(/[._-]+$/gu, '');
+
+  return normalized && !reservedPackageNames.has(normalized) ? normalized : fallbackPackageName;
+}
+
+async function loadStarter({ fileSystem, files, packageName, starterRoot, targetPath }) {
+  return Promise.all(
+    files.map(async (relativePath) => {
+      const source = await resolveStarterSource({ fileSystem, relativePath, starterRoot });
+      const target = containedPath(targetPath, relativePath, 'starter target');
+      const sourceStat = await fileSystem.lstat(source);
+      if (!sourceStat.isFile()) throw new Error(`Starter source is not a regular file: ${source}`);
+      const sourceContent = await fileSystem.readFile(source);
+      const content =
+        relativePath === 'package.json' ? renderPackageJson(sourceContent, packageName, source) : sourceContent;
+      return Object.freeze({ content, target });
+    })
+  );
+}
+
+async function resolveStarterSource({ fileSystem, relativePath, starterRoot }) {
+  const candidates = relativePath === '.gitignore' ? ['gitignore', '.gitignore'] : [relativePath];
+  let missingError;
+
+  for (const candidate of candidates) {
+    const source = containedPath(starterRoot, candidate, 'starter source');
+    try {
+      await fileSystem.lstat(source);
+      return source;
+    } catch (error) {
+      if (error?.code !== 'ENOENT') throw error;
+      missingError = error;
+    }
+  }
+
+  throw missingError;
+}
+
+function containedPath(root, relativePath, label) {
+  if (path.isAbsolute(relativePath)) throw new Error(`${label} must be relative: ${relativePath}`);
+  const resolvedRoot = path.resolve(root);
+  const resolved = path.resolve(resolvedRoot, relativePath);
+  const relative = path.relative(resolvedRoot, resolved);
+  if (!relative || relative.startsWith(`..${path.sep}`) || relative === '..' || path.isAbsolute(relative)) {
+    throw new Error(`${label} escapes its root: ${relativePath}`);
+  }
+  return resolved;
+}
+
+function renderPackageJson(content, packageName, source) {
+  try {
+    return `${JSON.stringify({ ...JSON.parse(content.toString('utf8')), name: packageName }, null, 2)}\n`;
+  } catch (error) {
+    throw new Error(`Starter package metadata is invalid: ${source}`, { cause: error });
+  }
+}
+
+async function assertEmptyTarget(targetPath, fileSystem) {
+  let targetStat;
+  try {
+    targetStat = await fileSystem.lstat(targetPath);
+  } catch (error) {
+    if (error?.code === 'ENOENT') return false;
+    throw error;
+  }
+
+  if (targetStat.isSymbolicLink() || !targetStat.isDirectory()) {
+    throw new Error(`Oxiquill init target is not a directory: ${targetPath}`);
+  }
+  if ((await fileSystem.readdir(targetPath)).length > 0) {
+    throw new Error(`Oxiquill init target is not empty: ${targetPath}`);
+  }
+  return true;
+}
+
+async function createParentDirectories(directory, targetRoot, createdDirectories, fileSystem) {
+  const relative = path.relative(targetRoot, directory);
+  if (!relative) return;
+
+  let current = targetRoot;
+  for (const segment of relative.split(path.sep)) {
+    current = path.join(current, segment);
+    try {
+      await fileSystem.mkdir(current);
+      createdDirectories.push(current);
+    } catch (error) {
+      if (error?.code !== 'EEXIST') throw error;
+    }
+  }
+}
+
+async function rollbackCreation({ createdDirectories, createdFiles, fileSystem }) {
+  for (const filePath of createdFiles.reverse()) {
+    await fileSystem.rm(filePath, { force: true }).catch(() => undefined);
+  }
+  for (const directory of createdDirectories.reverse()) {
+    await fileSystem.rmdir(directory).catch(() => undefined);
+  }
+}
+
+function printNextSteps({ cwd, log, targetPath }) {
+  const relativeTarget = path.relative(cwd, targetPath) || '.';
+  log(`Created an Oxiquill project in ${targetPath}.`);
+  log('');
+  log('Next steps:');
+  if (relativeTarget !== '.') log(`  cd ${shellArgument(relativeTarget)}`);
+  log('  pnpm install');
+  log('  pnpm dev');
+}
+
+function shellArgument(value) {
+  return /^[A-Za-z0-9_./\\:-]+$/u.test(value) ? value : JSON.stringify(value);
+}
+
+function errorMessage(error) {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/packages/oxiquill/src/config/metadata.mjs
+++ b/packages/oxiquill/src/config/metadata.mjs
@@ -19,15 +19,49 @@ export const oxiquillPathOptionNames = Object.freeze([
 
 export const astroDirectoryOptionNames = Object.freeze(['root', 'publicDir', 'cacheDir', 'outDir']);
 
-export function createOxiquillIntegrationMetadata({ astro = {}, paths = {} } = {}) {
+export function createOxiquillIntegrationMetadata({ astro = {}, paths = {}, python = {} } = {}) {
   return Object.freeze({
     kind: 'integration',
     cwd: process.cwd(),
     astro: normalizeSelectedOptions(astro, astroDirectoryOptionNames),
     astroExplicitFields: explicitFields(astro, astroDirectoryOptionNames),
     paths: normalizeSelectedOptions(paths, oxiquillPathOptionNames),
-    pathExplicitFields: explicitFields(paths, oxiquillPathOptionNames)
+    pathExplicitFields: explicitFields(paths, oxiquillPathOptionNames),
+    python: normalizePythonOptions(python)
   });
+}
+
+function normalizePythonOptions(options) {
+  if (!options || typeof options !== 'object' || Array.isArray(options)) {
+    throw new TypeError('python must be an object.');
+  }
+  const unknownFields = Object.keys(options).filter((name) => name !== 'offline' && name !== 'packageMirror');
+  if (unknownFields.length > 0) {
+    throw new TypeError(`Unknown python option: ${unknownFields.sort().join(', ')}.`);
+  }
+
+  const offline = options.offline ?? false;
+  if (typeof offline !== 'boolean') throw new TypeError('python.offline must be a boolean.');
+  const packageMirror = normalizePackageMirror(options.packageMirror);
+  return Object.freeze({ offline, ...(packageMirror ? { packageMirror } : {}) });
+}
+
+function normalizePackageMirror(value) {
+  if (value === undefined) return undefined;
+  let url;
+  try {
+    url = value instanceof URL ? new URL(value.href) : new URL(value);
+  } catch (error) {
+    throw new TypeError('python.packageMirror must be an absolute HTTP(S) URL.', { cause: error });
+  }
+  if (url.protocol !== 'https:' && url.protocol !== 'http:') {
+    throw new TypeError('python.packageMirror must be an absolute HTTP(S) URL.');
+  }
+  if (url.username || url.password || url.search || url.hash) {
+    throw new TypeError('python.packageMirror must not contain credentials, a query, or a fragment.');
+  }
+  if (!url.pathname.endsWith('/')) url.pathname += '/';
+  return url.href;
 }
 
 export function createOxiquillConfigMetadata({ astro = {} } = {}) {

--- a/packages/oxiquill/src/config/paths.mjs
+++ b/packages/oxiquill/src/config/paths.mjs
@@ -18,6 +18,7 @@ export function createOxiquillPaths(options = {}) {
     docsDir: directoryPath(options.docsDir ?? 'content/docs', workspaceRoot),
     cratesDir: directoryPath(options.cratesDir ?? 'crates', workspaceRoot),
     cacheDir,
+    downloadCacheDir: directoryPath('downloads/v1', cacheDir),
     outDir: directoryPath(options.outDir ?? 'dist', workspaceRoot),
     generatedDir,
     haskellCellsDir: directoryPath(options.haskellCellsDir ?? 'haskell-cells', cacheDir),

--- a/packages/oxiquill/src/config/project-config.mjs
+++ b/packages/oxiquill/src/config/project-config.mjs
@@ -143,7 +143,8 @@ export function resolveOxiquillProjectConfig({
     astroConfigArgs,
     configFile: resolvedConfigFile,
     cwd: invocationCwd,
-    paths
+    paths,
+    python: integrationMetadata.python
   });
 }
 
@@ -197,6 +198,7 @@ function validateOwnedPaths(paths) {
   assertPathWithin(paths.workspaceRoot, paths.cacheDir, 'cacheDir');
   assertPathWithin(paths.workspaceRoot, paths.outDir, 'outDir');
   assertPathWithin(paths.cacheDir, paths.generatedDir, 'paths.generatedDir');
+  assertPathWithin(paths.cacheDir, paths.downloadCacheDir, 'paths.downloadCacheDir');
   assertPathWithin(paths.cacheDir, paths.haskellCellsDir, 'paths.haskellCellsDir');
   assertPathWithin(paths.cacheDir, paths.rustCellsDir, 'paths.rustCellsDir');
   assertPathWithin(paths.publicDir, paths.publicAssetsDir, 'paths.publicAssetsDir');

--- a/packages/oxiquill/src/generator/doc-runtime-service.mjs
+++ b/packages/oxiquill/src/generator/doc-runtime-service.mjs
@@ -20,11 +20,13 @@ import { throwInteractiveCellDiagnostics, validateCellDependencies } from '../li
 import { defaultFileSystem, listFiles, writeIfChanged } from './doc-runtime/file-system.mjs';
 import { listHelperCrates } from './doc-runtime/helper-crate-service.mjs';
 import { normalizePath } from './doc-runtime/path-utils.mjs';
-import { copyPyodideAssets as defaultCopyPyodideAssets, requiredPyodideFiles } from './doc-runtime/pyodide-assets.mjs';
+import {
+  copyPyodideAssets as defaultCopyPyodideAssets,
+  resolvePyodideRuntimeInputs as defaultResolvePyodideRuntimeInputs
+} from './doc-runtime/pyodide-assets.mjs';
 import { syncLicenseArtifacts as defaultSyncLicenseArtifacts, syncRustBuildSupportFiles } from './license-notices.mjs';
 import { createRuntimeVersion, generateRuntimeVersionModule, summarizeCells } from './doc-runtime/runtime-summary.mjs';
 import { hashText, stableFingerprint } from './doc-runtime/hashing.mjs';
-import { vendoredPyodidePackageRoots } from './doc-runtime/constants.mjs';
 import { createRuntimePlan } from './doc-runtime/runtime-plan.mjs';
 import {
   createRuntimeOwnedOutputs,
@@ -32,6 +34,8 @@ import {
   readRuntimeOwnership
 } from './doc-runtime/runtime-ownership.mjs';
 import { createDirectoryStage, discardDirectoryStage, replaceDirectory } from './doc-runtime/atomic-output.mjs';
+import { readRuntimeInputs as defaultReadRuntimeInputs } from './doc-runtime/runtime-inputs.mjs';
+import { preflightRequiredToolchains as defaultPreflightToolchains } from './doc-runtime/toolchain-preflight.mjs';
 import {
   buildHaskellWasm as defaultBuildHaskellWasm,
   buildRustWasm as defaultBuildRustWasm
@@ -43,6 +47,11 @@ export { hashBytes, hashText, stableFingerprint } from './doc-runtime/hashing.mj
 export {
   copyPyodideAssets,
   copyVendoredPyodidePackages,
+  fetchPyodidePackage,
+  PYODIDE_DOWNLOAD_ATTEMPTS,
+  PYODIDE_REQUEST_TIMEOUT_MS,
+  requiredPyodideFiles,
+  resolvePyodideRuntimeInputs,
   resolveVendoredPyodidePackages
 } from './doc-runtime/pyodide-assets.mjs';
 export {
@@ -81,6 +90,12 @@ export {
   readRuntimeOwnership,
   validateRuntimeOwnership
 } from './doc-runtime/runtime-ownership.mjs';
+export { normalizeRepository, normalizeRuntimeInputs, readRuntimeInputs } from './doc-runtime/runtime-inputs.mjs';
+export {
+  preflightHaskellToolchain,
+  preflightRequiredToolchains,
+  preflightRustToolchain
+} from './doc-runtime/toolchain-preflight.mjs';
 
 export function createDocRuntimePaths(rootOrOptions = process.cwd()) {
   const options =
@@ -96,7 +111,9 @@ export async function createDocRuntimeContext({
   highlighter,
   paths: providedPaths,
   pathOptions,
+  pythonOptions = Object.freeze({ offline: false }),
   readManifests,
+  readRuntimeInputs = defaultReadRuntimeInputs,
   root = process.cwd()
 } = {}) {
   const paths = providedPaths ?? createDocRuntimePaths({ workspaceRoot: root, ...pathOptions });
@@ -108,7 +125,9 @@ export async function createDocRuntimeContext({
         themes: Object.values(sourceThemes)
       })),
     paths,
-    helperCrates: await listHelperCrates({ fileSystem, paths, readManifests })
+    pythonOptions,
+    helperCrates: await listHelperCrates({ fileSystem, paths, readManifests }),
+    runtimeInputs: await readRuntimeInputs({ fileSystem, paths })
   };
 }
 
@@ -121,6 +140,10 @@ export async function syncDocRuntime({
   helperCrates,
   mode = undefined,
   paths,
+  preflightToolchains = defaultPreflightToolchains,
+  pythonOptions = Object.freeze({ offline: false }),
+  resolvePyodideInputs = defaultResolvePyodideRuntimeInputs,
+  runtimeInputs,
   syncLicenses = defaultSyncLicenseArtifacts,
   syncPyodide = defaultCopyPyodideAssets,
   syncRustSupport = syncRustBuildSupportFiles,
@@ -135,12 +158,25 @@ export async function syncDocRuntime({
   const haskellCells = cells.filter((cell) => cell.language === 'haskell');
   const pythonCells = cells.filter((cell) => cell.language === 'python');
   const rustCells = cells.filter((cell) => cell.language === 'rust');
+  const requestedPythonPackages = Array.from(new Set(pythonCells.flatMap((cell) => cell.packages))).sort();
   const summary = summarizeCells(cells);
+  const toolchains = await preflightToolchains({
+    fileSystem,
+    haskellCellCount: haskellCells.length,
+    mode,
+    runtimeInputs,
+    rustCellCount: rustCells.length,
+    tolerateHaskellFailure: tolerateHaskellBuildFailure
+  });
+  const pyodideRuntimeInputs =
+    pythonCells.length > 0
+      ? await resolvePyodideInputs({ fileSystem, requestedPackages: requestedPythonPackages })
+      : undefined;
   const generated = {
     cellsJson: generateCellsJson(cells),
     cellsModule: generateCellsModule(cells),
     haskellMain: generateHaskellMain(haskellCells),
-    rustCargo: generateRustCargoToml(rustCells, helperCrates),
+    rustCargo: generateRustCargoToml(rustCells, helperCrates, runtimeInputs),
     rustLib: generateRustLib(rustCells)
   };
   const desired = await createDesiredRuntime({
@@ -148,7 +184,10 @@ export async function syncDocRuntime({
     generated,
     paths,
     pythonCellCount: pythonCells.length,
-    summary
+    pyodideRuntimeInputs,
+    runtimeInputs,
+    summary,
+    toolchains
   });
   const state = await readRuntimeOwnership({ fileSystem, paths });
   const { outputComplete, outputPresent } = runtimeOutputState({ fileSystem, paths, state });
@@ -181,6 +220,9 @@ export async function syncDocRuntime({
       generated,
       paths,
       plan,
+      pyodideRuntimeInputs,
+      pythonOptions,
+      requestedPythonPackages,
       stagedPaths,
       stages,
       syncPyodide,
@@ -236,24 +278,46 @@ export async function syncDocRuntime({
   }
 }
 
-async function createDesiredRuntime({ fileSystem, generated, paths, pythonCellCount, summary }) {
+async function createDesiredRuntime({
+  fileSystem,
+  generated,
+  paths,
+  pythonCellCount,
+  pyodideRuntimeInputs,
+  runtimeInputs,
+  summary,
+  toolchains
+}) {
   const helperFingerprint =
     summary.rustCellCount > 0 ? await fingerprintHelperSources({ fileSystem, paths }) : stableFingerprint([]);
-  const rustSourceFingerprint = hashText(`${generated.rustCargo}\0${generated.rustLib}`);
+  const rustSourceFingerprint = hashText(
+    stableFingerprint({
+      cargo: generated.rustCargo,
+      lib: generated.rustLib,
+      lockSha256: runtimeInputs.rustLockSha256
+    })
+  );
   const haskellSourceFingerprint = hashText(generated.haskellMain);
-  const pythonAssetFingerprint =
-    pythonCellCount > 0 ? await fingerprintPyodideRecipe({ fileSystem, paths }) : stableFingerprint([]);
+  const pythonAssetFingerprint = pythonCellCount > 0 ? pyodideRuntimeInputs.fingerprint : stableFingerprint([]);
 
   return Object.freeze({
     manifestFingerprint: summary.manifestFingerprint,
     rust: Object.freeze({
-      buildFingerprint: stableFingerprint({ helpers: helperFingerprint, source: rustSourceFingerprint }),
+      buildFingerprint: stableFingerprint({
+        helpers: helperFingerprint,
+        source: rustSourceFingerprint,
+        toolchain: toolchains.rust ?? runtimeInputs.rust
+      }),
       cellCount: summary.rustCellCount,
       sourceFingerprint: rustSourceFingerprint
     }),
     python: Object.freeze({ assetFingerprint: pythonAssetFingerprint, cellCount: pythonCellCount }),
     haskell: Object.freeze({
-      buildFingerprint: haskellSourceFingerprint,
+      buildFingerprint: stableFingerprint({
+        cells: summary.haskellFingerprint,
+        source: haskellSourceFingerprint,
+        toolchain: toolchains.haskell ?? runtimeInputs.haskell
+      }),
       cellCount: summary.haskellCellCount,
       sourceFingerprint: haskellSourceFingerprint
     })
@@ -296,6 +360,9 @@ async function stageLanguageOutputs({
   generated,
   paths,
   plan,
+  pyodideRuntimeInputs,
+  pythonOptions,
+  requestedPythonPackages,
   stagedPaths,
   stages,
   syncPyodide,
@@ -314,7 +381,13 @@ async function stageLanguageOutputs({
   }
   if (plan.languages.python.public === 'copy') {
     await addDirectoryStage('pyodidePublicDir', paths, stagedPaths, stages, { fileSystem });
-    await syncPyodide({ fileSystem, paths: stagedPaths });
+    await syncPyodide({
+      fileSystem,
+      paths: stagedPaths,
+      pythonOptions,
+      requestedPackages: requestedPythonPackages,
+      runtimeInputs: pyodideRuntimeInputs
+    });
   }
   if (plan.languages.haskell.source === 'write' || plan.languages.haskell.public === 'build') {
     const stagePath = await addDirectoryStage('haskellCellsDir', paths, stagedPaths, stages, { fileSystem });
@@ -479,21 +552,6 @@ function recordedFilesExist(files, directory, fileSystem) {
         fileSystem.existsSync(pathInUrl(directory, fileName))
     )
   );
-}
-
-async function fingerprintPyodideRecipe({ fileSystem, paths }) {
-  const packageJsonPath = pathInUrl(paths.frameworkRoot, 'package.json');
-  const packageJson = JSON.parse(await fileSystem.readFile(packageJsonPath, 'utf8'));
-  const pyodideVersion = packageJson.dependencies?.pyodide;
-  if (typeof pyodideVersion !== 'string' || pyodideVersion.trim() === '') {
-    throw new Error(`Oxiquill package metadata does not declare Pyodide: ${packageJsonPath}.`);
-  }
-
-  return stableFingerprint({
-    core: requiredPyodideFiles,
-    roots: vendoredPyodidePackageRoots,
-    version: pyodideVersion
-  });
 }
 
 async function fingerprintHelperSources({ fileSystem, paths }) {

--- a/packages/oxiquill/src/generator/doc-runtime/haskell-runtime-test.mjs
+++ b/packages/oxiquill/src/generator/doc-runtime/haskell-runtime-test.mjs
@@ -1,0 +1,128 @@
+import { readFile } from 'node:fs/promises';
+import { ConsoleStdout, File, OpenFile, WASI } from '@bjorn3/browser_wasi_shim';
+import { pathInUrl } from '../../config/paths.mjs';
+import { HASKELL_RUNTIME_STATUS_FILE, HASKELL_WASM_FILE } from './wasm-build.mjs';
+import { hashText } from './hashing.mjs';
+
+const defaultFileSystem = { readFile };
+
+export async function testGeneratedHaskellCells({
+  compile = WebAssembly.compile,
+  executeCell = executeGeneratedHaskellCell,
+  expectedFingerprint,
+  fileSystem = defaultFileSystem,
+  paths
+}) {
+  const cells = parseCellManifest(await fileSystem.readFile(paths.cellsJsonPath, 'utf8'));
+  const haskellCells = cells.filter((cell) => cell.language === 'haskell');
+  if (haskellCells.length === 0) return Object.freeze({ cellCount: 0 });
+
+  const statusPath = pathInUrl(paths.haskellWasmPublicDir, HASKELL_RUNTIME_STATUS_FILE);
+  const wasmPath = pathInUrl(paths.haskellWasmPublicDir, HASKELL_WASM_FILE);
+  const [status, wasmBytes] = await Promise.all([
+    readHaskellStatus(statusPath, { fileSystem }),
+    fileSystem.readFile(wasmPath)
+  ]);
+  assertReadyStatus(status, expectedFingerprint, statusPath);
+  const module = await compile(wasmBytes);
+
+  for (const cell of haskellCells) {
+    try {
+      await executeCell({ cell, module });
+    } catch (error) {
+      const message = error instanceof Error && error.message ? error.message : String(error);
+      throw new Error(`Generated Haskell cell "${cell.id}" failed with default inputs: ${message}`, {
+        cause: error
+      });
+    }
+  }
+
+  return Object.freeze({ cellCount: haskellCells.length });
+}
+
+export async function executeGeneratedHaskellCell({
+  cell,
+  createWasi = createHaskellWasi,
+  instantiate = WebAssembly.instantiate,
+  module
+}) {
+  const stdout = createOutputCapture();
+  const stderr = createOutputCapture();
+  const args = ['doc_haskell_cells', cell.id, ...cell.inputs.map(({ value }) => inputArgument(value))];
+  const wasi = createWasi({ args, stderr: stderr.write, stdout: stdout.write });
+  const instance = await instantiate(module, {
+    wasi_snapshot_preview1: wasi.wasiImport
+  });
+  const exitCode = wasi.start(instance);
+  const output = { stderr: stderr.take(), stdout: stdout.take() };
+
+  if (exitCode !== 0) {
+    throw new Error(output.stderr || output.stdout || `process exited with status ${exitCode}`);
+  }
+
+  return output;
+}
+
+function createHaskellWasi({ args, stderr, stdout }) {
+  return new WASI(args, [], [new OpenFile(new File([])), new ConsoleStdout(stdout), new ConsoleStdout(stderr)]);
+}
+
+function createOutputCapture() {
+  const chunks = [];
+  const decoder = new TextDecoder();
+  return {
+    take: () => `${chunks.join('')}${decoder.decode()}`.trimEnd(),
+    write: (buffer) => chunks.push(decoder.decode(buffer, { stream: true }))
+  };
+}
+
+function inputArgument(value) {
+  if (typeof value === 'boolean') return value ? 'true' : 'false';
+  if (typeof value === 'string' || typeof value === 'number') return String(value);
+  throw new TypeError(`Unsupported Haskell default input value: ${String(value)}.`);
+}
+
+async function readHaskellStatus(filePath, { fileSystem }) {
+  try {
+    return JSON.parse(await fileSystem.readFile(filePath, 'utf8'));
+  } catch (error) {
+    throw new Error(`Generated Haskell runtime status is invalid or missing: ${filePath}.`, { cause: error });
+  }
+}
+
+function assertReadyStatus(status, expectedFingerprint, filePath) {
+  if (
+    !status ||
+    status.status !== 'ready' ||
+    typeof status.haskellFingerprintHash !== 'string' ||
+    typeof status.message !== 'string'
+  ) {
+    const detail = typeof status?.message === 'string' && status.message ? ` ${status.message}` : '';
+    throw new Error(`Generated Haskell runtime is not ready: ${filePath}.${detail}`);
+  }
+  if (expectedFingerprint !== undefined && status.haskellFingerprintHash !== hashText(expectedFingerprint)) {
+    throw new Error(`Generated Haskell runtime is stale: ${filePath}.`);
+  }
+}
+
+function parseCellManifest(source) {
+  let cells;
+  try {
+    cells = JSON.parse(source);
+  } catch (error) {
+    throw new Error('Generated cell manifest is invalid JSON.', { cause: error });
+  }
+  if (!Array.isArray(cells)) throw new Error('Generated cell manifest must be an array.');
+  for (const cell of cells) {
+    if (
+      !cell ||
+      typeof cell.id !== 'string' ||
+      typeof cell.language !== 'string' ||
+      !Array.isArray(cell.inputs) ||
+      cell.inputs.some((input) => !input || !Object.hasOwn(input, 'value'))
+    ) {
+      throw new Error('Generated cell manifest contains an invalid cell.');
+    }
+  }
+  return cells;
+}

--- a/packages/oxiquill/src/generator/doc-runtime/pyodide-assets.mjs
+++ b/packages/oxiquill/src/generator/doc-runtime/pyodide-assets.mjs
@@ -1,11 +1,16 @@
+import { randomUUID } from 'node:crypto';
 import path from 'node:path';
 import { createRequire } from 'node:module';
 import { pathInUrl } from '../../config/paths.mjs';
 import { vendoredPyodidePackageRoots } from './constants.mjs';
 import { copyFileIfChanged, defaultFileSystem, hasPackageContent } from './file-system.mjs';
-import { hashBytes } from './hashing.mjs';
+import { hashBytes, stableFingerprint } from './hashing.mjs';
 
 const require = createRequire(import.meta.url);
+const defaultPackageCdn = 'https://cdn.jsdelivr.net/pyodide/';
+const cacheNamespace = 'pyodide';
+export const PYODIDE_DOWNLOAD_ATTEMPTS = 3;
+export const PYODIDE_REQUEST_TIMEOUT_MS = 30_000;
 export const requiredPyodideFiles = [
   'pyodide.mjs',
   'pyodide.mjs.map',
@@ -15,77 +20,259 @@ export const requiredPyodideFiles = [
   'pyodide-lock.json'
 ];
 
-export async function copyPyodideAssets({
-  fetchPackage,
+export async function resolvePyodideRuntimeInputs({
   fileSystem = defaultFileSystem,
-  paths,
+  requestedPackages = vendoredPyodidePackageRoots,
   resolvePackageJson = resolvePyodidePackageJson
-}) {
+} = {}) {
   const packageDir = resolvePyodidePackageDir(resolvePackageJson);
   assertRequiredPyodideFiles(packageDir, { fileSystem });
 
-  const [lockFile, pyodideVersion] = await Promise.all([
-    readJsonFile(path.join(packageDir, 'pyodide-lock.json'), { fileSystem }),
-    readPyodideVersion(packageDir, { fileSystem })
+  const packageJsonPath = path.join(packageDir, 'package.json');
+  const lockPath = path.join(packageDir, 'pyodide-lock.json');
+  const [packageMetadata, lockBytes] = await Promise.all([
+    readJsonFile(packageJsonPath, { fileSystem }),
+    fileSystem.readFile(lockPath)
   ]);
-  const coreChanged = await Promise.all(
-    requiredPyodideFiles.map((file) =>
-      copyFileIfChanged(path.join(packageDir, file), pathInUrl(paths.pyodidePublicDir, file), {
-        fileSystem
-      })
-    )
+  const lockFile = parseJson(lockBytes, lockPath);
+  const version = requiredText(packageMetadata.version, 'Pyodide package metadata is missing a version.');
+  if (lockFile.info?.version !== undefined && lockFile.info.version !== version) {
+    throw new Error(`Pyodide package version ${version} does not match lock file version ${lockFile.info.version}.`);
+  }
+  const lockSha256 = hashBytes(lockBytes);
+  const coreAssets = await Promise.all(
+    requiredPyodideFiles.map(async (fileName) => {
+      const sourcePath = path.join(packageDir, fileName);
+      return Object.freeze({ fileName, sha256: hashBytes(await fileSystem.readFile(sourcePath)), sourcePath });
+    })
   );
-  const packageChanged = await copyVendoredPyodidePackages({
-    fetchPackage,
-    fileSystem,
-    lockFile,
-    paths,
-    pyodideVersion
+  const packages = resolveVendoredPyodidePackages(lockFile, requestedPackages);
+  const fingerprint = stableFingerprint({
+    core: coreAssets.map(({ fileName, sha256 }) => ({ fileName, sha256 })),
+    lockSha256,
+    packages: packages.map(({ depends, file_name: fileName, name, sha256, version: packageVersion }) => ({
+      depends,
+      fileName,
+      name,
+      sha256,
+      version: packageVersion
+    })),
+    requestedPackages: Array.from(new Set(requestedPackages)).sort(),
+    version
   });
 
-  return coreChanged.some(Boolean) || packageChanged;
+  return Object.freeze({
+    coreAssets: Object.freeze(coreAssets),
+    defaultPackageBaseUrl: new URL(`v${version}/full/`, defaultPackageCdn).href,
+    fingerprint,
+    lockFile,
+    lockSha256,
+    packageDir,
+    packages: Object.freeze(packages),
+    version
+  });
+}
+
+export async function copyPyodideAssets({
+  fetchImplementation = globalThis.fetch,
+  fetchPackage,
+  fileSystem = defaultFileSystem,
+  paths,
+  pythonOptions = Object.freeze({ offline: false }),
+  requestedPackages = vendoredPyodidePackageRoots,
+  resolvePackageJson = resolvePyodidePackageJson,
+  runtimeInputs,
+  sleep = defaultSleep,
+  temporaryName = randomUUID
+}) {
+  const inputs =
+    runtimeInputs ?? (await resolvePyodideRuntimeInputs({ fileSystem, requestedPackages, resolvePackageJson }));
+  const packageBaseUrl = pythonOptions.packageMirror ?? inputs.defaultPackageBaseUrl;
+  const cacheDirectory = pathInUrl(paths.downloadCacheDir, cacheNamespace, inputs.version, inputs.lockSha256);
+  const assets = [
+    ...inputs.coreAssets.map((asset) => ({ ...asset, kind: 'installed' })),
+    ...inputs.packages.map((packageInfo) => ({
+      fileName: packageInfo.file_name,
+      kind: 'download',
+      name: packageInfo.name,
+      sha256: packageInfo.sha256
+    }))
+  ];
+
+  const cachedAssets = await Promise.all(
+    assets.map(async (asset) => ({
+      ...asset,
+      cachePath: await ensureCachedAsset(asset, {
+        cacheDirectory,
+        fetchImplementation,
+        fetchPackage,
+        fileSystem,
+        offline: pythonOptions.offline,
+        packageBaseUrl,
+        sleep,
+        temporaryName
+      })
+    }))
+  );
+  const copied = await Promise.all(
+    cachedAssets.map(({ cachePath, fileName }) =>
+      copyFileIfChanged(cachePath, pathInUrl(paths.pyodidePublicDir, fileName), { fileSystem })
+    )
+  );
+  return copied.some(Boolean);
 }
 
 export async function copyVendoredPyodidePackages({
+  fetchImplementation = globalThis.fetch,
   fetchPackage,
   fileSystem = defaultFileSystem,
   lockFile,
   paths,
   pyodideVersion,
-  roots = vendoredPyodidePackageRoots
+  roots = vendoredPyodidePackageRoots,
+  sleep = defaultSleep,
+  temporaryName = randomUUID
 }) {
+  const version = requiredText(pyodideVersion, 'pyodideVersion is required when copying vendored packages.');
   const packages = resolveVendoredPyodidePackages(lockFile, roots);
-  const downloadPackage = fetchPackage ?? ((fileName) => fetchPyodidePackage(fileName, pyodideVersion));
-  const changed = await Promise.all(
-    packages.map(async (packageInfo) => {
-      const targetPath = pathInUrl(paths.pyodidePublicDir, packageInfo.file_name);
-      if (await hasPackageContent(targetPath, packageInfo.sha256, { fileSystem })) return false;
-
-      const content = await downloadPackage(packageInfo.file_name);
-      assertPackageSha256(content, packageInfo.sha256, packageInfo.name);
-      await fileSystem.mkdir(path.dirname(targetPath), { recursive: true });
-      await fileSystem.writeFile(targetPath, content);
-      return true;
-    })
-  );
-
-  return changed.some(Boolean);
+  const runtimeInputs = {
+    coreAssets: [],
+    defaultPackageBaseUrl: new URL(`v${version}/full/`, defaultPackageCdn).href,
+    lockSha256: hashBytes(Buffer.from(JSON.stringify(lockFile))),
+    packages,
+    version
+  };
+  return copyPyodideAssets({
+    fetchImplementation,
+    fetchPackage,
+    fileSystem,
+    paths,
+    runtimeInputs,
+    sleep,
+    temporaryName
+  });
 }
 
-async function readPyodideVersion(packageDir, { fileSystem }) {
-  const packageMetadata = await readJsonFile(path.join(packageDir, 'package.json'), { fileSystem });
-  if (typeof packageMetadata.version !== 'string' || packageMetadata.version.trim() === '') {
-    throw new Error('Pyodide package metadata is missing a version.');
+export function resolveVendoredPyodidePackages(lockFile, roots = vendoredPyodidePackageRoots) {
+  const packages = lockFile?.packages;
+  if (!packages || typeof packages !== 'object' || Array.isArray(packages)) {
+    throw new Error('Pyodide lock file is missing a packages table.');
   }
 
-  return packageMetadata.version;
+  const selected = new Set();
+  function visit(packageName) {
+    if (selected.has(packageName)) return;
+    const packageInfo = packages[packageName];
+    if (!packageInfo) throw new Error(`Pyodide package "${packageName}" is missing from the lock file.`);
+    validatePackageInfo(packageName, packageInfo);
+    selected.add(packageName);
+    (packageInfo.depends ?? []).forEach(visit);
+  }
+
+  roots.forEach(visit);
+  return Array.from(selected)
+    .sort()
+    .map((name) => Object.freeze({ name, ...packages[name], depends: Object.freeze(packages[name].depends ?? []) }));
 }
 
-async function readJsonFile(filePath, { fileSystem }) {
+async function ensureCachedAsset(
+  asset,
+  { cacheDirectory, fetchImplementation, fetchPackage, fileSystem, offline, packageBaseUrl, sleep, temporaryName }
+) {
+  const cachePath = path.join(cacheDirectory, asset.fileName);
+  if (await hasPackageContent(cachePath, asset.sha256, { fileSystem })) return cachePath;
+  if (offline) {
+    throw new Error(
+      `Offline Pyodide cache miss for "${asset.fileName}" at "${cachePath}"; expected sha256 ${asset.sha256}.`
+    );
+  }
+
+  await fileSystem.mkdir(cacheDirectory, { recursive: true });
+  const temporaryPath = `${cachePath}.tmp-${temporaryName()}`;
   try {
-    return JSON.parse(await fileSystem.readFile(filePath, 'utf8'));
+    if (asset.kind === 'installed') {
+      await fileSystem.copyFile(asset.sourcePath, temporaryPath);
+    } else {
+      const content = fetchPackage
+        ? await fetchPackage(asset.fileName)
+        : await fetchPyodidePackage(asset.fileName, {
+            fetchImplementation,
+            packageBaseUrl,
+            sleep
+          });
+      await fileSystem.writeFile(temporaryPath, content);
+    }
+    await assertFileSha256(temporaryPath, asset.sha256, asset.name ?? asset.fileName, { fileSystem });
+    await fileSystem.rm(cachePath, { force: true });
+    await fileSystem.rename(temporaryPath, cachePath);
+    return cachePath;
+  } finally {
+    await fileSystem.rm(temporaryPath, { force: true });
+  }
+}
+
+export async function fetchPyodidePackage(
+  fileName,
+  {
+    fetchImplementation = globalThis.fetch,
+    packageBaseUrl,
+    sleep = defaultSleep,
+    timeoutMs = PYODIDE_REQUEST_TIMEOUT_MS
+  }
+) {
+  const url = new URL(encodeURIComponent(fileName), packageBaseUrl).href;
+  let lastError;
+  let attempts = 0;
+
+  for (let attempt = 1; attempt <= PYODIDE_DOWNLOAD_ATTEMPTS; attempt += 1) {
+    attempts = attempt;
+    try {
+      return await fetchOnce(url, { fetchImplementation, timeoutMs });
+    } catch (error) {
+      lastError = error;
+      if (!isRetryable(error) || attempt === PYODIDE_DOWNLOAD_ATTEMPTS) break;
+      await sleep(attempt === 1 ? 250 : 1_000);
+    }
+  }
+
+  throw new Error(`Failed to download ${url} after ${attempts} attempt(s): ${errorMessage(lastError)}`, {
+    cause: lastError
+  });
+}
+
+async function fetchOnce(url, { fetchImplementation, timeoutMs }) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const response = await fetchImplementation(url, { signal: controller.signal });
+    if (!response.ok) {
+      const error = new Error(`${response.status} ${response.statusText}`);
+      error.retryable = response.status === 408 || response.status === 429 || response.status >= 500;
+      throw error;
+    }
+    return Buffer.from(await response.arrayBuffer());
   } catch (error) {
-    throw new Error(`Pyodide metadata file is invalid: ${filePath}.`, { cause: error });
+    if (controller.signal.aborted) {
+      const timeoutError = new Error(`request timed out after ${timeoutMs}ms`);
+      timeoutError.retryable = true;
+      throw timeoutError;
+    }
+    throw error;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+function isRetryable(error) {
+  return error?.retryable !== false;
+}
+
+async function assertFileSha256(filePath, expectedSha256, assetName, { fileSystem }) {
+  const actualSha256 = hashBytes(await fileSystem.readFile(filePath));
+  if (actualSha256 !== expectedSha256) {
+    const error = new Error(`Pyodide asset "${assetName}" has sha256 ${actualSha256}; expected ${expectedSha256}.`);
+    error.retryable = false;
+    throw error;
   }
 }
 
@@ -99,12 +286,9 @@ function resolvePyodidePackageDir(resolvePackageJson) {
     if (typeof packageJsonPath !== 'string' || packageJsonPath.length === 0) {
       throw new TypeError('The package resolver did not return a file path.');
     }
-
     return path.dirname(packageJsonPath);
   } catch (error) {
-    throw new Error('Unable to resolve required Pyodide package "pyodide" from Oxiquill.', {
-      cause: error
-    });
+    throw new Error('Unable to resolve required Pyodide package "pyodide" from Oxiquill.', { cause: error });
   }
 }
 
@@ -112,53 +296,44 @@ function assertRequiredPyodideFiles(packageDir, { fileSystem }) {
   requiredPyodideFiles.forEach((fileName) => {
     const filePath = path.join(packageDir, fileName);
     if (fileSystem.existsSync(filePath)) return;
-
     throw new Error(`Required Pyodide asset "${fileName}" is missing from package "pyodide" at "${filePath}".`);
   });
 }
 
-export function resolveVendoredPyodidePackages(lockFile, roots = vendoredPyodidePackageRoots) {
-  const packages = lockFile?.packages;
-  if (!packages || typeof packages !== 'object') {
-    throw new Error('Pyodide lock file is missing a packages table.');
+function validatePackageInfo(name, packageInfo) {
+  const fileName = requiredText(packageInfo.file_name, `Pyodide package "${name}" is missing file_name.`);
+  if (path.basename(fileName) !== fileName || fileName.includes('\\')) {
+    throw new Error(`Pyodide package "${name}" has unsafe file_name "${fileName}".`);
   }
-
-  const selected = new Set();
-  function visit(packageName) {
-    if (selected.has(packageName)) return;
-    const packageInfo = packages[packageName];
-    if (!packageInfo) throw new Error(`Pyodide package "${packageName}" is missing from the lock file.`);
-    selected.add(packageName);
-    for (const dependency of packageInfo.depends ?? []) {
-      visit(dependency);
-    }
+  if (!/^[0-9a-f]{64}$/u.test(packageInfo.sha256)) {
+    throw new Error(`Pyodide package "${name}" has an invalid sha256.`);
   }
-
-  roots.forEach(visit);
-  return Array.from(selected)
-    .sort()
-    .map((name) => ({ name, ...packages[name] }));
-}
-
-function assertPackageSha256(content, expectedSha256, packageName) {
-  const actualSha256 = hashBytes(content);
-  if (actualSha256 !== expectedSha256) {
-    throw new Error(
-      `Downloaded Pyodide package "${packageName}" has sha256 ${actualSha256}; expected ${expectedSha256}.`
-    );
+  if (packageInfo.depends !== undefined && !Array.isArray(packageInfo.depends)) {
+    throw new Error(`Pyodide package "${name}" has invalid dependencies.`);
   }
 }
 
-async function fetchPyodidePackage(fileName, pyodideVersion) {
-  if (typeof pyodideVersion !== 'string' || pyodideVersion.trim() === '') {
-    throw new Error('A Pyodide version is required to download vendored packages.');
-  }
+async function readJsonFile(filePath, { fileSystem }) {
+  return parseJson(await fileSystem.readFile(filePath), filePath);
+}
 
-  const url = `https://cdn.jsdelivr.net/pyodide/v${pyodideVersion}/full/${fileName}`;
-  const response = await fetch(url);
-  if (!response.ok) {
-    throw new Error(`Failed to download ${url}: ${response.status} ${response.statusText}`);
+function parseJson(source, filePath) {
+  try {
+    return JSON.parse(String(source));
+  } catch (error) {
+    throw new Error(`Pyodide metadata file is invalid: ${filePath}.`, { cause: error });
   }
+}
 
-  return Buffer.from(await response.arrayBuffer());
+function requiredText(value, message) {
+  if (typeof value !== 'string' || value.trim() === '') throw new Error(message);
+  return value.trim();
+}
+
+function errorMessage(error) {
+  return error instanceof Error && error.message ? error.message : String(error);
+}
+
+function defaultSleep(milliseconds) {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
 }

--- a/packages/oxiquill/src/generator/doc-runtime/runtime-inputs.mjs
+++ b/packages/oxiquill/src/generator/doc-runtime/runtime-inputs.mjs
@@ -1,0 +1,141 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { pathInUrl } from '../../config/paths.mjs';
+import { defaultFileSystem } from './file-system.mjs';
+import { hashBytes } from './hashing.mjs';
+
+const runtimeInputsUrl = new URL('../runtime-data/runtime-inputs.json', import.meta.url);
+const rustLockUrl = new URL('../license-data/rust/runtime-Cargo.lock', import.meta.url);
+const defaultRuntimeInputsPath =
+  runtimeInputsUrl.protocol === 'file:'
+    ? fileURLToPath(runtimeInputsUrl)
+    : path.resolve(process.cwd(), 'packages/oxiquill/src/generator/runtime-data/runtime-inputs.json');
+const defaultRustLockPath =
+  rustLockUrl.protocol === 'file:'
+    ? fileURLToPath(rustLockUrl)
+    : path.resolve(process.cwd(), 'packages/oxiquill/src/generator/license-data/rust/runtime-Cargo.lock');
+
+export async function readRuntimeInputs({
+  fileSystem = defaultFileSystem,
+  paths,
+  runtimeInputsPath = defaultRuntimeInputsPath,
+  rustLockPath = defaultRustLockPath
+}) {
+  const [packageSource, runtimeSource, rustLock] = await Promise.all([
+    fileSystem.readFile(pathInUrl(paths.frameworkRoot, 'package.json'), 'utf8'),
+    fileSystem.readFile(runtimeInputsPath, 'utf8'),
+    fileSystem.readFile(rustLockPath, 'utf8')
+  ]);
+
+  return normalizeRuntimeInputs({
+    packageJson: parseJson(packageSource, pathInUrl(paths.frameworkRoot, 'package.json')),
+    runtimeData: parseJson(runtimeSource, runtimeInputsPath),
+    rustLock: String(rustLock)
+  });
+}
+
+export function normalizeRuntimeInputs({ packageJson, runtimeData, rustLock }) {
+  if (runtimeData?.schemaVersion !== 1) {
+    throw new Error('Oxiquill runtime inputs must use schemaVersion 1.');
+  }
+
+  const packageVersion = requiredText(packageJson?.version, 'Oxiquill package metadata is missing a version.');
+  const repository = normalizeRepository(packageJson?.repository);
+  const rust = normalizeRustInputs(runtimeData.rust);
+  const haskell = normalizeHaskellInputs(runtimeData.haskell);
+  assertRustLock(rustLock, { packageVersion, rust });
+
+  return Object.freeze({
+    haskell,
+    package: Object.freeze({ repository, version: packageVersion }),
+    rust,
+    rustLock,
+    rustLockSha256: hashBytes(Buffer.from(rustLock))
+  });
+}
+
+export function normalizeRepository(repository) {
+  const raw = typeof repository === 'string' ? repository : repository?.url;
+  const value = requiredText(raw, 'Oxiquill package metadata is missing a repository URL.')
+    .replace(/^git\+/u, '')
+    .replace(/\.git$/u, '');
+  let url;
+  try {
+    url = new URL(value);
+  } catch (error) {
+    throw new Error(`Oxiquill repository URL is invalid: ${value}.`, { cause: error });
+  }
+  if (url.protocol !== 'https:' && url.protocol !== 'http:') {
+    throw new Error(`Oxiquill repository URL must use HTTP(S): ${value}.`);
+  }
+  return url.href.replace(/\/$/u, '');
+}
+
+function normalizeRustInputs(value) {
+  const dependencies = value?.dependencies;
+  if (!dependencies || typeof dependencies !== 'object' || Array.isArray(dependencies)) {
+    throw new Error('Oxiquill Rust runtime inputs are missing dependencies.');
+  }
+
+  const normalizedDependencies = Object.freeze(
+    Object.fromEntries(
+      Object.entries(dependencies)
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([name, version]) => [name, requiredText(version, `Rust dependency ${name} is missing a version.`)])
+    )
+  );
+
+  return Object.freeze({
+    cargoVersion: requiredText(value.cargoVersion, 'Rust runtime inputs are missing cargoVersion.'),
+    dependencies: normalizedDependencies,
+    edition: requiredText(value.edition, 'Rust runtime inputs are missing edition.'),
+    rustVersion: requiredText(value.rustVersion, 'Rust runtime inputs are missing rustVersion.'),
+    rustcVersion: requiredText(value.rustcVersion, 'Rust runtime inputs are missing rustcVersion.'),
+    target: requiredText(value.target, 'Rust runtime inputs are missing target.'),
+    wasmPackVersion: requiredText(value.wasmPackVersion, 'Rust runtime inputs are missing wasmPackVersion.')
+  });
+}
+
+function normalizeHaskellInputs(value) {
+  return Object.freeze({
+    compiler: requiredText(value?.compiler, 'Haskell runtime inputs are missing compiler.'),
+    supportedVersionPrefix: requiredText(
+      value?.supportedVersionPrefix,
+      'Haskell runtime inputs are missing supportedVersionPrefix.'
+    )
+  });
+}
+
+function assertRustLock(rustLock, { packageVersion, rust }) {
+  const lock = requiredText(rustLock, 'The generated Rust Cargo.lock input is empty.');
+  const packageBlock = lock.match(/\[\[package\]\]\nname = "doc-rust-cells"\nversion = "([^"]+)"/u);
+  if (packageBlock?.[1] !== packageVersion) {
+    throw new Error(
+      `Generated Rust Cargo.lock has doc-rust-cells ${packageBlock?.[1] ?? '(missing)'}; expected ${packageVersion}.`
+    );
+  }
+
+  Object.entries(rust.dependencies).forEach(([name, version]) => {
+    const escapedName = escapeRegExp(name);
+    const escapedVersion = escapeRegExp(version);
+    if (new RegExp(`name = "${escapedName}"\\nversion = "${escapedVersion}"`, 'u').test(lock)) return;
+    throw new Error(`Generated Rust Cargo.lock is missing ${name} ${version}.`);
+  });
+}
+
+function parseJson(source, filePath) {
+  try {
+    return JSON.parse(source);
+  } catch (error) {
+    throw new Error(`Oxiquill runtime metadata is invalid JSON: ${path.resolve(filePath)}.`, { cause: error });
+  }
+}
+
+function requiredText(value, message) {
+  if (typeof value !== 'string' || value.trim() === '') throw new Error(message);
+  return value.trim();
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/gu, '\\$&');
+}

--- a/packages/oxiquill/src/generator/doc-runtime/rust-codegen/cargo.mjs
+++ b/packages/oxiquill/src/generator/doc-runtime/rust-codegen/cargo.mjs
@@ -1,6 +1,8 @@
 import { generatedTomlBanner } from './banners.mjs';
 
-export function generateRustCargoToml(rustCells, helperCrates) {
+export function generateRustCargoToml(rustCells, helperCrates, runtimeInputs) {
+  const packageMetadata = runtimeInputs.package;
+  const rust = runtimeInputs.rust;
   const dependencyLines = rustCells
     .flatMap((cell) => cell.crates)
     .filter((crateName, index, crates) => crates.indexOf(crateName) === index)
@@ -10,10 +12,11 @@ export function generateRustCargoToml(rustCells, helperCrates) {
 
   return `${generatedTomlBanner()}[package]
 name = "doc-rust-cells"
-version = "0.2.0"
+version = ${JSON.stringify(packageMetadata.version)}
 description = "Generated Rust cells for the documentation runtime."
-edition = "2024"
-rust-version = "1.95"
+repository = ${JSON.stringify(packageMetadata.repository)}
+edition = ${JSON.stringify(rust.edition)}
+rust-version = ${JSON.stringify(rust.rustVersion)}
 license = "MIT OR Apache-2.0"
 publish = false
 
@@ -23,13 +26,13 @@ publish = false
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-console_error_panic_hook = "0.1"
-${localDependencies}serde = { version = "1", features = ["derive"] }
-serde_json = "1"
-wasm-bindgen = "0.2"
+console_error_panic_hook = "=${rust.dependencies.console_error_panic_hook}"
+${localDependencies}serde = { version = "=${rust.dependencies.serde}", features = ["derive"] }
+serde_json = "=${rust.dependencies.serde_json}"
+wasm-bindgen = "=${rust.dependencies['wasm-bindgen']}"
 
 [dev-dependencies]
-wasm-bindgen-test = "0.3"
+wasm-bindgen-test = "=${rust.dependencies['wasm-bindgen-test']}"
 `;
 }
 

--- a/packages/oxiquill/src/generator/doc-runtime/rust-codegen/functions.mjs
+++ b/packages/oxiquill/src/generator/doc-runtime/rust-codegen/functions.mjs
@@ -1,5 +1,5 @@
 import { generateRustInputBinding } from '../rust-readers.mjs';
-import { rustFunctionName } from '../rust-identifiers.mjs';
+import { rustFunctionName, rustIdentifier } from '../rust-identifiers.mjs';
 import { generateRustPreludeMacros } from './macros.mjs';
 
 export function generateRustFunction(cell) {
@@ -24,23 +24,31 @@ ${escapedSource}
 }`;
 }
 
-export function generateRustTest(cell) {
-  const defaultInputs = Object.fromEntries(cell.inputs.map((input) => [input.name, input.value]));
+export function generateRustTests(cells) {
+  if (cells.length === 0) return '';
+  const tests = cells.map(generateRustTest).join('\n\n');
   return `#[cfg(test)]
 mod tests {
     use wasm_bindgen_test::wasm_bindgen_test;
 
-    #[wasm_bindgen_test]
-    fn first_generated_cell_runs() {
+${tests}
+}`;
+}
+
+function generateRustTest(cell) {
+  const defaultInputs = Object.fromEntries(cell.inputs.map((input) => [input.name, input.value]));
+  const testName = `generated_${rustIdentifier(cell.id)}_runs`;
+  const failureMessage = `generated Rust cell ${cell.id} should run with default inputs`;
+  return `    #[wasm_bindgen_test]
+    fn ${testName}() {
         let output = super::run_rust_cell(${JSON.stringify(cell.id)}, ${JSON.stringify(JSON.stringify(defaultInputs))})
-        .expect("generated Rust cell should run");
+            .expect(${JSON.stringify(failureMessage)});
 
         assert!(
             output.contains("stdout"),
-            "generated cell output should include stdout"
+            ${JSON.stringify(`generated Rust cell ${cell.id} output should include stdout`)}
         );
-    }
-}`;
+    }`;
 }
 
 function indentRustSource(source) {

--- a/packages/oxiquill/src/generator/doc-runtime/rust-codegen/lib.mjs
+++ b/packages/oxiquill/src/generator/doc-runtime/rust-codegen/lib.mjs
@@ -1,7 +1,7 @@
 import { generateRustReaders } from '../rust-readers.mjs';
 import { rustFunctionName } from '../rust-identifiers.mjs';
 import { generatedBanner } from './banners.mjs';
-import { generateRustFunction, generateRustTest } from './functions.mjs';
+import { generateRustFunction, generateRustTests } from './functions.mjs';
 import { generateRustOutputTypes } from './output-types.mjs';
 
 export function generateRustLib(rustCells) {
@@ -29,7 +29,7 @@ ${matchArms}
 }`;
 
   const functions = rustCells.map(generateRustFunction).join('\n\n');
-  const firstCellTest = rustCells[0] ? generateRustTest(rustCells[0]) : '';
+  const tests = generateRustTests(rustCells);
   const readers = generateRustReaders(rustCells);
   const outputTypes = generateRustOutputTypes(rustCells);
   const serdeImport = rustCells.length === 0 ? '' : 'use serde::Serialize;\n';
@@ -52,5 +52,5 @@ fn to_js_error(error: impl std::fmt::Display) -> JsValue {
 ${readers}
 ${functions}
 
-${firstCellTest}`;
+${tests}`;
 }

--- a/packages/oxiquill/src/generator/doc-runtime/toolchain-preflight.mjs
+++ b/packages/oxiquill/src/generator/doc-runtime/toolchain-preflight.mjs
@@ -1,0 +1,162 @@
+import { spawn } from 'node:child_process';
+import { defaultFileSystem } from './file-system.mjs';
+
+export async function preflightRequiredToolchains({
+  environment = process.env,
+  fileSystem = defaultFileSystem,
+  haskellCellCount,
+  mode,
+  platform = process.platform,
+  runCommand = runCommandWithCapturedOutput,
+  runtimeInputs,
+  rustCellCount,
+  tolerateHaskellFailure = false
+}) {
+  if (mode === undefined) return Object.freeze({});
+
+  const [rust, haskell] = await Promise.all([
+    rustCellCount > 0
+      ? preflightRustToolchain({ fileSystem, runCommand, runtimeInputs: runtimeInputs.rust })
+      : undefined,
+    haskellCellCount > 0
+      ? preflightHaskellToolchain({
+          environment,
+          platform,
+          runCommand,
+          runtimeInputs: runtimeInputs.haskell,
+          tolerateFailure: tolerateHaskellFailure
+        })
+      : undefined
+  ]);
+
+  return Object.freeze({ ...(rust ? { rust } : {}), ...(haskell ? { haskell } : {}) });
+}
+
+export async function preflightRustToolchain({ fileSystem = defaultFileSystem, runCommand, runtimeInputs }) {
+  const commands = [
+    ['rustc', ['--version'], 'rustc', runtimeInputs.rustcVersion],
+    ['cargo', ['--version'], 'cargo', runtimeInputs.cargoVersion],
+    ['wasm-pack', ['--version'], 'wasm-pack', runtimeInputs.wasmPackVersion]
+  ];
+  const versions = {};
+
+  for (const [command, args, label, expected] of commands) {
+    const output = await runVersionCommand(command, args, {
+      expected,
+      guidance: rustSetupGuidance(runtimeInputs),
+      label,
+      runCommand
+    });
+    versions[label] = output;
+  }
+
+  const targetCommand = ['rustc', ['--print', 'target-libdir', '--target', runtimeInputs.target]];
+  const targetLibdir = await runCommand(...targetCommand).catch((error) => {
+    throw preflightError(
+      targetCommand,
+      `support for ${runtimeInputs.target}`,
+      errorMessage(error),
+      rustSetupGuidance(runtimeInputs)
+    );
+  });
+  const targetPath = String(targetLibdir).trim();
+  let targetFiles;
+  try {
+    targetFiles = await fileSystem.readdir(targetPath);
+  } catch (error) {
+    throw preflightError(
+      targetCommand,
+      `installed target ${runtimeInputs.target}`,
+      errorMessage(error),
+      rustSetupGuidance(runtimeInputs)
+    );
+  }
+  if (!targetFiles.some((entry) => String(typeof entry === 'string' ? entry : entry.name).startsWith('libcore-'))) {
+    throw preflightError(
+      targetCommand,
+      `installed target ${runtimeInputs.target}`,
+      `no Rust core library was found in ${targetPath}`,
+      rustSetupGuidance(runtimeInputs)
+    );
+  }
+
+  return Object.freeze({ ...versions, target: runtimeInputs.target });
+}
+
+export async function preflightHaskellToolchain({
+  environment,
+  platform,
+  runCommand,
+  runtimeInputs,
+  tolerateFailure = false
+}) {
+  const compiler = environment.OXIQUILL_HASKELL_GHC?.trim() || runtimeInputs.compiler;
+  const command = [compiler, ['--numeric-version']];
+  try {
+    if (platform === 'win32') {
+      throw new Error('native Windows Haskell/WASI generation is unsupported');
+    }
+    const version = String(await runCommand(...command)).trim();
+    if (!version.startsWith(runtimeInputs.supportedVersionPrefix)) {
+      throw new Error(`reported ${version || '(empty output)'}`);
+    }
+    return Object.freeze({ command: compiler, version });
+  } catch (error) {
+    const failure = preflightError(
+      command,
+      `${runtimeInputs.supportedVersionPrefix.slice(0, -1)}.x support on Linux or macOS`,
+      errorMessage(error),
+      `Install ${runtimeInputs.compiler}, source ~/.ghc-wasm/env when using ghc-wasm-meta, or set OXIQUILL_HASKELL_GHC to the compiler path. Generated Haskell Wasm remains browser-portable.`
+    );
+    if (!tolerateFailure) throw failure;
+    return Object.freeze({ command: compiler, error: failure.message, unavailable: true });
+  }
+}
+
+async function runVersionCommand(command, args, { expected, guidance, label, runCommand }) {
+  let output;
+  try {
+    output = String(await runCommand(command, args)).trim();
+  } catch (error) {
+    throw preflightError([command, args], `${label} ${expected}`, errorMessage(error), guidance);
+  }
+  const version = output.split(/\s+/u)[1];
+  if (version !== expected) {
+    throw preflightError([command, args], `${label} ${expected}`, output || '(empty output)', guidance);
+  }
+  return output;
+}
+
+function preflightError([command, args], expected, actual, guidance) {
+  return new Error(
+    `Toolchain preflight failed: "${[command, ...args].join(' ')}" expected ${expected}; received ${actual}. ${guidance}`
+  );
+}
+
+function rustSetupGuidance(runtimeInputs) {
+  return `Install Rust ${runtimeInputs.rustcVersion}, run "rustup target add ${runtimeInputs.target} --toolchain ${runtimeInputs.rustcVersion}", and install wasm-pack ${runtimeInputs.wasmPackVersion}.`;
+}
+
+function errorMessage(error) {
+  return error instanceof Error && error.message ? error.message : String(error);
+}
+
+/* v8 ignore start -- external process adapter is covered through injected runCommand. */
+function runCommandWithCapturedOutput(command, args) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, { stdio: ['ignore', 'pipe', 'pipe'] });
+    const stdout = [];
+    const stderr = [];
+    child.stdout.on('data', (chunk) => stdout.push(chunk));
+    child.stderr.on('data', (chunk) => stderr.push(chunk));
+    child.on('error', reject);
+    child.on('exit', (code, signal) => {
+      if (code === 0) {
+        resolve(Buffer.concat(stdout).toString('utf8'));
+      } else {
+        reject(new Error(Buffer.concat(stderr).toString('utf8').trim() || `${command} exited with ${signal ?? code}`));
+      }
+    });
+  });
+}
+/* v8 ignore stop */

--- a/packages/oxiquill/src/generator/doc-runtime/wasm-build.mjs
+++ b/packages/oxiquill/src/generator/doc-runtime/wasm-build.mjs
@@ -54,7 +54,8 @@ export async function buildRustWasm({
       '--out-dir',
       pathFromUrl(resolvedPaths.rustWasmPublicDir),
       '--out-name',
-      'doc_rust_cells'
+      'doc_rust_cells',
+      '--locked'
     ],
     { cwd: pathFromUrl(resolvedPaths.workspaceRoot) }
   );

--- a/packages/oxiquill/src/generator/run-helper-cargo.mjs
+++ b/packages/oxiquill/src/generator/run-helper-cargo.mjs
@@ -80,7 +80,7 @@ export async function helperWorkspaceState({ fileSystem = defaultFileSystem, pat
 
 export function cargoArgsForHelperWorkspace(argv, manifestPath) {
   const separatorIndex = argv.indexOf('--');
-  const workspaceArgs = ['--manifest-path', manifestPath, '--workspace'];
+  const workspaceArgs = ['--manifest-path', manifestPath, '--workspace', '--locked'];
   if (separatorIndex === -1) return [...argv, ...workspaceArgs];
 
   return [...argv.slice(0, separatorIndex), ...workspaceArgs, ...argv.slice(separatorIndex)];

--- a/packages/oxiquill/src/generator/runtime-data/runtime-inputs.json
+++ b/packages/oxiquill/src/generator/runtime-data/runtime-inputs.json
@@ -1,0 +1,22 @@
+{
+  "schemaVersion": 1,
+  "rust": {
+    "cargoVersion": "1.95.0",
+    "dependencies": {
+      "console_error_panic_hook": "0.1.7",
+      "serde": "1.0.228",
+      "serde_json": "1.0.150",
+      "wasm-bindgen": "0.2.122",
+      "wasm-bindgen-test": "0.3.72"
+    },
+    "edition": "2024",
+    "rustVersion": "1.95",
+    "rustcVersion": "1.95.0",
+    "target": "wasm32-unknown-unknown",
+    "wasmPackVersion": "0.15.0"
+  },
+  "haskell": {
+    "compiler": "wasm32-wasi-ghc",
+    "supportedVersionPrefix": "9.14."
+  }
+}

--- a/packages/oxiquill/src/generator/watch-doc-runtime.mjs
+++ b/packages/oxiquill/src/generator/watch-doc-runtime.mjs
@@ -1,6 +1,6 @@
 import chokidar from 'chokidar';
 import { pathToFileURL } from 'node:url';
-import { parseConfigOption } from '../cli/config-option.mjs';
+import { parseArgs } from 'node:util';
 import { pathFromUrl } from '../config/paths.mjs';
 import { loadOxiquillProjectConfig } from '../config/project-config.mjs';
 import { createDocRuntimeContext, syncDocRuntime } from './doc-runtime-service.mjs';
@@ -23,16 +23,21 @@ const defaultServices = {
 
 export async function main(argv = process.argv.slice(2), serviceOverrides = {}) {
   const services = { ...defaultServices, ...serviceOverrides };
-  const { commandArgs, configFile } = parseConfigOption(argv);
-  const unexpectedArgs = commandArgs.filter((argument) => argument !== '--skip-initial');
-  if (unexpectedArgs.length > 0) {
-    throw new Error(`Unknown runtime watcher option: ${unexpectedArgs[0]}.`);
-  }
+  const { values } = parseArgs({
+    allowPositionals: false,
+    args: argv,
+    options: {
+      config: { type: 'string' },
+      'skip-initial': { type: 'boolean' }
+    },
+    strict: true
+  });
+  const configFile = values.config;
   const projectConfig = await services.loadProjectConfig({ cwd: process.cwd(), configFile });
   return watchDocRuntime({
     projectConfig,
     serviceOverrides: services,
-    skipInitial: commandArgs.includes('--skip-initial')
+    skipInitial: values['skip-initial'] === true
   });
 }
 

--- a/templates/basic/.gitignore
+++ b/templates/basic/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+.astro/
+.oxiquill/
+dist/
+public/oxiquill/

--- a/templates/basic/README.md
+++ b/templates/basic/README.md
@@ -1,0 +1,22 @@
+# Oxiquill Docs
+
+This project was created with the versioned Oxiquill static starter.
+
+## Develop
+
+Install dependencies and start the development server:
+
+```sh
+pnpm install
+pnpm dev
+```
+
+## Validate and build
+
+```sh
+pnpm check
+pnpm build
+pnpm preview
+```
+
+Remove generated output with `pnpm clean`.

--- a/templates/basic/content/docs/index.mdx
+++ b/templates/basic/content/docs/index.mdx
@@ -5,4 +5,4 @@ description: Start writing with Oxiquill.
 
 # Home
 
-Write docs in MDX and run `pnpm dev`.
+Write prose-first technical documentation in MDX.

--- a/templates/basic/package.json
+++ b/templates/basic/package.json
@@ -3,11 +3,15 @@
   "version": "0.2.0",
   "private": true,
   "type": "module",
+  "packageManager": "pnpm@11.2.2",
+  "engines": {
+    "node": ">=24.0.0"
+  },
   "scripts": {
     "dev": "oxiquill dev",
     "build": "oxiquill build",
     "check": "oxiquill check",
-    "docgen": "oxiquill docgen",
+    "preview": "oxiquill preview",
     "clean": "oxiquill clean"
   },
   "dependencies": {

--- a/templates/basic/public/favicon.svg
+++ b/templates/basic/public/favicon.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="Rust Notes">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="Oxiquill Docs">
   <rect width="64" height="64" rx="12" fill="#111827"/>
   <path d="M18 44V18h16c6 0 10 4 10 9 0 4-2 7-6 8l8 9h-9l-7-8h-5v8h-7Zm7-14h8c3 0 5-1 5-4s-2-4-5-4h-8v8Z" fill="#f9fafb"/>
   <circle cx="48" cy="48" r="7" fill="#0f766e"/>

--- a/tests/package/consumer-smoke.mjs
+++ b/tests/package/consumer-smoke.mjs
@@ -1,9 +1,26 @@
 import assert from 'node:assert/strict';
-import { spawnSync } from 'node:child_process';
+import { spawn, spawnSync } from 'node:child_process';
 import { appendFile, cp, mkdir, mkdtemp, readFile, rename, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { chromium } from '@playwright/test';
+
+const supportedPythonPackages = [
+  'contourpy',
+  'cycler',
+  'fonttools',
+  'kiwisolver',
+  'matplotlib',
+  'numpy',
+  'packaging',
+  'pandas',
+  'pillow',
+  'pyparsing',
+  'python-dateutil',
+  'pytz',
+  'six'
+];
 
 const packageManagerArgument = process.argv.indexOf('--package-manager');
 const packageManager = process.argv[packageManagerArgument + 1];
@@ -93,6 +110,7 @@ try {
   const tarballReference = path.relative(consumerRoot, tarballPath).split(path.sep).join('/');
   packageJson.dependencies.oxiquill = `file:${tarballReference}`;
   packageJson.scripts['wasm:dev'] = 'oxiquill docgen --wasm dev';
+  packageJson.scripts['test:wasm'] = 'oxiquill test-wasm';
   await writeFile(packageJsonPath, `${JSON.stringify(packageJson, null, 2)}\n`);
   await writeFile(path.join(projectRoot, 'package-api.ts'), packageApiSource);
   run(packageManager, ['install'], consumerRoot);
@@ -130,28 +148,54 @@ try {
       '',
       '```python',
       '#| id: package-python',
-      '#| packages: [numpy]',
-      'print("packed consumer")',
+      '#| run: autorun',
+      `#| packages: [${supportedPythonPackages.join(', ')}]`,
+      'import contourpy',
+      'import cycler',
+      'import fontTools',
+      'import kiwisolver',
+      'import matplotlib',
+      'import numpy',
+      'import packaging',
+      'import pandas',
+      'from PIL import Image',
+      'import pyparsing',
+      'import dateutil',
+      'import pytz',
+      'import six',
+      'print("packed python imports: ok")',
       '```',
+      ...(process.platform === 'win32'
+        ? []
+        : [
+            '',
+            '```haskell',
+            '--| id: package-haskell',
+            '--| inputs:',
+            '--|   label: { type: text, label: label, value: packed-consumer }',
+            'putStrLn (label ++ ": Haskell/WASI")',
+            '```'
+          ]),
       ''
     ].join('\n')
   );
 
   run(packageManager, ['run', 'check'], consumerRoot);
   run(packageManager, ['run', 'wasm:dev'], consumerRoot);
+  run(packageManager, ['run', 'test:wasm'], consumerRoot);
   run(packageManager, ['run', 'build'], consumerRoot);
 
   const pyodidePublicDir = path.join(projectRoot, 'static files/oxiquill assets/python runtime');
   const pyodideBuildDir = path.join(projectRoot, 'built site/oxiquill assets/python runtime');
   const lockFile = JSON.parse(await readFile(path.join(pyodidePublicDir, 'pyodide-lock.json'), 'utf8'));
-  const numpyWheel = lockFile.packages.numpy.file_name;
+  const packageWheels = supportedPythonPackages.map((packageName) => lockFile.packages[packageName].file_name);
   const requiredPyodideFiles = [
     'pyodide.mjs',
     'pyodide.asm.mjs',
     'pyodide.asm.wasm',
     'python_stdlib.zip',
     'pyodide-lock.json',
-    numpyWheel
+    ...packageWheels
   ];
 
   for (const fileName of requiredPyodideFiles) {
@@ -174,11 +218,18 @@ try {
     'packed consumer emitted an oversized client chunk'
   );
   await assertFile(path.join(projectRoot, 'static files/oxiquill assets/rust runtime/doc_rust_cells_bg.wasm'));
+  if (process.platform !== 'win32') {
+    await assertFile(path.join(projectRoot, 'static files/oxiquill assets/haskell runtime/doc_haskell_cells.wasm'));
+  }
   for (const fileName of ['doc_rust_cells.d.ts', 'doc_rust_cells_bg.wasm.d.ts', 'package.json']) {
     await assertMissing(path.join(projectRoot, 'static files/oxiquill assets/rust runtime', fileName));
     await assertMissing(path.join(projectRoot, 'built site/oxiquill assets/rust runtime', fileName));
   }
   await assertFile(path.join(projectRoot, 'state cache/generated runtime/cells.json'));
+
+  if (process.env.OXIQUILL_PACKED_BROWSER === 'true') {
+    await runPackedPythonBrowserSmoke({ consumerRoot, packedCliPath, projectRoot });
+  }
 
   run(packageManager, ['run', 'clean'], consumerRoot);
   await assertMissing(path.join(projectRoot, 'state cache'));
@@ -189,6 +240,75 @@ try {
   console.log(`Packed consumer smoke test passed with ${packageManager} in ${consumerRoot}.`);
 } finally {
   await rm(temporaryRoot, { force: true, recursive: true });
+}
+
+async function runPackedPythonBrowserSmoke({ consumerRoot, packedCliPath, projectRoot }) {
+  const port = 4_387;
+  const server = spawn(process.execPath, [packedCliPath, 'preview', '--host', '127.0.0.1', '--port', String(port)], {
+    cwd: consumerRoot,
+    env: process.env,
+    stdio: ['ignore', 'pipe', 'pipe']
+  });
+  const serverOutput = [];
+  server.stdout.on('data', (chunk) => serverOutput.push(String(chunk)));
+  server.stderr.on('data', (chunk) => serverOutput.push(String(chunk)));
+  let browser;
+
+  try {
+    await waitForHttp(`http://127.0.0.1:${port}/`, 60_000, server, serverOutput);
+    const executablePath = process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH?.trim();
+    browser = await chromium.launch({
+      headless: true,
+      ...(executablePath ? { executablePath } : {})
+    });
+    const page = await browser.newPage();
+    await page.goto(`http://127.0.0.1:${port}/`);
+    const manifest = JSON.parse(await readFile(path.join(projectRoot, 'state cache/generated runtime/cells.json')));
+    const pythonCell = manifest.find((cell) => cell.id.endsWith('__package-python'));
+    assert.deepEqual(pythonCell?.packages, supportedPythonPackages);
+    const result = await page.evaluate(
+      async ({ packageNames, source }) => {
+        const indexUrl = new URL('/oxiquill%20assets/python%20runtime/', location.href).href;
+        const response = await fetch(new URL('pyodide.mjs', indexUrl));
+        if (!response.ok) throw new Error(`Unable to load packed Pyodide module: ${response.status}.`);
+        const moduleUrl = URL.createObjectURL(new Blob([await response.text()], { type: 'text/javascript' }));
+        try {
+          const { loadPyodide } = await import(moduleUrl);
+          const pyodide = await loadPyodide({ indexURL: indexUrl });
+          await pyodide.loadPackage(packageNames);
+          return pyodide.runPython(source);
+        } finally {
+          URL.revokeObjectURL(moduleUrl);
+        }
+      },
+      { packageNames: pythonCell.packages, source: pythonCell.source }
+    );
+    assert.equal(result, null);
+  } finally {
+    await browser?.close();
+    if (!server.killed) server.kill('SIGTERM');
+    await Promise.race([
+      new Promise((resolve) => server.once('exit', resolve)),
+      new Promise((resolve) => setTimeout(resolve, 5_000))
+    ]);
+  }
+}
+
+async function waitForHttp(url, timeoutMs, server, output) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (server.exitCode !== null) {
+      throw new Error(`Packed preview exited before startup.\n${output.join('')}`);
+    }
+    try {
+      const response = await fetch(url);
+      if (response.ok) return;
+    } catch {
+      // The preview server is still starting.
+    }
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  }
+  throw new Error(`Timed out waiting for packed preview at ${url}.\n${output.join('')}`);
 }
 
 function run(command, args, cwd, capture = false, environment = process.env) {

--- a/tests/package/consumer-smoke.mjs
+++ b/tests/package/consumer-smoke.mjs
@@ -58,7 +58,52 @@ try {
   const [packed] = JSON.parse(packResult.stdout);
   const tarballPath = path.join(temporaryRoot, packed.filename);
 
-  await cp(path.join(repositoryRoot, 'templates/basic'), consumerRoot, { recursive: true });
+  initializePackedConsumer(packageManager, tarballPath, consumerRoot, temporaryRoot);
+  const packageJsonPath = path.join(consumerRoot, 'package.json');
+  const packageJson = JSON.parse(await readFile(packageJsonPath, 'utf8'));
+  const tarballReference = path.relative(consumerRoot, tarballPath).split(path.sep).join('/');
+  packageJson.dependencies.oxiquill = `file:${tarballReference}`;
+  packageJson.scripts['wasm:dev'] = 'oxiquill docgen --wasm dev';
+  packageJson.scripts['test:wasm'] = 'oxiquill test-wasm';
+  await writeFile(packageJsonPath, `${JSON.stringify(packageJson, null, 2)}\n`);
+
+  run(packageManager, ['install'], consumerRoot);
+  const packedCliPath = path.join(consumerRoot, 'node_modules/oxiquill/dist/cli/index.mjs');
+  const versionResult = run(process.execPath, [packedCliPath, '--version'], consumerRoot, true);
+  assert.equal(versionResult.stdout.trim(), packed.version);
+  for (const command of [
+    'init',
+    'dev',
+    'dev:runtime',
+    'dev:astro',
+    'preview',
+    'build',
+    'check',
+    'docgen',
+    'clean',
+    'test-rust',
+    'test-rust-coverage',
+    'lint-rust',
+    'doc-rust',
+    'test-wasm'
+  ]) {
+    const helpResult = run(process.execPath, [packedCliPath, command, '--help'], consumerRoot, true);
+    assert.match(helpResult.stdout, new RegExp(`Usage: oxiquill ${command.replace(/[.*+?^${}()|[\]\\]/gu, '\\$&')}`));
+  }
+  run(
+    'node',
+    ['--input-type=module', '--eval', "await import('oxiquill'); await import('oxiquill/astro');"],
+    consumerRoot
+  );
+
+  const nodeOnlyEnvironment = createNodeOnlyEnvironment();
+  run(process.execPath, [packedCliPath, 'check'], consumerRoot, false, nodeOnlyEnvironment);
+  run(process.execPath, [packedCliPath, 'build'], consumerRoot, false, nodeOnlyEnvironment);
+  run(packageManager, ['run', 'preview', '--', '--background', '--host', '127.0.0.1', '--port', '4321'], consumerRoot);
+  await assertFile(path.join(consumerRoot, '.astro/preview.json'));
+  stopAstroPreview(packageManager, consumerRoot);
+  run(packageManager, ['run', 'clean'], consumerRoot);
+
   const projectRoot = path.join(consumerRoot, 'site root');
   await mkdir(projectRoot);
   await rename(path.join(consumerRoot, 'content'), path.join(projectRoot, 'content'));
@@ -105,27 +150,12 @@ try {
       ''
     ].join('\n')
   );
-  const packageJsonPath = path.join(consumerRoot, 'package.json');
-  const packageJson = JSON.parse(await readFile(packageJsonPath, 'utf8'));
-  const tarballReference = path.relative(consumerRoot, tarballPath).split(path.sep).join('/');
-  packageJson.dependencies.oxiquill = `file:${tarballReference}`;
-  packageJson.scripts['wasm:dev'] = 'oxiquill docgen --wasm dev';
-  packageJson.scripts['test:wasm'] = 'oxiquill test-wasm';
-  await writeFile(packageJsonPath, `${JSON.stringify(packageJson, null, 2)}\n`);
   await writeFile(path.join(projectRoot, 'package-api.ts'), packageApiSource);
-  run(packageManager, ['install'], consumerRoot);
   run(
     packageManager,
     packageManager === 'npm' ? ['exec', '--', 'oxiquill', 'help'] : ['exec', 'oxiquill', 'help'],
     consumerRoot
   );
-  run(
-    'node',
-    ['--input-type=module', '--eval', "await import('oxiquill'); await import('oxiquill/astro');"],
-    consumerRoot
-  );
-  const packedCliPath = path.join(consumerRoot, 'node_modules/oxiquill/dist/cli/index.mjs');
-  const nodeOnlyEnvironment = createNodeOnlyEnvironment();
   run(process.execPath, [packedCliPath, 'check'], consumerRoot, false, nodeOnlyEnvironment);
   run(process.execPath, [packedCliPath, 'build'], consumerRoot, false, nodeOnlyEnvironment);
 
@@ -309,6 +339,20 @@ async function waitForHttp(url, timeoutMs, server, output) {
     await new Promise((resolve) => setTimeout(resolve, 250));
   }
   throw new Error(`Timed out waiting for packed preview at ${url}.\n${output.join('')}`);
+}
+
+function initializePackedConsumer(packageManager, tarballPath, target, cwd) {
+  const args =
+    packageManager === 'npm'
+      ? ['exec', '--yes', `--package=${tarballPath}`, '--', 'oxiquill', 'init', target]
+      : ['dlx', tarballPath, 'init', target];
+  run(packageManager, args, cwd);
+}
+
+function stopAstroPreview(packageManager, cwd) {
+  const args =
+    packageManager === 'npm' ? ['exec', '--', 'astro', 'preview', 'stop'] : ['exec', 'astro', 'preview', 'stop'];
+  run(packageManager, args, cwd);
 }
 
 function run(command, args, cwd, capture = false, environment = process.env) {

--- a/tests/package/package-contents.mjs
+++ b/tests/package/package-contents.mjs
@@ -94,6 +94,10 @@ async function expectedPackageFiles() {
   const licenseDataFiles = (await listFiles(licenseDataRoot)).map(
     (filePath) => `dist/generator/license-data/${normalizePath(path.relative(licenseDataRoot, filePath))}`
   );
+  const runtimeDataRoot = path.join(sourceRoot, 'generator/runtime-data');
+  const runtimeDataFiles = (await listFiles(runtimeDataRoot)).map(
+    (filePath) => `dist/generator/runtime-data/${normalizePath(path.relative(runtimeDataRoot, filePath))}`
+  );
   const copiedFiles = [
     'dist/components/starlight/PageFrame.astro',
     'dist/env.d.ts',
@@ -109,7 +113,8 @@ async function expectedPackageFiles() {
     'package.json',
     ...compiledFiles,
     ...copiedFiles,
-    ...licenseDataFiles
+    ...licenseDataFiles,
+    ...runtimeDataFiles
   ].sort();
 }
 

--- a/tests/package/package-contents.mjs
+++ b/tests/package/package-contents.mjs
@@ -29,7 +29,11 @@ try {
   assert.ok(actualFiles.every((filePath) => !filePath.startsWith('src/')));
   assert.ok(
     actualFiles.every(
-      (filePath) => !filePath.endsWith('.ts') || filePath.endsWith('.d.ts') || filePath.endsWith('.d.mts')
+      (filePath) =>
+        !filePath.endsWith('.ts') ||
+        filePath.startsWith('dist/cli/starter/') ||
+        filePath.endsWith('.d.ts') ||
+        filePath.endsWith('.d.mts')
     )
   );
   assert.ok(actualFiles.every((filePath) => !filePath.endsWith('.tsx')));
@@ -98,6 +102,11 @@ async function expectedPackageFiles() {
   const runtimeDataFiles = (await listFiles(runtimeDataRoot)).map(
     (filePath) => `dist/generator/runtime-data/${normalizePath(path.relative(runtimeDataRoot, filePath))}`
   );
+  const starterRoot = path.join(repositoryRoot, 'templates/basic');
+  const starterFiles = (await listFiles(starterRoot)).map(
+    (filePath) =>
+      `dist/cli/starter/v1/${normalizePath(path.relative(starterRoot, filePath)) === '.gitignore' ? 'gitignore' : normalizePath(path.relative(starterRoot, filePath))}`
+  );
   const copiedFiles = [
     'dist/components/starlight/PageFrame.astro',
     'dist/env.d.ts',
@@ -114,7 +123,8 @@ async function expectedPackageFiles() {
     ...compiledFiles,
     ...copiedFiles,
     ...licenseDataFiles,
-    ...runtimeDataFiles
+    ...runtimeDataFiles,
+    ...starterFiles
   ].sort();
 }
 

--- a/tests/runtime/haskell-smoke.mjs
+++ b/tests/runtime/haskell-smoke.mjs
@@ -1,29 +1,8 @@
-import assert from 'node:assert/strict';
-import { readFile } from 'node:fs/promises';
 import { fileURLToPath } from 'node:url';
-import { ConsoleStdout, File, OpenFile, WASI } from '@bjorn3/browser_wasi_shim';
+import { createOxiquillPaths } from '../../packages/oxiquill/dist/config/paths.mjs';
+import { testGeneratedHaskellCells } from '../../packages/oxiquill/dist/generator/doc-runtime/haskell-runtime-test.mjs';
 
-const runtimeRoot = new URL('../../examples/docs-site/public/oxiquill/haskell-wasm/', import.meta.url);
-const status = JSON.parse(await readFile(new URL('status.json', runtimeRoot), 'utf8'));
-assert.equal(status.status, 'ready', status.message || 'Haskell runtime is not ready.');
+const workspaceRoot = fileURLToPath(new URL('../../examples/docs-site/', import.meta.url));
+const result = await testGeneratedHaskellCells({ paths: createOxiquillPaths({ workspaceRoot }) });
 
-const chunks = [];
-const stdout = new ConsoleStdout((buffer) => chunks.push(new TextDecoder().decode(buffer)));
-const stderr = new ConsoleStdout((buffer) => chunks.push(new TextDecoder().decode(buffer)));
-const wasi = new WASI(
-  ['doc_haskell_cells', 'features__interactive-cells__haskell-controls', '3', 'sample', 'true'],
-  [],
-  [new OpenFile(new File([])), stdout, stderr]
-);
-const wasmPath = fileURLToPath(new URL('doc_haskell_cells.wasm', runtimeRoot));
-const module = await WebAssembly.compile(await readFile(wasmPath));
-const instance = await WebAssembly.instantiate(module, {
-  wasi_snapshot_preview1: wasi.wasiImport
-});
-const exitCode = wasi.start(instance);
-const output = chunks.join('').trimEnd();
-
-assert.equal(exitCode, 0, output);
-assert.match(output, /sample: 9, 36, 81, 144/u);
-assert.match(output, /total = 270/u);
-console.log('Generated Haskell/WASI runtime smoke test passed.');
+console.log(`Generated Haskell/WASI all-cell test passed (${result.cellCount} cells).`);

--- a/tests/unit/astro-config.test.mjs
+++ b/tests/unit/astro-config.test.mjs
@@ -109,11 +109,18 @@ describe('defineOxiquillConfig', () => {
   });
 
   it('retains frozen internal metadata without adding enumerable config fields', () => {
-    const config = defineOxiquillConfig({ sidebar: [], title: 'Docs' });
+    const config = defineOxiquillConfig({
+      python: { offline: true, packageMirror: 'https://packages.example/pyodide' },
+      sidebar: [],
+      title: 'Docs'
+    });
     const integration = config.integrations.flat().find((entry) => entry.name === 'oxiquill');
 
     expect(readOxiquillMetadata(config)).toMatchObject({ kind: 'config' });
-    expect(readOxiquillMetadata(integration)).toMatchObject({ kind: 'integration' });
+    expect(readOxiquillMetadata(integration)).toMatchObject({
+      kind: 'integration',
+      python: { offline: true, packageMirror: 'https://packages.example/pyodide/' }
+    });
     expect(Object.isFrozen(readOxiquillMetadata(config))).toBe(true);
     expect(Object.keys(config)).not.toContain('oxiquill');
   });

--- a/tests/unit/cli.test.mjs
+++ b/tests/unit/cli.test.mjs
@@ -57,7 +57,7 @@ const actualProjectConfig = Object.freeze({
 const repoRoot = path.resolve('/repo');
 const { canLoadNativePackage, frameworkEnv, isCliEntrypoint, nodeExecutableCandidates, runCli, selectFrameworkNode } =
   await import('../../packages/oxiquill/src/cli/commands.mjs');
-const { formatCliError, formatCliHelp, parseCliArguments } =
+const { debugRequested, formatCliError, formatCliHelp, parseCliArguments } =
   await import('../../packages/oxiquill/src/cli/arguments.mjs');
 const testRoot = path.parse(process.cwd()).root;
 
@@ -103,6 +103,21 @@ describe('oxiquill CLI', () => {
     );
     expect(() => parseCliArguments(['preview', '--config=a', '--config', 'b'])).toThrow(
       '--config may only be specified once'
+    );
+  });
+
+  it('forwards explicit optional Astro option values and rejects empty assignments', () => {
+    expect(parseCliArguments(['preview', '--host=127.0.0.1', '--open=/docs'])).toEqual(
+      expect.objectContaining({
+        commandArgs: ['--host=127.0.0.1', '--open=/docs'],
+        values: expect.objectContaining({ host: '127.0.0.1', open: '/docs' })
+      })
+    );
+    expect(() => parseCliArguments(['preview', '--host='])).toThrow(
+      expect.objectContaining({
+        message: '--host requires a non-empty value after =.',
+        usage: expect.stringContaining('Usage: oxiquill preview')
+      })
     );
   });
 
@@ -161,6 +176,21 @@ describe('oxiquill CLI', () => {
     });
   });
 
+  it('rejects unknown and extra help topics with useful usage', () => {
+    expect(() => parseCliArguments(['help', 'unknown'])).toThrow(
+      expect.objectContaining({
+        message: 'Unknown oxiquill command "unknown".',
+        usage: expect.stringContaining('Usage: oxiquill <command>')
+      })
+    );
+    expect(() => parseCliArguments(['help', 'build', 'preview'])).toThrow(
+      expect.objectContaining({
+        message: 'The help command accepts at most one command name.',
+        usage: expect.stringContaining('Usage: oxiquill help')
+      })
+    );
+  });
+
   it('prints the installed package version without loading project configuration', async () => {
     const log = vi.fn();
 
@@ -195,6 +225,21 @@ describe('oxiquill CLI', () => {
     expect(debug.stderr).toContain('CliUsageError: build received unexpected positional arguments');
     expect(debug.stderr).toContain('at parseCliArguments');
     expect(formatCliError(new Error('plain failure'))).toBe('Error: plain failure');
+  });
+
+  it('keeps forwarded debug flags scoped to Astro and renders nested causes only on request', () => {
+    const failure = new Error('project initialization failed', {
+      cause: new Error('starter read failed', { cause: 'permission denied' })
+    });
+    const detailedFailure = formatCliError(failure, { debug: true });
+
+    expect(debugRequested(['preview', '--', '--debug'])).toBe(false);
+    expect(debugRequested(['--debug', 'preview', '--', '--host', 'localhost'])).toBe(true);
+    expect(formatCliError(failure)).toBe('Error: project initialization failed');
+    expect(detailedFailure).toContain('Caused by: Error: starter read failed');
+    expect(detailedFailure).toContain('Caused by: permission denied');
+    expect(formatCliError('non-error failure')).toBe('Error: non-error failure');
+    expect(formatCliError('non-error failure', { debug: true })).toBe('non-error failure');
   });
 
   it('loads a selected config once and forwards the resolved Astro arguments', async () => {

--- a/tests/unit/cli.test.mjs
+++ b/tests/unit/cli.test.mjs
@@ -16,7 +16,8 @@ const cliMocks = vi.hoisted(() => ({
   markRuntimeReady: vi.fn(),
   runHelperCargo: vi.fn(),
   syncDocRuntime: vi.fn(),
-  syncLicenseArtifacts: vi.fn()
+  syncLicenseArtifacts: vi.fn(),
+  testGeneratedHaskellCells: vi.fn()
 }));
 
 vi.mock('../../packages/oxiquill/src/generator/doc-runtime-service.mjs', () => ({
@@ -32,6 +33,9 @@ vi.mock('../../packages/oxiquill/src/generator/clean.mjs', () => ({
 }));
 vi.mock('../../packages/oxiquill/src/generator/run-helper-cargo.mjs', () => ({
   runHelperCargo: cliMocks.runHelperCargo
+}));
+vi.mock('../../packages/oxiquill/src/generator/doc-runtime/haskell-runtime-test.mjs', () => ({
+  testGeneratedHaskellCells: cliMocks.testGeneratedHaskellCells
 }));
 vi.mock('../../packages/oxiquill/src/config/project-config.mjs', () => ({
   loadOxiquillProjectConfig: cliMocks.loadProjectConfig
@@ -63,6 +67,7 @@ beforeEach(() => {
     rustCellCount: 1
   });
   cliMocks.buildHaskellWasm.mockResolvedValue({ ok: true });
+  cliMocks.testGeneratedHaskellCells.mockResolvedValue({ cellCount: 1 });
 });
 
 afterEach(() => {
@@ -303,22 +308,28 @@ describe('oxiquill CLI', () => {
 
     expect(runCommand).toHaveBeenCalledWith(
       'wasm-pack',
-      ['test', '--node', path.join(repoRoot, '.oxiquill', 'rust-cells')],
+      ['test', '--node', path.join(repoRoot, '.oxiquill', 'rust-cells'), '--locked'],
       { cwd: repoRoot }
     );
     expect(cliMocks.syncDocRuntime).toHaveBeenCalledWith(expect.objectContaining({ mode: 'dev' }));
+    expect(cliMocks.testGeneratedHaskellCells).toHaveBeenCalledWith({
+      expectedFingerprint: 'haskell-fingerprint',
+      paths: expect.objectContaining({ workspaceRoot: repoRoot })
+    });
     expect(log).toHaveBeenCalled();
   });
 
   it('skips wasm-pack tests when the manifest contains no Rust cells', async () => {
-    cliMocks.syncDocRuntime.mockResolvedValue({ cellCount: 0, rustCellCount: 0 });
+    cliMocks.syncDocRuntime.mockResolvedValue({ cellCount: 0, haskellCellCount: 0, rustCellCount: 0 });
     const log = vi.spyOn(console, 'log').mockImplementation(() => {});
     const runCommand = vi.fn(async () => undefined);
 
     await runCli('test-wasm', [], { cwd: repoRoot, runCommand });
 
     expect(runCommand).not.toHaveBeenCalledWith('wasm-pack', expect.anything(), expect.anything());
+    expect(cliMocks.testGeneratedHaskellCells).not.toHaveBeenCalled();
     expect(log).toHaveBeenCalledWith('[runtime] no Rust cells; skipping wasm-pack test');
+    expect(log).toHaveBeenCalledWith('[runtime] no Haskell cells; skipping Haskell/WASI test');
   });
 
   it('reports missing CLI entrypoints and unusable Node overrides', () => {

--- a/tests/unit/cli.test.mjs
+++ b/tests/unit/cli.test.mjs
@@ -1,5 +1,6 @@
 // @vitest-environment node
 
+import { spawnSync } from 'node:child_process';
 import { mkdtemp, rm, symlink } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
@@ -17,7 +18,8 @@ const cliMocks = vi.hoisted(() => ({
   runHelperCargo: vi.fn(),
   syncDocRuntime: vi.fn(),
   syncLicenseArtifacts: vi.fn(),
-  testGeneratedHaskellCells: vi.fn()
+  testGeneratedHaskellCells: vi.fn(),
+  watchDocRuntime: vi.fn()
 }));
 
 vi.mock('../../packages/oxiquill/src/generator/doc-runtime-service.mjs', () => ({
@@ -40,6 +42,9 @@ vi.mock('../../packages/oxiquill/src/generator/doc-runtime/haskell-runtime-test.
 vi.mock('../../packages/oxiquill/src/config/project-config.mjs', () => ({
   loadOxiquillProjectConfig: cliMocks.loadProjectConfig
 }));
+vi.mock('../../packages/oxiquill/src/generator/watch-doc-runtime.mjs', () => ({
+  watchDocRuntime: cliMocks.watchDocRuntime
+}));
 
 const cliPath = fileURLToPath(new URL('../../packages/oxiquill/src/cli/index.mjs', import.meta.url));
 const actualRepoRoot = fileURLToPath(new URL('../..', import.meta.url));
@@ -52,7 +57,8 @@ const actualProjectConfig = Object.freeze({
 const repoRoot = path.resolve('/repo');
 const { canLoadNativePackage, frameworkEnv, isCliEntrypoint, nodeExecutableCandidates, runCli, selectFrameworkNode } =
   await import('../../packages/oxiquill/src/cli/commands.mjs');
-const { parseConfigOption } = await import('../../packages/oxiquill/src/cli/config-option.mjs');
+const { formatCliError, formatCliHelp, parseCliArguments } =
+  await import('../../packages/oxiquill/src/cli/arguments.mjs');
 const testRoot = path.parse(process.cwd()).root;
 
 beforeEach(() => {
@@ -68,6 +74,7 @@ beforeEach(() => {
   });
   cliMocks.buildHaskellWasm.mockResolvedValue({ ok: true });
   cliMocks.testGeneratedHaskellCells.mockResolvedValue({ cellCount: 1 });
+  cliMocks.watchDocRuntime.mockResolvedValue({ close: vi.fn(async () => undefined) });
 });
 
 afterEach(() => {
@@ -75,17 +82,119 @@ afterEach(() => {
 });
 
 describe('oxiquill CLI', () => {
-  it('parses one config option without forwarding it to command-specific arguments', () => {
-    expect(parseConfigOption(['--host', 'localhost', '--config', 'custom config.mts'])).toEqual({
+  it('parses global and command options without forwarding Oxiquill options', () => {
+    expect(parseCliArguments(['--debug', 'preview', '--host', 'localhost', '--config', 'custom config.mts'])).toEqual({
+      action: 'run',
       commandArgs: ['--host', 'localhost'],
-      configFile: 'custom config.mts'
+      commandName: 'preview',
+      configFile: 'custom config.mts',
+      positionals: [],
+      values: {
+        config: 'custom config.mts',
+        debug: true,
+        host: 'localhost'
+      }
     });
-    expect(parseConfigOption(['--config=custom.mjs'])).toEqual({
-      commandArgs: [],
-      configFile: 'custom.mjs'
+    expect(parseCliArguments(['preview', '--host', '--open'])).toEqual(
+      expect.objectContaining({
+        commandArgs: ['--host', '--open'],
+        values: expect.objectContaining({ 'host-default': true, 'open-default': true })
+      })
+    );
+    expect(() => parseCliArguments(['preview', '--config=a', '--config', 'b'])).toThrow(
+      '--config may only be specified once'
+    );
+  });
+
+  it('validates and forwards command options after the argument separator', () => {
+    expect(parseCliArguments(['dev', '--', '--host', '0.0.0.0', '--port', '4321'])).toEqual(
+      expect.objectContaining({
+        commandArgs: ['--host', '0.0.0.0', '--port', '4321'],
+        values: expect.objectContaining({ host: '0.0.0.0', port: '4321' })
+      })
+    );
+    expect(() => parseCliArguments(['dev', '--', '--debug'])).toThrow('Unknown option');
+    expect(() => parseCliArguments(['build', '--', 'extra'])).toThrow('does not accept positional Astro arguments');
+    expect(() => parseCliArguments(['clean', '--', '--force'])).toThrow(
+      'separator is only supported by Astro forwarding commands'
+    );
+  });
+
+  it('rejects unknown, missing, invalid, and extra command arguments with command usage', () => {
+    for (const args of [
+      ['preview', '--unknown'],
+      ['preview', '--port'],
+      ['check', '--minimumSeverity', 'notice'],
+      ['docgen', '--wasm', 'release'],
+      ['build', 'extra']
+    ]) {
+      expect(() => parseCliArguments(args)).toThrow(
+        expect.objectContaining({ usage: expect.stringContaining('Usage:') })
+      );
+    }
+  });
+
+  it('renders complete global and command-specific help', () => {
+    const commands = [
+      'init',
+      'dev',
+      'dev:runtime',
+      'dev:astro',
+      'preview',
+      'build',
+      'check',
+      'docgen',
+      'clean',
+      'test-rust',
+      'test-rust-coverage',
+      'lint-rust',
+      'doc-rust',
+      'test-wasm'
+    ];
+    const globalHelp = formatCliHelp();
+
+    commands.forEach((command) => {
+      expect(globalHelp).toContain(command);
+      expect(formatCliHelp(command)).toContain(`Usage: oxiquill ${command}`);
+      expect(parseCliArguments(['help', command])).toEqual({ action: 'help', commandName: command });
+      expect(parseCliArguments([command, '--help'])).toEqual({ action: 'help', commandName: command });
     });
-    expect(() => parseConfigOption(['--config'])).toThrow('--config must be followed by a path');
-    expect(() => parseConfigOption(['--config=a', '--config', 'b'])).toThrow('--config may only be specified once');
+  });
+
+  it('prints the installed package version without loading project configuration', async () => {
+    const log = vi.fn();
+
+    await runCli(['--version'], { loadPackageVersion: async () => '9.8.7', log });
+
+    expect(log).toHaveBeenCalledWith('9.8.7');
+    expect(cliMocks.loadProjectConfig).not.toHaveBeenCalled();
+  });
+
+  it('initializes a target without loading project configuration', async () => {
+    const initialize = vi.fn(async () => undefined);
+    const log = vi.fn();
+
+    await runCli(['init', 'My Docs'], { cwd: '/invocation', initialize, log });
+
+    expect(initialize).toHaveBeenCalledWith({ cwd: '/invocation', directory: 'My Docs', log });
+    expect(cliMocks.loadProjectConfig).not.toHaveBeenCalled();
+    expect(() => parseCliArguments(['init', 'first', 'second'])).toThrow(
+      'init received unexpected positional arguments: "second"'
+    );
+    expect(() => parseCliArguments(['init', '--config', 'astro.config.mjs'])).toThrow('Unknown option');
+  });
+
+  it('shows concise expected errors unless debug output is requested', () => {
+    const concise = spawnSync(process.execPath, [cliPath, 'build', 'extra'], { encoding: 'utf8' });
+    const debug = spawnSync(process.execPath, [cliPath, '--debug', 'build', 'extra'], { encoding: 'utf8' });
+
+    expect(concise.status).toBe(1);
+    expect(concise.stderr).toContain('Error: build received unexpected positional arguments');
+    expect(concise.stderr).not.toContain('at parseCliArguments');
+    expect(debug.status).toBe(1);
+    expect(debug.stderr).toContain('CliUsageError: build received unexpected positional arguments');
+    expect(debug.stderr).toContain('at parseCliArguments');
+    expect(formatCliError(new Error('plain failure'))).toBe('Error: plain failure');
   });
 
   it('loads a selected config once and forwards the resolved Astro arguments', async () => {
@@ -118,6 +227,25 @@ describe('oxiquill CLI', () => {
       ]),
       expect.objectContaining({ cwd: actualRepoRoot })
     );
+  });
+
+  it('forwards documented development server arguments unchanged', async () => {
+    const runCommand = vi.fn(async () => undefined);
+    const nodePath = fakeNodeExecutable(path.join(testRoot, 'node', 'bin'));
+
+    await runCli('dev', ['--host', '0.0.0.0', '--port', '4321'], {
+      cwd: actualRepoRoot,
+      loadProjectConfig: async () => actualProjectConfig,
+      runCommand,
+      selectNode: () => nodePath
+    });
+
+    expect(runCommand).toHaveBeenCalledWith(
+      nodePath,
+      expect.arrayContaining(['dev', '--host', '0.0.0.0', '--port', '4321']),
+      expect.objectContaining({ cwd: actualRepoRoot, successfulSignals: ['SIGTERM'] })
+    );
+    expect(cliMocks.watchDocRuntime).toHaveBeenCalledWith({ projectConfig: actualProjectConfig, skipInitial: true });
   });
 
   it('can be imported without running the command dispatcher', async () => {
@@ -295,7 +423,7 @@ describe('oxiquill CLI', () => {
 
   it('rejects invalid Wasm generation modes before creating a runtime', async () => {
     await expect(runCli('docgen', ['--wasm', 'release'], { cwd: repoRoot })).rejects.toThrow(
-      '--wasm must be followed by "dev" or "build".'
+      '--wasm must be one of: dev, build.'
     );
     expect(cliMocks.createDocRuntimeContext).not.toHaveBeenCalled();
   });

--- a/tests/unit/doc-runtime-core.test.mjs
+++ b/tests/unit/doc-runtime-core.test.mjs
@@ -46,6 +46,20 @@ const helperCrates = new Map([
   ['doc-rust', { name: 'doc-rust', relativePath: '../../crates/doc-rust' }],
   ['doc-rust-text', { name: 'doc-rust-text', relativePath: '../../crates/doc-rust-text' }]
 ]);
+const runtimeInputs = {
+  package: { repository: 'https://example.com/oxiquill', version: '1.2.3' },
+  rust: {
+    dependencies: {
+      console_error_panic_hook: '0.1.7',
+      serde: '1.0.228',
+      serde_json: '1.0.150',
+      'wasm-bindgen': '0.2.122',
+      'wasm-bindgen-test': '0.3.72'
+    },
+    edition: '2024',
+    rustVersion: '1.95'
+  }
+};
 
 describe('doc runtime core', () => {
   it('creates stable page-scoped authoring ids', () => {
@@ -416,9 +430,14 @@ describe('doc runtime core', () => {
     expect(generateCellsModule(cells)).toContain('export const cells');
     expect(generateCellsJson(cells)).toContain('"id": "one"');
 
-    expect(generateRustCargoToml([], helperCrates)).not.toContain('doc-rust =');
-    expect(generateRustCargoToml([], helperCrates)).toContain('license = "MIT OR Apache-2.0"');
-    expect(generateRustCargoToml([{ crates: ['doc-rust'] }], helperCrates)).toContain(
+    expect(generateRustCargoToml([], helperCrates, runtimeInputs)).not.toContain('doc-rust =');
+    expect(generateRustCargoToml([], helperCrates, runtimeInputs)).toContain('license = "MIT OR Apache-2.0"');
+    expect(generateRustCargoToml([], helperCrates, runtimeInputs)).toContain('version = "1.2.3"');
+    expect(generateRustCargoToml([], helperCrates, runtimeInputs)).toContain(
+      'repository = "https://example.com/oxiquill"'
+    );
+    expect(generateRustCargoToml([], helperCrates, runtimeInputs)).toContain('serde_json = "=1.0.150"');
+    expect(generateRustCargoToml([{ crates: ['doc-rust'] }], helperCrates, runtimeInputs)).toContain(
       'doc-rust = { path = "../../crates/doc-rust" }'
     );
     expect(generateRustDependency('doc-rust', helperCrates)).toContain('doc-rust');

--- a/tests/unit/doc-runtime-core.test.mjs
+++ b/tests/unit/doc-runtime-core.test.mjs
@@ -559,7 +559,7 @@ describe('doc runtime core', () => {
     expect(generateRustLib([chartCell])).toContain('fn bar_chart_spec');
     expect(generateRustLib([chartCell])).toContain('fn histogram_chart_spec');
     expect(generateRustLib([chartCell])).toContain('fn heatmap_chart_spec');
-    expect(generateRustLib([rustCell])).toContain('first_generated_cell_runs');
+    expect(generateRustLib([rustCell])).toContain('generated_plot_cell_runs');
 
     const haskellCell = {
       id: 'haskell-cell',

--- a/tests/unit/doc-runtime-service.test.mjs
+++ b/tests/unit/doc-runtime-service.test.mjs
@@ -174,6 +174,34 @@ function createMemoryFileSystem(initialFiles = {}) {
 const highlighter = {
   codeToHtml: (source, options) => Promise.resolve(`<pre data-lang="${options.lang}">${source}</pre>`)
 };
+const runtimeInputs = Object.freeze({
+  haskell: Object.freeze({ compiler: 'wasm32-wasi-ghc', supportedVersionPrefix: '9.14.' }),
+  package: Object.freeze({ repository: 'https://example.com/oxiquill', version: '0.2.0' }),
+  rust: Object.freeze({
+    cargoVersion: '1.95.0',
+    dependencies: Object.freeze({
+      console_error_panic_hook: '0.1.7',
+      serde: '1.0.228',
+      serde_json: '1.0.150',
+      'wasm-bindgen': '0.2.122',
+      'wasm-bindgen-test': '0.3.72'
+    }),
+    edition: '2024',
+    rustVersion: '1.95',
+    rustcVersion: '1.95.0',
+    target: 'wasm32-unknown-unknown',
+    wasmPackVersion: '0.15.0'
+  }),
+  rustLock: 'fixture lock',
+  rustLockSha256: hashText('fixture lock')
+});
+const runtimeSyncOptions = Object.freeze({
+  preflightToolchains: async () => ({}),
+  resolvePyodideInputs: async ({ requestedPackages }) => ({
+    fingerprint: stableFingerprint({ requestedPackages })
+  }),
+  runtimeInputs
+});
 
 function pyodidePackage(name, fileName, content, depends = []) {
   return {
@@ -260,6 +288,7 @@ describe('doc runtime service', () => {
     const context = await createDocRuntimeContext({
       fileSystem,
       highlighter,
+      readRuntimeInputs: async () => runtimeInputs,
       root: '/repo'
     });
 
@@ -267,6 +296,8 @@ describe('doc runtime service', () => {
     await expect(
       createDocRuntimeContext({
         fileSystem,
+        highlighter,
+        readRuntimeInputs: async () => runtimeInputs,
         root: '/repo'
       })
     ).resolves.toMatchObject({
@@ -440,6 +471,7 @@ describe('doc runtime service', () => {
 
     await expect(
       syncDocRuntime({
+        ...runtimeSyncOptions,
         fileSystem: localDuplicate,
         helperCrates: new Map(),
         highlighter: countingHighlighter,
@@ -455,6 +487,7 @@ describe('doc runtime service', () => {
     });
     await expect(
       syncDocRuntime({
+        ...runtimeSyncOptions,
         fileSystem: scopedDuplicate,
         helperCrates: new Map(),
         highlighter: countingHighlighter,
@@ -613,6 +646,7 @@ describe('doc runtime service', () => {
         fileSystem,
         lockFile,
         paths,
+        pyodideVersion: '314.0.6',
         roots: ['root']
       })
     ).resolves.toBe(true);
@@ -622,6 +656,7 @@ describe('doc runtime service', () => {
         fileSystem,
         lockFile,
         paths,
+        pyodideVersion: '314.0.6',
         roots: ['root']
       })
     ).resolves.toBe(false);
@@ -636,6 +671,7 @@ describe('doc runtime service', () => {
         fileSystem: createMemoryFileSystem(),
         lockFile,
         paths,
+        pyodideVersion: '314.0.6',
         roots: ['root']
       })
     ).rejects.toThrow('has sha256');
@@ -656,6 +692,7 @@ describe('doc runtime service', () => {
         fileSystem: readFailure,
         lockFile,
         paths,
+        pyodideVersion: '314.0.6',
         roots: ['root']
       })
     ).rejects.toThrow('permission denied');
@@ -744,6 +781,7 @@ describe('doc runtime service', () => {
     };
 
     const first = await syncDocRuntime({
+      ...runtimeSyncOptions,
       fileSystem,
       helperCrates,
       highlighter,
@@ -796,6 +834,7 @@ describe('doc runtime service', () => {
     fileSystem.writes.length = 0;
     await expect(
       syncDocRuntime({
+        ...runtimeSyncOptions,
         fileSystem,
         helperCrates,
         highlighter,
@@ -822,6 +861,7 @@ describe('doc runtime service', () => {
     const syncPyodide = vi.fn();
 
     const result = await syncDocRuntime({
+      ...runtimeSyncOptions,
       buildHaskell,
       buildRust,
       fileSystem,
@@ -856,6 +896,7 @@ describe('doc runtime service', () => {
       await runtimeFileSystem.writeFile(path.join(runtimePaths.pyodidePublicDir, 'pyodide.mjs'), 'python');
     });
     const options = {
+      ...runtimeSyncOptions,
       buildHaskell,
       buildRust,
       fileSystem,
@@ -902,6 +943,7 @@ describe('doc runtime service', () => {
       ]);
     });
     const options = {
+      ...runtimeSyncOptions,
       buildHaskell: vi.fn(),
       buildRust,
       fileSystem,
@@ -942,6 +984,7 @@ describe('doc runtime service', () => {
     });
 
     const result = await syncDocRuntime({
+      ...runtimeSyncOptions,
       buildHaskell,
       buildRust: vi.fn(),
       fileSystem,
@@ -1008,7 +1051,8 @@ describe('doc runtime service', () => {
           '--out-dir',
           repoPath('public/oxiquill/rust-wasm'),
           '--out-name',
-          'doc_rust_cells'
+          'doc_rust_cells',
+          '--locked'
         ],
         { cwd: repoRoot }
       ],

--- a/tests/unit/haskell-runtime-test.test.mjs
+++ b/tests/unit/haskell-runtime-test.test.mjs
@@ -1,0 +1,160 @@
+// @vitest-environment node
+
+import path from 'node:path';
+import { describe, expect, it, vi } from 'vitest';
+import { hashText } from '../../packages/oxiquill/src/generator/doc-runtime/hashing.mjs';
+import {
+  executeGeneratedHaskellCell,
+  testGeneratedHaskellCells
+} from '../../packages/oxiquill/src/generator/doc-runtime/haskell-runtime-test.mjs';
+
+const paths = {
+  cellsJsonPath: '/repo/.oxiquill/generated/cells.json',
+  haskellWasmPublicDir: '/repo/public/oxiquill/haskell-wasm'
+};
+const statusPath = path.join(paths.haskellWasmPublicDir, 'status.json');
+const wasmPath = path.join(paths.haskellWasmPublicDir, 'doc_haskell_cells.wasm');
+
+describe('generated Haskell runtime tests', () => {
+  it('compiles once and executes every Haskell manifest cell with defaults', async () => {
+    const cells = [
+      cell('first', [input('scale', 3), input('label', 'sample')]),
+      { ...cell('python', []), language: 'python' },
+      cell('second', [input('enabled', true)])
+    ];
+    const expectedFingerprint = 'haskell fingerprint';
+    const fileSystem = memoryFileSystem({
+      [paths.cellsJsonPath]: JSON.stringify(cells),
+      [statusPath]: JSON.stringify({
+        haskellFingerprintHash: hashText(expectedFingerprint),
+        message: '',
+        status: 'ready'
+      }),
+      [wasmPath]: Buffer.from('wasm')
+    });
+    const module = {};
+    const compile = vi.fn(async () => module);
+    const executed = [];
+    const executeCell = vi.fn(async ({ cell: manifestCell, module: compiledModule }) => {
+      executed.push([manifestCell.id, manifestCell.inputs.map(({ value }) => value), compiledModule]);
+    });
+
+    await expect(
+      testGeneratedHaskellCells({ compile, executeCell, expectedFingerprint, fileSystem, paths })
+    ).resolves.toEqual({ cellCount: 2 });
+    expect(compile).toHaveBeenCalledOnce();
+    expect(executed).toEqual([
+      ['first', [3, 'sample'], module],
+      ['second', [true], module]
+    ]);
+  });
+
+  it('identifies a failing cell and rejects stale or unavailable runtime state', async () => {
+    const expectedFingerprint = 'current';
+    const readyFiles = {
+      [paths.cellsJsonPath]: JSON.stringify([cell('first', []), cell('failing-cell', [])]),
+      [statusPath]: JSON.stringify({
+        haskellFingerprintHash: hashText(expectedFingerprint),
+        message: '',
+        status: 'ready'
+      }),
+      [wasmPath]: Buffer.from('wasm')
+    };
+    await expect(
+      testGeneratedHaskellCells({
+        compile: async () => ({}),
+        executeCell: async ({ cell: manifestCell }) => {
+          if (manifestCell.id === 'failing-cell') throw new Error('exit 1');
+        },
+        expectedFingerprint,
+        fileSystem: memoryFileSystem(readyFiles),
+        paths
+      })
+    ).rejects.toThrow('Generated Haskell cell "failing-cell" failed with default inputs: exit 1');
+
+    await expect(
+      testGeneratedHaskellCells({
+        expectedFingerprint: 'different',
+        fileSystem: memoryFileSystem(readyFiles),
+        paths
+      })
+    ).rejects.toThrow('Generated Haskell runtime is stale');
+
+    await expect(
+      testGeneratedHaskellCells({
+        fileSystem: memoryFileSystem({
+          ...readyFiles,
+          [statusPath]: JSON.stringify({
+            haskellFingerprintHash: hashText(expectedFingerprint),
+            message: 'compiler unavailable',
+            status: 'unavailable'
+          })
+        }),
+        paths
+      })
+    ).rejects.toThrow('compiler unavailable');
+  });
+
+  it('passes scalar default inputs to a fresh WASI instance and reports nonzero exits', async () => {
+    const module = {};
+    const instance = {};
+    const instantiate = vi.fn(async () => instance);
+    const invocations = [];
+    const createWasi = vi.fn(({ args, stdout }) => {
+      invocations.push(args);
+      stdout(Buffer.from('standard output'));
+      return {
+        start: (receivedInstance) => {
+          expect(receivedInstance).toBe(instance);
+          return 0;
+        },
+        wasiImport: { fixture: true }
+      };
+    });
+
+    await expect(
+      executeGeneratedHaskellCell({
+        cell: cell('defaults', [input('number', 2.5), input('enabled', false), input('label', 'hello')]),
+        createWasi,
+        instantiate,
+        module
+      })
+    ).resolves.toEqual({ stderr: '', stdout: 'standard output' });
+    expect(invocations).toEqual([['doc_haskell_cells', 'defaults', '2.5', 'false', 'hello']]);
+    expect(instantiate).toHaveBeenCalledWith(module, { wasi_snapshot_preview1: { fixture: true } });
+
+    await expect(
+      executeGeneratedHaskellCell({
+        cell: cell('failure', []),
+        createWasi: ({ stderr }) => {
+          stderr(Buffer.from('runtime failure'));
+          return { start: () => 1, wasiImport: {} };
+        },
+        instantiate: async () => ({}),
+        module
+      })
+    ).rejects.toThrow('runtime failure');
+  });
+});
+
+function cell(id, inputs) {
+  return { id, inputs, language: 'haskell' };
+}
+
+function input(name, value) {
+  return { name, value };
+}
+
+function memoryFileSystem(files) {
+  return {
+    readFile: async (filePath, encoding) => {
+      if (!Object.hasOwn(files, filePath)) {
+        const error = new Error(`missing ${filePath}`);
+        error.code = 'ENOENT';
+        throw error;
+      }
+      const content = Buffer.isBuffer(files[filePath]) ? files[filePath] : Buffer.from(files[filePath]);
+      return encoding ? content.toString(encoding) : content;
+    }
+  };
+}

--- a/tests/unit/init.test.mjs
+++ b/tests/unit/init.test.mjs
@@ -129,6 +129,57 @@ describe('oxiquill init', () => {
     await expect(access(path.join(cwd, 'missing'))).rejects.toMatchObject({ code: 'ENOENT' });
   });
 
+  it('validates starter metadata and file types before creating the target', async () => {
+    const cwd = await temporaryDirectory();
+    const invalidMetadataStarter = await temporaryDirectory();
+    const directoryStarter = await temporaryDirectory();
+    await writeFile(path.join(invalidMetadataStarter, 'package.json'), '{ invalid json');
+    await mkdir(path.join(directoryStarter, 'README.md'));
+
+    await expect(
+      initializeProject({
+        cwd,
+        directory: 'invalid-metadata',
+        files: ['package.json'],
+        starterRoot: invalidMetadataStarter
+      })
+    ).rejects.toThrow('Starter package metadata is invalid');
+    await expect(
+      initializeProject({ cwd, directory: 'directory-source', files: ['README.md'], starterRoot: directoryStarter })
+    ).rejects.toThrow('Starter source is not a regular file');
+
+    await expect(access(path.join(cwd, 'invalid-metadata'))).rejects.toMatchObject({ code: 'ENOENT' });
+    await expect(access(path.join(cwd, 'directory-source'))).rejects.toMatchObject({ code: 'ENOENT' });
+  });
+
+  it('does not overwrite a file created after the target emptiness check', async () => {
+    const cwd = await temporaryDirectory();
+    const targetPath = path.join(cwd, 'raced-target');
+    const racedFile = path.join(targetPath, '.gitignore');
+    let injectCollision = true;
+    await mkdir(targetPath);
+
+    await expect(
+      initializeProject({
+        cwd,
+        directory: 'raced-target',
+        fileSystem: {
+          writeFile: async (...args) => {
+            if (injectCollision) {
+              injectCollision = false;
+              await writeFile(racedFile, 'created concurrently\n');
+            }
+            return writeFile(...args);
+          }
+        },
+        starterRoot
+      })
+    ).rejects.toThrow('Could not initialize an Oxiquill project');
+
+    expect(await readFile(racedFile, 'utf8')).toBe('created concurrently\n');
+    expect(await relativeFiles(targetPath)).toEqual(['.gitignore']);
+  });
+
   it.each([
     ['My Docs', 'my-docs'],
     ['UPPER_case', 'upper_case'],

--- a/tests/unit/init.test.mjs
+++ b/tests/unit/init.test.mjs
@@ -1,0 +1,167 @@
+// @vitest-environment node
+
+import { access, lstat, mkdir, mkdtemp, readFile, readdir, rm, symlink, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { initializeProject, packageNameFromTarget, starterFiles } from '../../packages/oxiquill/src/cli/init.mjs';
+
+const repositoryRoot = fileURLToPath(new URL('../..', import.meta.url));
+const starterRoot = path.join(repositoryRoot, 'templates/basic');
+const temporaryRoots = [];
+
+afterEach(async () => {
+  await Promise.all(temporaryRoots.splice(0).map((directory) => rm(directory, { force: true, recursive: true })));
+  vi.restoreAllMocks();
+});
+
+describe('oxiquill init', () => {
+  it('creates the complete starter in a new target and prints executable next steps', async () => {
+    const cwd = await temporaryDirectory();
+    const log = vi.fn();
+
+    const result = await initializeProject({ cwd, directory: 'My Docs!', log, starterRoot });
+
+    expect(result).toEqual({ packageName: 'my-docs', targetPath: path.join(cwd, 'My Docs!') });
+    expect(await relativeFiles(result.targetPath)).toEqual([...starterFiles].sort());
+    const packageJson = JSON.parse(await readFile(path.join(result.targetPath, 'package.json'), 'utf8'));
+    expect(packageJson).toEqual(
+      expect.objectContaining({
+        engines: { node: '>=24.0.0' },
+        name: 'my-docs',
+        packageManager: 'pnpm@11.2.2',
+        scripts: {
+          build: 'oxiquill build',
+          check: 'oxiquill check',
+          clean: 'oxiquill clean',
+          dev: 'oxiquill dev',
+          preview: 'oxiquill preview'
+        }
+      })
+    );
+    await expect(access(path.join(result.targetPath, 'node_modules'))).rejects.toMatchObject({ code: 'ENOENT' });
+    await expect(access(path.join(result.targetPath, '.git'))).rejects.toMatchObject({ code: 'ENOENT' });
+    expect(log.mock.calls.map(([message]) => message)).toEqual([
+      `Created an Oxiquill project in ${result.targetPath}.`,
+      '',
+      'Next steps:',
+      '  cd "My Docs!"',
+      '  pnpm install',
+      '  pnpm dev'
+    ]);
+  });
+
+  it('initializes an existing empty current directory without printing a cd command', async () => {
+    const cwd = await temporaryDirectory();
+    const log = vi.fn();
+
+    await initializeProject({ cwd, log, starterRoot });
+
+    expect(await relativeFiles(cwd)).toEqual([...starterFiles].sort());
+    expect(log.mock.calls.flat()).not.toContain(expect.stringMatching(/^ {2}cd /u));
+  });
+
+  it('never changes a non-empty target or a file target', async () => {
+    const cwd = await temporaryDirectory();
+    const nonEmptyTarget = path.join(cwd, 'existing');
+    const fileTarget = path.join(cwd, 'file-target');
+    await mkdir(nonEmptyTarget);
+    await writeFile(path.join(nonEmptyTarget, 'keep.txt'), 'keep');
+    await writeFile(fileTarget, 'keep-file');
+
+    await expect(initializeProject({ cwd, directory: 'existing', starterRoot })).rejects.toThrow('is not empty');
+    await expect(initializeProject({ cwd, directory: 'file-target', starterRoot })).rejects.toThrow(
+      'is not a directory'
+    );
+
+    expect(await readFile(path.join(nonEmptyTarget, 'keep.txt'), 'utf8')).toBe('keep');
+    expect(await readFile(fileTarget, 'utf8')).toBe('keep-file');
+  });
+
+  it.runIf(process.platform !== 'win32')('rejects a symbolic-link target', async () => {
+    const cwd = await temporaryDirectory();
+    const actualTarget = path.join(cwd, 'actual');
+    const linkedTarget = path.join(cwd, 'linked');
+    await mkdir(actualTarget);
+    await symlink(actualTarget, linkedTarget, 'dir');
+
+    await expect(initializeProject({ cwd, directory: 'linked', starterRoot })).rejects.toThrow('is not a directory');
+    expect(await readdir(actualTarget)).toEqual([]);
+  });
+
+  it('rolls back only the files and directories created during a failed initialization', async () => {
+    const cwd = await temporaryDirectory();
+    const targetPath = path.join(cwd, 'existing-empty');
+    let writes = 0;
+    await mkdir(targetPath);
+
+    await expect(
+      initializeProject({
+        cwd,
+        directory: 'existing-empty',
+        fileSystem: {
+          writeFile: async (...args) => {
+            writes += 1;
+            if (writes === 3) throw new Error('injected write failure');
+            return writeFile(...args);
+          }
+        },
+        starterRoot
+      })
+    ).rejects.toThrow('injected write failure');
+
+    expect((await lstat(targetPath)).isDirectory()).toBe(true);
+    expect(await readdir(targetPath)).toEqual([]);
+  });
+
+  it('rejects escaping or missing starter sources before creating the target', async () => {
+    const cwd = await temporaryDirectory();
+    const emptyStarter = await temporaryDirectory();
+
+    await expect(initializeProject({ cwd, directory: 'escape', files: ['../outside'], starterRoot })).rejects.toThrow(
+      'starter source escapes its root'
+    );
+    await expect(initializeProject({ cwd, directory: 'missing', starterRoot: emptyStarter })).rejects.toMatchObject({
+      code: 'ENOENT'
+    });
+    await expect(access(path.join(cwd, 'escape'))).rejects.toMatchObject({ code: 'ENOENT' });
+    await expect(access(path.join(cwd, 'missing'))).rejects.toMatchObject({ code: 'ENOENT' });
+  });
+
+  it.each([
+    ['My Docs', 'my-docs'],
+    ['UPPER_case', 'upper_case'],
+    ['Hello, world!!!', 'hello-world'],
+    ['Crème Brûlée', 'creme-brulee'],
+    ['node_modules', 'oxiquill-docs'],
+    ['favicon.ico', 'oxiquill-docs'],
+    ['!!!', 'oxiquill-docs'],
+    ['C:\\Users\\Example\\Windows Docs\\', 'windows-docs'],
+    ['/home/example/My Project/', 'my-project']
+  ])('derives the npm package name from %s', (target, expected) => {
+    expect(packageNameFromTarget(target)).toBe(expected);
+  });
+});
+
+async function temporaryDirectory() {
+  const directory = await mkdtemp(path.join(tmpdir(), 'oxiquill-init-'));
+  temporaryRoots.push(directory);
+  return directory;
+}
+
+async function relativeFiles(root) {
+  const entries = await readdir(root, { withFileTypes: true });
+  const nested = await Promise.all(
+    entries.map(async (entry) => {
+      const entryPath = path.join(root, entry.name);
+      return entry.isDirectory()
+        ? (await relativeFiles(entryPath)).map((child) => path.join(entry.name, child))
+        : [entry.name];
+    })
+  );
+  return nested
+    .flat()
+    .map((filePath) => filePath.split(path.sep).join('/'))
+    .sort();
+}

--- a/tests/unit/project-config.test.mjs
+++ b/tests/unit/project-config.test.mjs
@@ -32,11 +32,13 @@ describe('Oxiquill project configuration', () => {
         docsDir: path.join(root, 'content/docs'),
         cratesDir: path.join(root, 'crates'),
         cacheDir: path.join(root, '.oxiquill'),
+        downloadCacheDir: path.join(root, '.oxiquill/downloads/v1'),
         generatedDir: path.join(root, '.oxiquill/generated'),
         outDir: path.join(root, 'dist'),
         publicDir: path.join(root, 'public'),
         publicAssetsDir: path.join(root, 'public/oxiquill')
-      }
+      },
+      python: { offline: false }
     });
     expect(Object.isFrozen(projectConfig)).toBe(true);
     expect(Object.isFrozen(projectConfig.paths)).toBe(true);
@@ -97,6 +99,28 @@ describe('Oxiquill project configuration', () => {
       `Conflicting project paths: cacheDir resolves to ${path.join(root, '.astro-cache')}, ` +
         `but paths.cacheDir resolves to ${path.join(root, '.runtime-cache')}.`
     );
+  });
+
+  it('normalizes Python mirror and offline settings before runtime generation', () => {
+    const root = path.resolve('/repo');
+    const projectConfig = resolveProject({
+      python: { offline: true, packageMirror: new URL('https://packages.example/pyodide') },
+      root
+    });
+
+    expect(projectConfig.python).toEqual({
+      offline: true,
+      packageMirror: 'https://packages.example/pyodide/'
+    });
+    expect(Object.isFrozen(projectConfig.python)).toBe(true);
+    expect(() => resolveProject({ python: { offline: 'yes' }, root })).toThrow('python.offline must be a boolean');
+    expect(() => resolveProject({ python: { packageMirror: 'file:///packages' }, root })).toThrow(
+      'python.packageMirror must be an absolute HTTP(S) URL'
+    );
+    expect(() => resolveProject({ python: { packageMirror: 'https://user@example.com/' }, root })).toThrow(
+      'must not contain credentials'
+    );
+    expect(() => resolveProject({ python: { unexpected: true }, root })).toThrow('Unknown python option');
   });
 
   it('canonicalizes symlinked ancestors before comparing explicit settings', async () => {
@@ -197,12 +221,12 @@ describe('Oxiquill project configuration', () => {
   });
 });
 
-function resolveProject({ astro = {}, paths = {}, root }) {
+function resolveProject({ astro = {}, paths = {}, python = {}, root }) {
   return resolveOxiquillProjectConfig({
     astroConfig: { root, ...astro },
     astroExplicitFields: ['root', ...Object.keys(astro)],
     cwd: root,
-    integrationMetadata: createOxiquillIntegrationMetadata({ paths })
+    integrationMetadata: createOxiquillIntegrationMetadata({ paths, python })
   });
 }
 

--- a/tests/unit/pyodide-assets.test.mjs
+++ b/tests/unit/pyodide-assets.test.mjs
@@ -1,0 +1,231 @@
+// @vitest-environment node
+
+import { mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  copyPyodideAssets,
+  createDocRuntimePaths,
+  fetchPyodidePackage,
+  hashBytes,
+  PYODIDE_DOWNLOAD_ATTEMPTS,
+  PYODIDE_REQUEST_TIMEOUT_MS,
+  requiredPyodideFiles,
+  resolvePyodideRuntimeInputs
+} from '../../packages/oxiquill/src/generator/doc-runtime-service.mjs';
+
+const fixtureVersion = 'test-release';
+const temporaryDirectories = [];
+
+afterEach(async () => {
+  await Promise.all(temporaryDirectories.splice(0).map((directory) => rm(directory, { force: true, recursive: true })));
+});
+
+describe('Pyodide assets', () => {
+  it('derives a deterministic release, package graph, and hashes from installed metadata', async () => {
+    const fixture = await createInstalledPyodide();
+
+    const first = await resolvePyodideRuntimeInputs({
+      requestedPackages: ['root'],
+      resolvePackageJson: fixture.resolvePackageJson
+    });
+    const second = await resolvePyodideRuntimeInputs({
+      requestedPackages: ['root'],
+      resolvePackageJson: fixture.resolvePackageJson
+    });
+
+    expect(first).toMatchObject({
+      defaultPackageBaseUrl: `https://cdn.jsdelivr.net/pyodide/v${fixtureVersion}/full/`,
+      version: fixtureVersion
+    });
+    expect(first.coreAssets.map(({ fileName }) => fileName)).toEqual(requiredPyodideFiles);
+    expect(first.packages.map(({ name }) => name)).toEqual(['dependency', 'root']);
+    expect(first.lockSha256).toBe(hashBytes(await readFile(fixture.lockPath)));
+    expect(first.fingerprint).toBe(second.fingerprint);
+  });
+
+  it('uses a mirror, repairs corrupt entries online, and serves only verified cached assets offline', async () => {
+    const fixture = await createInstalledPyodide();
+    const paths = createDocRuntimePaths(fixture.workspaceRoot);
+    const runtimeInputs = await resolvePyodideRuntimeInputs({
+      requestedPackages: ['root'],
+      resolvePackageJson: fixture.resolvePackageJson
+    });
+    const fetchedUrls = [];
+    const fetchImplementation = vi.fn(async (url) => {
+      fetchedUrls.push(String(url));
+      const content = fixture.wheels[path.basename(new URL(url).pathname)];
+      return response(content);
+    });
+    const options = {
+      fetchImplementation,
+      paths,
+      pythonOptions: { offline: false, packageMirror: 'https://mirror.example/packages/' },
+      requestedPackages: ['root'],
+      runtimeInputs
+    };
+
+    await expect(copyPyodideAssets(options)).resolves.toBe(true);
+    expect(fetchedUrls.sort()).toEqual([
+      'https://mirror.example/packages/dependency.whl',
+      'https://mirror.example/packages/root.whl'
+    ]);
+
+    const cacheDirectory = path.join(paths.downloadCacheDir, 'pyodide', fixtureVersion, runtimeInputs.lockSha256);
+    expect(await readFile(path.join(cacheDirectory, 'root.whl'))).toEqual(fixture.wheels['root.whl']);
+
+    await rm(paths.pyodidePublicDir, { force: true, recursive: true });
+    await expect(
+      copyPyodideAssets({
+        ...options,
+        fetchImplementation: vi.fn(),
+        pythonOptions: { offline: true }
+      })
+    ).resolves.toBe(true);
+
+    await writeFile(path.join(cacheDirectory, 'root.whl'), 'corrupt');
+    await rm(paths.pyodidePublicDir, { force: true, recursive: true });
+    await expect(
+      copyPyodideAssets({
+        ...options,
+        fetchImplementation: vi.fn(),
+        pythonOptions: { offline: true }
+      })
+    ).rejects.toThrow(
+      `Offline Pyodide cache miss for "root.whl" at "${path.join(cacheDirectory, 'root.whl')}"; expected sha256 ${hashBytes(fixture.wheels['root.whl'])}.`
+    );
+
+    await expect(copyPyodideAssets(options)).resolves.toBe(true);
+    expect(fetchImplementation).toHaveBeenCalledTimes(3);
+    expect(await readFile(path.join(cacheDirectory, 'root.whl'))).toEqual(fixture.wheels['root.whl']);
+  });
+
+  it('rejects a hash mismatch without publishing or caching the invalid wheel', async () => {
+    const fixture = await createInstalledPyodide();
+    const paths = createDocRuntimePaths(fixture.workspaceRoot);
+    const runtimeInputs = await resolvePyodideRuntimeInputs({
+      requestedPackages: ['root'],
+      resolvePackageJson: fixture.resolvePackageJson
+    });
+
+    await expect(
+      copyPyodideAssets({
+        fetchImplementation: async () => response(Buffer.from('invalid wheel')),
+        paths,
+        requestedPackages: ['root'],
+        runtimeInputs
+      })
+    ).rejects.toThrow('Pyodide asset');
+
+    const cachedWheel = path.join(
+      paths.downloadCacheDir,
+      'pyodide',
+      fixtureVersion,
+      runtimeInputs.lockSha256,
+      'root.whl'
+    );
+    await expect(readFile(cachedWheel)).rejects.toMatchObject({ code: 'ENOENT' });
+    await expect(readFile(path.join(paths.pyodidePublicDir, 'root.whl'))).rejects.toMatchObject({ code: 'ENOENT' });
+  });
+
+  it('bounds retries and backoff, avoids retrying permanent responses, and times out requests', async () => {
+    const sleeps = [];
+    const retryingFetch = vi
+      .fn()
+      .mockResolvedValueOnce(response(undefined, 503, 'unavailable'))
+      .mockResolvedValueOnce(response(undefined, 429, 'rate limited'))
+      .mockResolvedValueOnce(response(Buffer.from('wheel')));
+
+    await expect(
+      fetchPyodidePackage('root.whl', {
+        fetchImplementation: retryingFetch,
+        packageBaseUrl: 'https://packages.example/',
+        sleep: async (milliseconds) => sleeps.push(milliseconds)
+      })
+    ).resolves.toEqual(Buffer.from('wheel'));
+    expect(retryingFetch).toHaveBeenCalledTimes(PYODIDE_DOWNLOAD_ATTEMPTS);
+    expect(sleeps).toEqual([250, 1_000]);
+
+    const permanentFetch = vi.fn(async () => response(undefined, 404, 'not found'));
+    await expect(
+      fetchPyodidePackage('missing.whl', {
+        fetchImplementation: permanentFetch,
+        packageBaseUrl: 'https://packages.example/',
+        sleep: vi.fn()
+      })
+    ).rejects.toThrow('after 1 attempt(s): 404 not found');
+    expect(permanentFetch).toHaveBeenCalledOnce();
+
+    const hangingFetch = vi.fn(
+      async (_url, { signal }) =>
+        new Promise((_resolve, reject) => {
+          signal.addEventListener('abort', () => reject(new Error('aborted')), { once: true });
+        })
+    );
+    await expect(
+      fetchPyodidePackage('slow.whl', {
+        fetchImplementation: hangingFetch,
+        packageBaseUrl: 'https://packages.example/',
+        sleep: async () => {},
+        timeoutMs: 5
+      })
+    ).rejects.toThrow('after 3 attempt(s): request timed out after 5ms');
+    expect(hangingFetch).toHaveBeenCalledTimes(PYODIDE_DOWNLOAD_ATTEMPTS);
+    expect(PYODIDE_REQUEST_TIMEOUT_MS).toBe(30_000);
+  });
+});
+
+async function createInstalledPyodide() {
+  const workspaceRoot = await mkdtemp(path.join(tmpdir(), 'oxiquill-pyodide-'));
+  temporaryDirectories.push(workspaceRoot);
+  const packageDirectory = path.join(workspaceRoot, 'installed', 'pyodide');
+  await mkdir(packageDirectory, { recursive: true });
+
+  const wheels = {
+    'dependency.whl': Buffer.from('dependency wheel'),
+    'root.whl': Buffer.from('root wheel')
+  };
+  const lockFile = {
+    info: { version: fixtureVersion },
+    packages: {
+      dependency: packageEntry('dependency', 'dependency.whl', wheels['dependency.whl']),
+      root: packageEntry('root', 'root.whl', wheels['root.whl'], ['dependency'])
+    }
+  };
+  await Promise.all([
+    writeFile(path.join(packageDirectory, 'package.json'), JSON.stringify({ version: fixtureVersion })),
+    ...requiredPyodideFiles.map((fileName) =>
+      writeFile(
+        path.join(packageDirectory, fileName),
+        fileName === 'pyodide-lock.json' ? JSON.stringify(lockFile) : `core ${fileName}`
+      )
+    )
+  ]);
+
+  return {
+    lockPath: path.join(packageDirectory, 'pyodide-lock.json'),
+    resolvePackageJson: () => path.join(packageDirectory, 'package.json'),
+    wheels,
+    workspaceRoot
+  };
+}
+
+function packageEntry(name, fileName, content, depends = []) {
+  return {
+    depends,
+    file_name: fileName,
+    name,
+    sha256: hashBytes(content),
+    version: 'fixture-package'
+  };
+}
+
+function response(content, status = 200, statusText = 'ok') {
+  return {
+    arrayBuffer: async () => content,
+    ok: status >= 200 && status < 300,
+    status,
+    statusText
+  };
+}

--- a/tests/unit/run-helper-cargo.test.mjs
+++ b/tests/unit/run-helper-cargo.test.mjs
@@ -81,7 +81,8 @@ describe('helper cargo runner', () => {
       'test',
       '--manifest-path',
       manifestPath,
-      '--workspace'
+      '--workspace',
+      '--locked'
     ]);
     expect(cargoArgsForHelperWorkspace(['clippy', '--all-targets', '--', '-D', 'warnings'], manifestPath)).toEqual([
       'clippy',
@@ -89,6 +90,7 @@ describe('helper cargo runner', () => {
       '--manifest-path',
       manifestPath,
       '--workspace',
+      '--locked',
       '--',
       '-D',
       'warnings'
@@ -136,7 +138,11 @@ describe('helper cargo runner', () => {
     });
 
     expect(commands).toEqual([
-      ['cargo', ['doc', '--no-deps', '--manifest-path', 'crates/Cargo.toml', '--workspace'], { cwd: repoRoot }]
+      [
+        'cargo',
+        ['doc', '--no-deps', '--manifest-path', 'crates/Cargo.toml', '--workspace', '--locked'],
+        { cwd: repoRoot }
+      ]
     ]);
   });
 

--- a/tests/unit/runtime-inputs.test.mjs
+++ b/tests/unit/runtime-inputs.test.mjs
@@ -1,0 +1,179 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  normalizeRepository,
+  normalizeRuntimeInputs
+} from '../../packages/oxiquill/src/generator/doc-runtime/runtime-inputs.mjs';
+import {
+  preflightHaskellToolchain,
+  preflightRequiredToolchains,
+  preflightRustToolchain
+} from '../../packages/oxiquill/src/generator/doc-runtime/toolchain-preflight.mjs';
+
+const runtimeData = {
+  schemaVersion: 1,
+  rust: {
+    cargoVersion: '1.95.0',
+    dependencies: {
+      console_error_panic_hook: '0.1.7',
+      serde: '1.0.228',
+      serde_json: '1.0.150',
+      'wasm-bindgen': '0.2.122',
+      'wasm-bindgen-test': '0.3.72'
+    },
+    edition: '2024',
+    rustVersion: '1.95',
+    rustcVersion: '1.95.0',
+    target: 'wasm32-unknown-unknown',
+    wasmPackVersion: '0.15.0'
+  },
+  haskell: {
+    compiler: 'wasm32-wasi-ghc',
+    supportedVersionPrefix: '9.14.'
+  }
+};
+const lock = `version = 4
+
+[[package]]
+name = "console_error_panic_hook"
+version = "0.1.7"
+
+[[package]]
+name = "doc-rust-cells"
+version = "0.2.0"
+
+[[package]]
+name = "serde"
+version = "1.0.228"
+
+[[package]]
+name = "serde_json"
+version = "1.0.150"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.122"
+
+[[package]]
+name = "wasm-bindgen-test"
+version = "0.3.72"
+`;
+
+describe('runtime inputs', () => {
+  it('normalizes installed package metadata and validates pinned lock inputs', () => {
+    const inputs = normalizeRuntimeInputs({
+      packageJson: {
+        repository: { directory: 'packages/oxiquill', url: 'git+https://example.com/oxiquill.git' },
+        version: '0.2.0'
+      },
+      runtimeData,
+      rustLock: lock
+    });
+
+    expect(inputs.package).toEqual({ repository: 'https://example.com/oxiquill', version: '0.2.0' });
+    expect(Object.keys(inputs.rust.dependencies)).toEqual([
+      'console_error_panic_hook',
+      'serde',
+      'serde_json',
+      'wasm-bindgen',
+      'wasm-bindgen-test'
+    ]);
+    expect(inputs.rustLockSha256).toMatch(/^[0-9a-f]{64}$/u);
+    expect(normalizeRepository('https://example.com/repository.git')).toBe('https://example.com/repository');
+  });
+
+  it('rejects missing, inconsistent, or unsafe runtime metadata', () => {
+    expect(() =>
+      normalizeRuntimeInputs({
+        packageJson: { repository: 'https://example.com/oxiquill', version: '9.9.9' },
+        runtimeData,
+        rustLock: lock
+      })
+    ).toThrow('expected 9.9.9');
+    expect(() =>
+      normalizeRuntimeInputs({
+        packageJson: { repository: 'https://example.com/oxiquill', version: '0.2.0' },
+        runtimeData: { ...runtimeData, schemaVersion: 2 },
+        rustLock: lock
+      })
+    ).toThrow('schemaVersion 1');
+    expect(() => normalizeRepository('git@example.com:repository.git')).toThrow('repository URL is invalid');
+  });
+});
+
+describe('toolchain preflight', () => {
+  it('checks only toolchains needed by the manifest and records exact versions', async () => {
+    const runCommand = vi.fn(async (command, args) => {
+      const invocation = [command, ...args].join(' ');
+      return {
+        'cargo --version': 'cargo 1.95.0 (fixture)',
+        'rustc --print target-libdir --target wasm32-unknown-unknown': '/toolchain/lib',
+        'rustc --version': 'rustc 1.95.0 (fixture)',
+        'wasm-pack --version': 'wasm-pack 0.15.0'
+      }[invocation];
+    });
+    const fileSystem = {
+      readdir: async () => ['libcore-fixture.rlib']
+    };
+    const runtimeInputs = normalizeRuntimeInputs({
+      packageJson: { repository: 'https://example.com/oxiquill', version: '0.2.0' },
+      runtimeData,
+      rustLock: lock
+    });
+
+    await expect(
+      preflightRequiredToolchains({
+        fileSystem,
+        haskellCellCount: 0,
+        mode: 'build',
+        runCommand,
+        runtimeInputs,
+        rustCellCount: 1
+      })
+    ).resolves.toEqual({
+      rust: {
+        cargo: 'cargo 1.95.0 (fixture)',
+        rustc: 'rustc 1.95.0 (fixture)',
+        target: 'wasm32-unknown-unknown',
+        'wasm-pack': 'wasm-pack 0.15.0'
+      }
+    });
+    expect(runCommand).not.toHaveBeenCalledWith('wasm32-wasi-ghc', expect.anything());
+    await expect(
+      preflightRequiredToolchains({
+        haskellCellCount: 1,
+        mode: undefined,
+        runCommand,
+        runtimeInputs,
+        rustCellCount: 1
+      })
+    ).resolves.toEqual({});
+  });
+
+  it('reports commands, expected versions, actual output, and setup guidance', async () => {
+    await expect(
+      preflightRustToolchain({
+        fileSystem: { readdir: async () => [] },
+        runCommand: async () => 'rustc 1.94.0',
+        runtimeInputs: runtimeData.rust
+      })
+    ).rejects.toThrow('"rustc --version" expected rustc 1.95.0; received rustc 1.94.0');
+
+    await expect(
+      preflightHaskellToolchain({
+        environment: {},
+        platform: 'win32',
+        runCommand: vi.fn(),
+        runtimeInputs: runtimeData.haskell
+      })
+    ).rejects.toThrow('native Windows Haskell/WASI generation is unsupported');
+
+    await expect(
+      preflightHaskellToolchain({
+        environment: { OXIQUILL_HASKELL_GHC: '/opt/wasm-ghc' },
+        platform: 'linux',
+        runCommand: async () => '9.14.1.20260330',
+        runtimeInputs: runtimeData.haskell
+      })
+    ).resolves.toEqual({ command: '/opt/wasm-ghc', version: '9.14.1.20260330' });
+  });
+});


### PR DESCRIPTION
## Summary
- make generated runtime inputs reproducible, verified, cached, and toolchain-aware
- exercise every generated Rust and Haskell cell and validate supported Python packages from packed consumers
- complete CLI argument handling and ship a safe versioned oxiquill init starter
- preserve runtime data and starter assets together in the published package

## Testing
- pnpm wasm:dev
- pnpm lint
- pnpm check
- pnpm test

Closes #53
Closes #56