### PR TITLE
Complete release hardening and add collapsible desktop TOC

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,10 @@
+# Oxiquill License
+
+Oxiquill is dual-licensed under your choice of either:
+
+- the [MIT License](LICENSE-MIT); or
+- the [Apache License, Version 2.0](LICENSE-APACHE).
+
+You may use, modify, and distribute Oxiquill under the terms of either license.
+
+SPDX-License-Identifier: MIT OR Apache-2.0

--- a/examples/docs-site/astro.config.mjs
+++ b/examples/docs-site/astro.config.mjs
@@ -4,6 +4,7 @@ import { defineOxiquillConfig } from 'oxiquill/astro';
 const basePath = process.env.BASE_PATH;
 
 export default defineOxiquillConfig({
+  desktopTableOfContentsToggle: true,
   framework: { starlight },
   site: process.env.SITE ?? 'https://oxiquill.local',
   ...(basePath ? { base: basePath } : {}),

--- a/examples/docs-site/astro.config.mjs
+++ b/examples/docs-site/astro.config.mjs
@@ -20,7 +20,7 @@ export default defineOxiquillConfig({
       },
       ja: {
         label: '日本語',
-        lang: 'ja'
+        lang: 'ja-JP'
       }
     },
     sidebar: [

--- a/examples/docs-site/content/docs/features/interactive-cells.mdx
+++ b/examples/docs-site/content/docs/features/interactive-cells.mdx
@@ -56,7 +56,7 @@ This autorun cell has no execution controls and runs once for the current genera
 println!("autorun ready");
 ```
 
-Superseded queued work is discarded, stale results cannot replace newer state, and ordinary reactive updates keep the shared language worker alive. A timeout or worker fault rejects requests owned by that worker, clears their timers, and creates a fresh worker for future runs. Unmounting cancels pending UI work and prevents late state updates.
+Superseding a reactive run actively cancels its worker request, rejects every request affected by the worker recycle, clears their timers, and starts the latest complete values after the debounce. Cancellation is not shown as an execution error, and stale results cannot replace newer state. Timeout and worker-fault recovery use the same deterministic recycle boundary. Unmounting cancels pending and active work.
 
 ## Input Schema
 
@@ -65,12 +65,16 @@ Every input accepts only fields relevant to its type. Common fields are `type`, 
 | Type               | Value and constraints                                                                                  |
 | ------------------ | ------------------------------------------------------------------------------------------------------ |
 | `range`, `number`  | Finite number; `step > 0`, `min <= max`, and the default must be within bounds.                        |
-| `integer`          | Integer value and integer bounds/step; the same numeric constraints apply.                             |
+| `integer`          | Signed 32-bit integer from `-2147483648` through `2147483647`; bounds and step use the same domain.    |
 | `text`, `textarea` | String value.                                                                                          |
 | `checkbox`         | Boolean value.                                                                                         |
 | `select`, `radio`  | Non-empty unique string options or `{ label, value }` objects; the default must equal an option value. |
 
 `type` defaults to `text`, and `label` defaults to the input name. `description` is an optional non-empty string associated with the control for assistive technology. Default values are `false` for checkbox, `0` for numeric inputs, and an empty string for text inputs. Numeric-only fields are rejected on non-numeric controls, and `options` is rejected outside `select` and `radio`.
+
+The signed 32-bit integer domain is exactly representable by JavaScript and maps consistently to Rust `i32`, Haskell `Int`, and Python `int`. Authoring rejects an integer `value`, `min`, `max`, or `step` outside that domain. Browser controls apply the same domain before constructing a worker request, including for `integer: true` numeric inputs.
+
+Number and integer controls keep their raw edit text separate from committed runtime values. Empty, incomplete, non-finite, out-of-range, and step-mismatched text remains visible but cannot update cell inputs. The Run button is disabled while any control is invalid, and reactive execution resumes exactly once with the latest complete value set after validity returns. Range labels derive their displayed precision from `step`.
 
 The visible `label` is the control's accessible name; the input key is only the generated language binding. Normalization must not make two Rust or Haskell bindings collide. Labels, descriptions, current values, validation messages, and grouped controls use stable IDs, keyboard focus remains visible, and run/error status is announced without stealing focus.
 
@@ -110,9 +114,9 @@ A cell with `crates: []` does not depend on helper crates. This example shows ch
 //|   operation: { type: select, label: operation, value: double, options: [identity, double, triple] }
 //|   style: { type: radio, label: style, value: compact, options: [compact, verbose] }
 let base_score = match operation.as_str() {
-    "triple" => 21_u32,
-    "double" => 14_u32,
-    _ => 7_u32,
+    "triple" => 21_i32,
+    "double" => 14_i32,
+    _ => 7_i32,
 };
 let score = if include_bonus {
     base_score + 5

--- a/examples/docs-site/content/docs/features/interactive-cells.mdx
+++ b/examples/docs-site/content/docs/features/interactive-cells.mdx
@@ -91,6 +91,7 @@ This Rust cell uses a helper crate and redraws a plot whenever the sliders chang
 //|   r: { type: range, label: r, min: 0, max: 4, step: 0.01, value: 3.2 }
 //|   x0: { type: range, label: x0, min: 0, max: 1, step: 0.01, value: 0.2 }
 //|   steps: { type: integer, label: steps, min: 10, max: 300, step: 10, value: 120 }
+let steps = u32::try_from(steps).map_err(|_| "steps must be non-negative".to_owned())?;
 let points = doc_rust::logistic_series(r, x0, steps).map_err(|error| error.to_string())?;
 
 for point in points.iter().take(5) {

--- a/examples/docs-site/content/docs/features/rich-output.mdx
+++ b/examples/docs-site/content/docs/features/rich-output.mdx
@@ -27,35 +27,49 @@ Every artifact may have optional string `id`, `title`, and `caption` fields. Val
 | `table` | `columns`, rectangular `rows`                                  | `rowCount` records the original size; `truncated` marks a preview.                                  |
 | `chart` | Valid `spec` described below                                   | Oversize/invalid charts become a local artifact error.                                              |
 | `image` | `mime: image/png \| image/jpeg \| image/svg+xml`, valid data   | `alt` supplies the image alternative.                                                               |
-| `html`  | `html: string`, `sandboxed: true`                              | Always rendered in an iframe with an empty sandbox permission set.                                  |
+| `html`  | `html: string`, `sandboxed: true`                              | Rendered with an empty sandbox, no referrer, and the restrictive CSP described below.               |
 
 Table columns contain `key`, `label`, and optional `type`: `string`, `number`, `integer`, `boolean`, `date`, `datetime`, `null`, or `unknown`. Every row must have exactly the declared column count.
 
 ## Chart Schema
 
-All chart specs accept optional `title`, `xLabel`, `yLabel`, `xType`, `yType`, `legend`, `tooltip`, and `dataZoom`. Axis types are `value`, `category`, `time`, and `log`.
+All chart specs accept optional `title`, `xLabel`, `yLabel`, `xType`, `yType`, `legend`, `tooltip`, and `dataZoom`. Axis types are `value`, `category`, `time`, and `log`. Unspecified axes default to `value`, except the category axes intrinsic to bar/histogram charts and heatmap axes with a corresponding categories array.
+
+- `value` coordinates are finite numbers, and `log` coordinates are finite numbers greater than zero.
+- `time` coordinates are finite epoch milliseconds or ISO-8601 strings in `YYYY-MM-DDTHH:mm:ss[.sss]Z` or `YYYY-MM-DDTHH:mm:ss[.sss]±HH:mm` form. Calendar fields and the explicit time zone must be valid.
+- `category` coordinates are strings or finite numbers. When a heatmap supplies `xCategories` or `yCategories`, a coordinate must be a listed string or an in-range zero-based integer index. A declared categories array makes that axis categorical; a conflicting axis type is rejected.
 
 - `line`, `scatter`, and `area`: `series[]`, each with optional `name` and `[x, y]` points.
 - `bar`: string `categories[]` plus series of numeric-or-null `values[]` with matching length.
-- `histogram`: `bins[]` as finite `[lower, upper, count]` tuples.
+- `histogram`: `bins[]` as finite `[lower, upper, count]` tuples, where `lower < upper` and count is non-negative.
 - `heatmap`: optional `xCategories`/`yCategories` and finite `[x, y, value]` cells.
 
-Charts expose a textual title/caption and bounded accessible summary or equivalent table. The implementation canvas is hidden from accessibility APIs when that equivalent is present.
+Empty charts and equal point domains are valid. Heatmaps report X, Y, and heat-value ranges separately; their color scale uses the actual heat values, with a `0–1` fallback only for an empty dataset. Charts expose a textual title/caption and bounded accessible summary or equivalent table. The implementation canvas is hidden from accessibility APIs when that equivalent is present.
+
+Charts use contrast-aware colors for the current Starlight light/dark theme, recreate their ECharts instance when `html[data-theme]` changes, and expose a retry action after a transient renderer load failure.
 
 ## Resource Limits
 
-Limits apply after validation and are cumulative for each run:
+Producers enforce limits inside each language worker before `postMessage`; the main thread independently validates the bounded response again. Limits are UTF-8 byte limits and are cumulative for each run where noted:
 
-| Resource                    | Limit                           | Over-limit result                                              |
-| --------------------------- | ------------------------------- | -------------------------------------------------------------- |
-| Artifacts                   | 100 per run                     | Additional artifacts are rejected locally.                     |
-| Text, serialized JSON, HTML | 1 MiB per artifact              | Text/JSON may use `truncated: true`; HTML is rejected.         |
-| Table                       | 10,000 rows and 100 columns     | A bounded table may use `truncated: true` and `rowCount`.      |
-| Chart                       | 100,000 total points/bins/cells | Artifact-local error.                                          |
-| Image                       | 10 MiB decoded bytes            | Artifact-local error.                                          |
-| All validated output        | 16 MiB per run                  | Artifacts exceeding the remaining budget are rejected locally. |
+| Resource                    | Limit                           | Over-limit result                                                 |
+| --------------------------- | ------------------------------- | ----------------------------------------------------------------- |
+| Artifacts                   | 100 per run                     | Additional artifacts are rejected locally.                        |
+| stdout or stderr            | 1 MiB per stream                | Captured text is retained only to the limit and marked truncated. |
+| Text, serialized JSON, HTML | 1 MiB per artifact              | Text/JSON may use `truncated: true`; HTML is rejected.            |
+| Table                       | 10,000 rows and 100 columns     | A bounded table may use `truncated: true` and `rowCount`.         |
+| Chart                       | 100,000 total points/bins/cells | Artifact-local error.                                             |
+| Image                       | 10 MiB decoded bytes            | Artifact-local error.                                             |
+| All validated output        | 16 MiB per run                  | Artifacts exceeding the remaining budget are rejected locally.    |
+| Complete worker response    | 16 MiB                          | Later artifacts are omitted before worker-to-page transfer.       |
+| Worker error                | 16 KiB                          | The UTF-8 message is truncated.                                   |
+| Artifact diagnostic         | 8 KiB each; 64 KiB per run      | Diagnostics are truncated within both limits.                     |
 
-`truncated: true` is valid only for text, JSON, and table artifacts. Chart, image, and HTML artifacts are never silently truncated. Invalid/cyclic/over-deep JSON, ragged tables, non-finite chart values, invalid base64/MIME pairs, or unsafe structural records cannot crash the cell component.
+`truncated: true` is valid only for text, JSON, and table artifacts. Chart, image, and HTML artifacts are never silently truncated. Invalid/cyclic/over-deep JSON, ragged tables, non-finite chart values, invalid base64/MIME pairs, or unsafe structural records cannot crash the cell component. Legacy `stdout`, `stderr`, `value`, and `plots` aliases are regenerated from validated, bounded `outputs`; raw aliases cannot retain a second unbounded payload.
+
+## CSV Copy Safety
+
+The default table action copies visible rows as spreadsheet-safe CSV. String headers or cells whose first meaningful character is `=`, `+`, `-`, `@`, tab, or carriage return receive a leading apostrophe before RFC-style comma/quote/line-break escaping. This deterministic convention prevents common spreadsheet applications from evaluating string data as a formula. Numeric values remain numeric, so a genuine number such as `-42` is copied as `-42`.
 
 ## Python Display Helpers
 
@@ -133,6 +147,6 @@ emit_html!(r#"<p><strong>Sandboxed HTML</strong> emitted from Rust.</p>"#);
 
 Use stdout for short explanatory text. Use JSON when readers need the exact structured value. Use tables for comparable records, charts for trends or distributions, images for generated visuals, and sandboxed HTML only when the output needs markup that cannot be represented by the other artifact types.
 
-Copy, sort, pagination, validation, running, completion, and failure states are keyboard-operable and announced with localized English/Japanese labels. Sandboxed HTML intentionally has no script or same-origin permission; see [Support and Security](/guides/support-and-security/) for the full trust boundary.
+Copy, sort, pagination, validation, running, completion, and failure states are keyboard-operable and announced with localized English/Japanese labels. Sandboxed HTML intentionally has no script or same-origin permission, sends no referrer, and blocks external subresources by default; see [Support and Security](/guides/support-and-security/) for the exact policy and trust boundary.
 
 Table interaction state is scoped to one execution result. A new result resets the page, sort, and copy status. Rerenders of the same result preserve a compatible sort and page, but row shrinkage stores the clamped page and a removed or replaced sorted column clears the sort.

--- a/examples/docs-site/content/docs/features/rich-output.mdx
+++ b/examples/docs-site/content/docs/features/rich-output.mdx
@@ -134,3 +134,5 @@ emit_html!(r#"<p><strong>Sandboxed HTML</strong> emitted from Rust.</p>"#);
 Use stdout for short explanatory text. Use JSON when readers need the exact structured value. Use tables for comparable records, charts for trends or distributions, images for generated visuals, and sandboxed HTML only when the output needs markup that cannot be represented by the other artifact types.
 
 Copy, sort, pagination, validation, running, completion, and failure states are keyboard-operable and announced with localized English/Japanese labels. Sandboxed HTML intentionally has no script or same-origin permission; see [Support and Security](/guides/support-and-security/) for the full trust boundary.
+
+Table interaction state is scoped to one execution result. A new result resets the page, sort, and copy status. Rerenders of the same result preserve a compatible sort and page, but row shrinkage stores the clamped page and a removed or replaced sorted column clears the sort.

--- a/examples/docs-site/content/docs/guides/authoring.mdx
+++ b/examples/docs-site/content/docs/guides/authoring.mdx
@@ -32,6 +32,12 @@ Start with what the page helps the reader do, then move into examples. Use headi
 
 Use the same route and general structure in Japanese translations. The Japanese page does not need to be word-for-word identical, but it should cover the same behavior and examples.
 
+## Choose the Page Table of Contents
+
+Regular pages show Starlight's table of contents. On desktop, readers can collapse the right column and Oxiquill remembers that choice for the current browser tab. On mobile, Starlight's existing disclosure remains unchanged.
+
+Use `tableOfContents: false` in frontmatter when a page should have no table of contents or desktop control. Starlight splash pages also omit both automatically. This page-level setting is separate from the project-wide `desktopTableOfContentsToggle` option, which only enables or disables the desktop collapse control.
+
 ## Write Rust Cells
 
 Rust cells are fenced `rust` code blocks with metadata in leading `//|` or `///|` comments. Metadata comments must form one contiguous block at the very start of the cell; later option-looking comments remain source code. The `id` must be unique within the page and match lowercase kebab-case. English and Japanese versions may reuse the same local `id`; the build creates page-scoped internal IDs.

--- a/examples/docs-site/content/docs/guides/authoring.mdx
+++ b/examples/docs-site/content/docs/guides/authoring.mdx
@@ -101,6 +101,8 @@ Common metadata fields:
 
 These are the only top-level fields. Dependency arrays must contain unique non-empty strings. Supported input types are `range`, `number`, `integer`, `text`, `textarea`, `checkbox`, `select`, and `radio`. See [Interactive Cells](../../features/interactive-cells/) for the exact input fields, defaults, constraints, and option schema.
 
+Integer metadata uses one portable signed 32-bit domain: `-2147483648` through `2147483647`. This limit applies to `value`, `min`, `max`, and `step` so generated Rust, Haskell, and Python bindings receive the same exact integer.
+
 ## Add Math
 
 Inline math uses `$...$`, and block math uses `$$...$$`.

--- a/examples/docs-site/content/docs/guides/project-configuration.mdx
+++ b/examples/docs-site/content/docs/guides/project-configuration.mdx
@@ -88,7 +88,15 @@ export default defineOxiquillConfig({
 4. Consumer Markdown, Vite, CSS, component, and integration additions are retained after Oxiquill's required entries.
 5. A conflicting path, missing Oxiquill integration, multiple Oxiquill integrations, or an unreadable config fails before generation or cleanup.
 
-Do not point an Oxiquill-owned output at the project root or another broad directory. `oxiquill clean` removes only validated, resolved generated paths and configured Astro output directories. It deliberately preserves `downloadCacheDir`, which must be outside every cleaned output path.
+## Cleanup Ownership and Safety
+
+`oxiquill clean` recursively removes exactly three resolved roots: `cacheDir`, Astro's `outDir`, and `publicAssetsDir`. It does not remove `downloadCacheDir`; the default verified download cache at `.cache/oxiquill/downloads/v1` persists across clean and can be reused by later generation.
+
+The exact default roots `.oxiquill`, `dist`, and `public/oxiquill` are reserved generated locations and may be cleaned without an ownership marker. For a custom cleanup root, the corresponding generation or build lifecycle writes `.oxiquill-ownership.json` after claiming a missing or empty directory. A pre-existing non-empty custom directory without the matching marker is never inferred to be generated output. Do not create or edit the marker manually.
+
+Every recursively deleted root must stay inside `workspaceRoot`. Cleanup roots must be disjoint from one another and from `docsDir`, `cratesDir`, `publicDir`, `frameworkRoot`, the selected Astro config, recognized project config/manifest/lock files, the persistent download cache, and discovered VCS or package-installation state such as `.git` and `node_modules`. Generated child roles must also be disjoint from their siblings. The only authored/generated containment exception is a strict `publicAssetsDir` child below `publicDir`; it cannot equal `publicDir` or sit below another authored public subtree.
+
+Oxiquill canonicalizes existing paths and symlinked ancestors before comparing or deleting them. Clean validates every root and every ownership marker before its first recursive deletion. If one root is unsafe or unowned, no root is removed; the diagnostic names the field, absolute resolved path, conflicting path role, and corrective action.
 
 ## Runtime Fingerprints
 
@@ -98,6 +106,6 @@ Runtime fingerprints contain semantic build inputs rather than machine-local pat
 
 Set Astro's `base` when publishing below a subpath. Oxiquill applies it to interactive-cell manifests, language runtimes, diagrams, and `/media/...` references. Keep authored public URLs root-relative; the Markdown transform adds the configured base exactly once.
 
-Generated runtime files belong under `.oxiquill` and `public/oxiquill`; the verified download cache belongs under `.cache/oxiquill/downloads/v1`; and the final static site belongs under Astro's `outDir` (normally `dist`). Generated directories must not be edited directly. The download cache may be retained across builds and reconstructed outputs, but its files are verified before every use.
+Generated runtime files belong under `.oxiquill` and `public/oxiquill`; the verified download cache belongs under `.cache/oxiquill/downloads/v1`; and the final static site belongs under Astro's `outDir` (normally `dist`). Generated directories and their ownership markers must not be edited directly. The download cache may be retained across builds and reconstructed outputs, but its files are verified before every use.
 
 When you customize generated directories, update `tsconfig.json` exclusions to the resolved cache, helper-crate target, output, and public-asset paths. Otherwise a broad include such as `**/*` can make Astro/TypeScript analyze generated JavaScript such as Pyodide instead of treating it as output.

--- a/examples/docs-site/content/docs/guides/project-configuration.mdx
+++ b/examples/docs-site/content/docs/guides/project-configuration.mdx
@@ -36,6 +36,7 @@ export const collections = createOxiquillCollections({ defineCollection, docsLoa
 | Field                             | Meaning                                                                                                              |
 | --------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
 | `title`, `description`, `sidebar` | Shorthand for the corresponding Starlight settings.                                                                  |
+| `desktopTableOfContentsToggle`    | Enables the persistent desktop table-of-contents control. Defaults to `true`.                                        |
 | `starlight`                       | Any other Starlight option. A value here overrides the matching shorthand.                                           |
 | `framework.starlight`             | Required Starlight integration factory imported from `@astrojs/starlight`.                                           |
 | `framework.preact`                | Optional Preact integration-factory override for embedded/framework consumers.                                       |
@@ -49,6 +50,22 @@ export const collections = createOxiquillCollections({ defineCollection, docsLoa
 Use `oxiquillIntegration()` only when composing an Astro configuration manually. It accepts `base`, `markdown`, `paths`, `python`, and `vite`; the caller is then responsible for adding Preact and Starlight.
 
 Oxiquill owns `markdown.processor` because interactive cells, Mermaid, KaTeX, and public-asset base paths require its unified pipeline. A custom processor is not supported and throws a `TypeError`; configure supported Markdown fields and append `remarkPlugins` or `rehypePlugins` instead.
+
+## Desktop Table of Contents
+
+On pages with a table of contents, Oxiquill adds a desktop collapse/expand button while preserving Starlight's mobile disclosure. Collapsing the table of contents removes the complete right column and lets the main content use the released width. The preference is stored for the current browser tab in `sessionStorage` under `oxiquill-table-of-contents-collapsed`; it is independent from the left-sidebar preference.
+
+Set `desktopTableOfContentsToggle: false` to retain Starlight's always-visible desktop table of contents:
+
+```js
+export default defineOxiquillConfig({
+  desktopTableOfContentsToggle: false,
+  framework: { starlight },
+  title: 'My Docs'
+});
+```
+
+The control is not rendered for `tableOfContents: false` or splash pages. Consumer entries in `starlight.components` take precedence over Oxiquill's defaults, including `PageFrame`, `TableOfContents`, and `TwoColumnContent` overrides.
 
 ## Path Fields
 

--- a/examples/docs-site/content/docs/guides/project-configuration.mdx
+++ b/examples/docs-site/content/docs/guides/project-configuration.mdx
@@ -8,9 +8,11 @@ Oxiquill loads one project configuration and uses the same resolved paths for de
 ## Minimal Configuration
 
 ```js
+import starlight from '@astrojs/starlight';
 import { defineOxiquillConfig } from 'oxiquill/astro';
 
 export default defineOxiquillConfig({
+  framework: { starlight },
   site: 'https://example.com',
   title: 'My Docs',
   sidebar: [{ label: 'Overview', items: [{ label: 'Home', slug: 'index' }] }]
@@ -19,26 +21,34 @@ export default defineOxiquillConfig({
 
 ```ts
 // content.config.ts
-export { collections } from 'oxiquill/content';
+import { defineCollection } from 'astro:content';
+import { docsLoader } from '@astrojs/starlight/loaders';
+import { docsSchema } from '@astrojs/starlight/schema';
+import { createOxiquillCollections } from 'oxiquill/content';
+
+export const collections = createOxiquillCollections({ defineCollection, docsLoader, docsSchema });
 ```
 
 `defineOxiquillConfig()` returns an Astro configuration with static output, Oxiquill's Markdown transforms, Preact, and Starlight already installed.
 
 ## Configuration Fields
 
-| Field                                     | Meaning                                                                                                              |
-| ----------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
-| `title`, `description`, `sidebar`         | Shorthand for the corresponding Starlight settings.                                                                  |
-| `starlight`                               | Any other Starlight option. A value here overrides the matching shorthand.                                           |
-| `framework.preact`, `framework.starlight` | Advanced integration-factory overrides used by embedded/framework consumers.                                         |
-| `integrations`                            | Additional Astro integrations, appended after Oxiquill, Preact, and Starlight.                                       |
-| `markdown`                                | Additional Astro Markdown settings and plugins. Oxiquill's required plugins run first.                               |
-| `vite`                                    | Additional Vite settings. Oxiquill preserves required aliases, deduplication, worker plugins, and filesystem access. |
-| `paths`                                   | Oxiquill-owned source, cache, generated, and public paths described below.                                           |
-| `python`                                  | Pyodide download behavior: `offline` and the optional `packageMirror`.                                               |
-| Other Astro fields                        | Passed through to Astro. Oxiquill always produces static output.                                                     |
+| Field                             | Meaning                                                                                                              |
+| --------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| `title`, `description`, `sidebar` | Shorthand for the corresponding Starlight settings.                                                                  |
+| `starlight`                       | Any other Starlight option. A value here overrides the matching shorthand.                                           |
+| `framework.starlight`             | Required Starlight integration factory imported from `@astrojs/starlight`.                                           |
+| `framework.preact`                | Optional Preact integration-factory override for embedded/framework consumers.                                       |
+| `integrations`                    | Additional Astro integrations, appended after Oxiquill, Preact, and Starlight.                                       |
+| `markdown`                        | Supported Astro Markdown settings and plugins. Oxiquill's required plugins run first.                                |
+| `vite`                            | Additional Vite settings. Oxiquill preserves required aliases, deduplication, worker plugins, and filesystem access. |
+| `paths`                           | Oxiquill-owned source, cache, generated, and public paths described below.                                           |
+| `python`                          | Pyodide download behavior: `offline` and the optional `packageMirror`.                                               |
+| Other Astro fields                | Passed through to Astro. Oxiquill always produces static output.                                                     |
 
 Use `oxiquillIntegration()` only when composing an Astro configuration manually. It accepts `base`, `markdown`, `paths`, `python`, and `vite`; the caller is then responsible for adding Preact and Starlight.
+
+Oxiquill owns `markdown.processor` because interactive cells, Mermaid, KaTeX, and public-asset base paths require its unified pipeline. A custom processor is not supported and throws a `TypeError`; configure supported Markdown fields and append `remarkPlugins` or `rehypePlugins` instead.
 
 ## Path Fields
 

--- a/examples/docs-site/content/docs/guides/python-runtime.mdx
+++ b/examples/docs-site/content/docs/guides/python-runtime.mdx
@@ -33,12 +33,12 @@ Downloads use this sequence:
 
 1. Check the versioned Oxiquill download cache.
 2. Verify a cached file against its expected SHA-256 before use.
-3. If it is missing or corrupt and offline mode is disabled, download to a temporary file.
-4. Apply a 30-second timeout and make no more than three total attempts with bounded backoff.
-5. Verify the completed temporary file, then atomically place it in the cache.
-6. Copy the verified artifact into the resolved public Pyodide directory.
+3. If it is missing or corrupt and offline mode is disabled, stream the response to a uniquely named temporary file while incrementally calculating SHA-256.
+4. Process at most four core files and wheels concurrently. Retries remain inside the same worker slot, use a 30-second timeout, and make no more than three total attempts with bounded backoff.
+5. Verify the completed temporary file, then atomically claim its cache name. Concurrent generators reuse the verified winner instead of overwriting it with partial content.
+6. After every required cache entry is verified, copy artifacts into the resolved public Pyodide directory in deterministic order.
 
-A hash mismatch is always fatal for that source. Oxiquill never publishes or caches an unverified partial response.
+A hash mismatch is always fatal for that source. A failed, interrupted, or aborted operation removes its temporary files. Oxiquill never publishes or caches an unverified partial response, and public staging does not begin until every required cache entry is ready.
 
 ## Cache Behavior
 

--- a/examples/docs-site/content/docs/guides/support-and-security.mdx
+++ b/examples/docs-site/content/docs/guides/support-and-security.mdx
@@ -36,9 +36,11 @@ Image data is passed to browser image decoders. SVG is rendered in image context
 
 ## Sandboxed HTML
 
-HTML artifacts render in an iframe with an empty `sandbox` attribute. The frame intentionally receives no `allow-scripts`, `allow-same-origin`, `allow-forms`, `allow-popups`, `allow-top-navigation`, or download permission. It therefore cannot execute script, access the parent DOM or same-origin storage/cookies, submit forms, open popups, or navigate the top-level page.
+HTML artifacts render in an iframe with an empty `sandbox` attribute and `referrerPolicy="no-referrer"`. The frame intentionally receives no `allow-scripts`, `allow-same-origin`, `allow-forms`, `allow-popups`, `allow-top-navigation`, or download permission. It therefore cannot execute script, access the parent DOM or same-origin storage/cookies, submit forms, open popups, initiate downloads, or navigate the top-level page.
 
-The sandbox is not an HTML sanitizer. Passive subresources and links may still cause network requests, and browser parsing still processes the supplied markup. Prefer typed text, JSON, table, chart, or image artifacts; publish HTML only from reviewed authors.
+Oxiquill prepends a Content Security Policy to `srcdoc`: `default-src 'none'; img-src data: blob:; media-src data: blob:; style-src 'unsafe-inline'; font-src data:; base-uri 'none'; form-action 'none'`. This blocks HTTP(S) and other external subresource requests while retaining inline styles and data/blob images or media needed by reviewed presentation artifacts. The explicit base/form directives prevent markup from changing URL resolution or selecting a form destination. The iframe policy also suppresses referrers.
+
+The sandbox and CSP are isolation controls, not HTML sanitization. The browser still parses supplied markup, and a user can still interact with ordinary content such as text or links within the isolated frame. Prefer typed text, JSON, table, chart, or image artifacts; publish HTML only from reviewed authors.
 
 ## Reporting Security Issues
 

--- a/examples/docs-site/content/docs/guides/troubleshooting.mdx
+++ b/examples/docs-site/content/docs/guides/troubleshooting.mdx
@@ -45,7 +45,11 @@ Start with the first Oxiquill diagnostic. Generation errors include the relevant
 
 If different commands appear to use different directories, pass the same `--config <path>` and inspect the conflicting field named by the diagnostic. Relative child paths resolve against their documented parent. Do not combine Astro and `paths` values that normalize to different locations.
 
-`clean` refuses broad or unsafe targets. Fix the configuration instead of deleting the workspace manually.
+`clean` reports the unsafe field, its absolute resolved path, and the conflicting path role. Move the cleanup root to a dedicated generated directory when it overlaps authored input, the public root, project or repository metadata, dependencies, the framework, the persistent download cache, or another generated role. Symlink aliases do not bypass these checks.
+
+If a custom root reports a missing or mismatched `.oxiquill-ownership.json`, do not manufacture the marker. Preserve or move any authored files, select a missing or empty dedicated directory, and rerun the corresponding generation or build command so Oxiquill can establish ownership. An old custom output created before ownership markers must be reviewed and emptied explicitly before it can be claimed.
+
+Clean preflights all three targets before deleting any of them. A diagnostic for one target therefore leaves the other generated roots, authored files, repository/dependency state, and `.cache/oxiquill/downloads/v1` untouched. Fix the reported configuration or ownership problem, then rerun `pnpm clean`.
 
 ## Worker Timeouts and Browser Failures
 
@@ -55,6 +59,6 @@ For browser failures, verify the site was rebuilt, the expected files exist belo
 
 ## Stale Output
 
-Run `pnpm clean` followed by the required generation/build command when source and public output disagree. Generated ownership data removes stale language output when the final cell of that language disappears. Never repair generated manifests, Wasm, Pyodide files, licenses, or `dist` by hand.
+Run `pnpm clean` followed by the required generation/build command when source and public output disagree. Generated ownership data removes stale language output when the final cell of that language disappears. Never repair generated manifests, ownership markers, Wasm, Pyodide files, licenses, or `dist` by hand.
 
 If the problem persists, open a [GitHub issue](https://github.com/kakune/oxiquill/issues) with the Oxiquill/Node/tool versions, operating system, command, complete concise diagnostic, and a minimal reproducer. Use private vulnerability reporting for security-sensitive details.

--- a/examples/docs-site/content/docs/ja/features/interactive-cells.mdx
+++ b/examples/docs-site/content/docs/ja/features/interactive-cells.mdx
@@ -91,6 +91,7 @@ visible `label` が control の accessible name で、input key は generated la
 //|   r: { type: range, label: r, min: 0, max: 4, step: 0.01, value: 3.2 }
 //|   x0: { type: range, label: x0, min: 0, max: 1, step: 0.01, value: 0.2 }
 //|   steps: { type: integer, label: steps, min: 10, max: 300, step: 10, value: 120 }
+let steps = u32::try_from(steps).map_err(|_| "steps must be non-negative".to_owned())?;
 let points = doc_rust::logistic_series(r, x0, steps).map_err(|error| error.to_string())?;
 
 for point in points.iter().take(5) {

--- a/examples/docs-site/content/docs/ja/features/interactive-cells.mdx
+++ b/examples/docs-site/content/docs/ja/features/interactive-cells.mdx
@@ -56,7 +56,7 @@ println!("button value = {value}");
 println!("autorun ready");
 ```
 
-superseded queued work は破棄され、stale result が新しい state を上書きしません。通常の reactive update は shared language worker を維持します。timeout/worker fault はその worker 所有 request を reject し timer を除去して、次回用 fresh worker を作ります。unmount は pending UI work を cancel し、late state update を防ぎます。
+reactive run が supersede されると、その worker request を active に cancel し、worker recycle の影響を受ける全 request を reject して timer を除去します。debounce 後は最新の complete value だけを実行します。cancellation は execution error として表示されず、stale result は新しい state を上書きしません。timeout/worker fault も同じ deterministic recycle boundary で回復します。unmount は pending/active work を cancel します。
 
 ## Input schema
 
@@ -65,12 +65,16 @@ superseded queued work は破棄され、stale result が新しい state を上�
 | Type               | Value と constraint                                                                               |
 | ------------------ | ------------------------------------------------------------------------------------------------- |
 | `range`, `number`  | finite number。`step > 0`、`min <= max`、default が bound 内。                                    |
-| `integer`          | integer value と integer bound/step。同じ numeric constraint。                                    |
+| `integer`          | `-2147483648` 以上 `2147483647` 以下の signed 32-bit integer。bound/step も同じ domain。          |
 | `text`, `textarea` | string value。                                                                                    |
 | `checkbox`         | boolean value。                                                                                   |
 | `select`, `radio`  | non-empty unique string option または `{ label, value }` object。default は option value と一致。 |
 
 `type` の default は `text`、`label` の default は input name です。`description` は control と assistive technology 向けに関連付ける optional non-empty string です。default value は checkbox が `false`、numeric input が `0`、text input が空 string です。numeric 専用 field は non-numeric control で拒否され、`options` は `select`/`radio` 以外では使えません。
+
+signed 32-bit integer domain は JavaScript で正確に表現でき、Rust `i32`、Haskell `Int`、Python `int` に同じ値として渡されます。domain 外の integer `value`、`min`、`max`、`step` は authoring 時に拒否されます。browser control と worker request も、`integer: true` の numeric input を含めて同じ domain を適用します。
+
+number/integer control は raw edit text と committed runtime value を分離します。空、入力途中、non-finite、range 外、step 不一致の text は表示を保ちますが cell input を更新しません。どれか一つでも invalid なら Run button は disabled になり、reactive execution は validity が戻った後に最新の complete value set を一度だけ実行します。range label の表示精度は `step` から決まります。
 
 visible `label` が control の accessible name で、input key は generated language binding にだけ使います。normalization で二つの Rust/Haskell binding が衝突してはなりません。label、description、current value、validation message、grouped control は stable ID で関連付けられ、keyboard focus を表示し、run/error status は focus を奪わず announce されます。
 
@@ -110,9 +114,9 @@ emit_line_plot!(&points, "n", "x");
 //|   operation: { type: select, label: operation, value: double, options: [identity, double, triple] }
 //|   style: { type: radio, label: style, value: compact, options: [compact, verbose] }
 let base_score = match operation.as_str() {
-    "triple" => 21_u32,
-    "double" => 14_u32,
-    _ => 7_u32,
+    "triple" => 21_i32,
+    "double" => 14_i32,
+    _ => 7_i32,
 };
 let score = if include_bonus {
     base_score + 5

--- a/examples/docs-site/content/docs/ja/features/rich-output.mdx
+++ b/examples/docs-site/content/docs/ja/features/rich-output.mdx
@@ -134,3 +134,5 @@ emit_html!(r#"<p><strong>Sandboxed HTML</strong> emitted from Rust.</p>"#);
 短い説明文には stdout を使います。正確な構造を見せたい場合は JSON、比較可能な record には table、傾向や分布には chart、生成された視覚情報には image、他の artifact で表せない markup には sandboxed HTML を使います。
 
 copy、sort、pagination、validation、running、completion、failure state は keyboard 操作可能で、localized English/Japanese label とともに announce されます。sandboxed HTML には意図的に script/same-origin permission がありません。trust boundary は [サポートとセキュリティ](/ja/guides/support-and-security/) を参照してください。
+
+table interaction state は一つの execution result に限定されます。新しい result では page、sort、copy status を reset します。同じ result の rerender は互換性のある sort/page を維持しますが、row が減った場合は clamp 後の page を保存し、sort 対象 column が削除・置換された場合は sort を解除します。

--- a/examples/docs-site/content/docs/ja/features/rich-output.mdx
+++ b/examples/docs-site/content/docs/ja/features/rich-output.mdx
@@ -27,35 +27,49 @@ Oxiquill は次の出力を表示します。
 | `table` | `columns`、rectangular `rows`                                  | `rowCount` が original size、`truncated` が preview を示します。                                   |
 | `chart` | 下記の valid `spec`                                            | oversize/invalid chart は local artifact error。                                                   |
 | `image` | `mime: image/png \| image/jpeg \| image/svg+xml`、valid data   | `alt` が image alternative。                                                                       |
-| `html`  | `html: string`, `sandboxed: true`                              | empty sandbox permission の iframe 内に常に表示。                                                  |
+| `html`  | `html: string`, `sandboxed: true`                              | empty sandbox、no-referrer、下記の restrictive CSP で表示。                                        |
 
 table column は `key`、`label`、optional `type` を持ちます。type は `string`、`number`、`integer`、`boolean`、`date`、`datetime`、`null`、`unknown` です。各 row は declared column count と正確に一致する必要があります。
 
 ## Chart schema
 
-すべての chart spec は optional `title`、`xLabel`、`yLabel`、`xType`、`yType`、`legend`、`tooltip`、`dataZoom` を受け取ります。axis type は `value`、`category`、`time`、`log` です。
+すべての chart spec は optional `title`、`xLabel`、`yLabel`、`xType`、`yType`、`legend`、`tooltip`、`dataZoom` を受け取ります。axis type は `value`、`category`、`time`、`log` です。未指定 axis は `value` が default ですが、bar/histogram 固有の category axis と、対応する categories array を持つ heatmap axis は `category` になります。
+
+- `value` coordinate は finite number、`log` coordinate は 0 より大きい finite number です。
+- `time` coordinate は finite epoch millisecond、または `YYYY-MM-DDTHH:mm:ss[.sss]Z` / `YYYY-MM-DDTHH:mm:ss[.sss]±HH:mm` 形式の ISO-8601 string です。calendar field と明示的な time zone も valid である必要があります。
+- `category` coordinate は string または finite number です。heatmap が `xCategories` / `yCategories` を持つ場合は、listed string または範囲内の zero-based integer index に限定されます。categories array を宣言した axis は category になり、矛盾する axis type は reject されます。
 
 - `line`、`scatter`、`area`: optional `name` と `[x, y]` point を持つ `series[]`。
 - `bar`: string `categories[]` と同じ length の numeric-or-null `values[]` series。
-- `histogram`: finite `[lower, upper, count]` tuple の `bins[]`。
+- `histogram`: `lower < upper` かつ count が non-negative の finite `[lower, upper, count]` tuple の `bins[]`。
 - `heatmap`: optional `xCategories`/`yCategories` と finite `[x, y, value]` cell。
 
-chart は textual title/caption と bounded accessible summary または equivalent table を提供します。equivalent がある場合、implementation canvas は accessibility API から隠されます。
+empty chart と equal point domain は valid です。heatmap は X、Y、heat value の範囲を別々に示し、color scale には実際の heat value を使います。empty dataset だけは `0–1` を fallback にします。chart は textual title/caption と bounded accessible summary または equivalent table を提供します。equivalent がある場合、implementation canvas は accessibility API から隠されます。
+
+chart は現在の Starlight light/dark theme に合わせた contrast-aware color を使い、`html[data-theme]` の変更時に ECharts instance を作り直します。一時的な renderer load failure の後には retry action を表示します。
 
 ## Resource limit
 
-limit は validation 後に適用され、各 run で累積します。
+producer は各 language worker 内で `postMessage` より前に limit を適用し、main thread でも bounded response を独立して再検証します。limit は UTF-8 byte 単位で、記載のものは run ごとに累積します。
 
 | Resource                    | Limit                      | 超過時                                                      |
 | --------------------------- | -------------------------- | ----------------------------------------------------------- |
 | Artifact                    | 1 run 100個                | 追加 artifact を local reject。                             |
+| stdout / stderr             | stream ごとに 1 MiB        | limit までだけ保持し、truncated として表示。                |
 | Text、serialized JSON、HTML | artifact ごとに 1 MiB      | Text/JSON は `truncated: true` 可、HTML は reject。         |
 | Table                       | 10,000 row、100 column     | bounded table は `truncated: true` と `rowCount` を使用可。 |
 | Chart                       | 合計100,000 point/bin/cell | artifact-local error。                                      |
 | Image                       | decoded 10 MiB             | artifact-local error。                                      |
 | 全 validated output         | 1 run 16 MiB               | remaining budget を超える artifact を local reject。        |
+| complete worker response    | 16 MiB                     | worker から page へ渡す前に後続 artifact を省略。           |
+| worker error                | 16 KiB                     | UTF-8 message を truncate。                                 |
+| artifact diagnostic         | 1件 8 KiB、1 run 64 KiB    | 各 limit 内で diagnostic を truncate。                      |
 
-`truncated: true` を使えるのは text、JSON、table だけです。chart、image、HTML は黙って truncate しません。invalid/cyclic/over-deep JSON、ragged table、non-finite chart value、invalid base64/MIME pair、unsafe structural record が cell component を crash させることはありません。
+`truncated: true` を使えるのは text、JSON、table だけです。chart、image、HTML は黙って truncate しません。invalid/cyclic/over-deep JSON、ragged table、non-finite chart value、invalid base64/MIME pair、unsafe structural record が cell component を crash させることはありません。legacy の `stdout`、`stderr`、`value`、`plots` alias は validated/bounded `outputs` から再生成され、raw alias が別の unbounded payload を保持することはありません。
+
+## CSV copy の安全性
+
+default table action は表示中の row を spreadsheet-safe CSV として copy します。最初の meaningful character が `=`、`+`、`-`、`@`、tab、carriage return の string header/cell には、RFC-style の comma/quote/line-break escape より前に apostrophe を付けます。この決定的な規則により、一般的な spreadsheet application が string data を formula として評価することを防ぎます。数値は変更しないため、実際の number `-42` は `-42` のままです。
 
 ## Python display helper
 
@@ -133,6 +147,6 @@ emit_html!(r#"<p><strong>Sandboxed HTML</strong> emitted from Rust.</p>"#);
 
 短い説明文には stdout を使います。正確な構造を見せたい場合は JSON、比較可能な record には table、傾向や分布には chart、生成された視覚情報には image、他の artifact で表せない markup には sandboxed HTML を使います。
 
-copy、sort、pagination、validation、running、completion、failure state は keyboard 操作可能で、localized English/Japanese label とともに announce されます。sandboxed HTML には意図的に script/same-origin permission がありません。trust boundary は [サポートとセキュリティ](/ja/guides/support-and-security/) を参照してください。
+copy、sort、pagination、validation、running、completion、failure state は keyboard 操作可能で、localized English/Japanese label とともに announce されます。sandboxed HTML には意図的に script/same-origin permission がなく、referrer を送らず、external subresource を default で block します。正確な policy と trust boundary は [サポートとセキュリティ](/ja/guides/support-and-security/) を参照してください。
 
 table interaction state は一つの execution result に限定されます。新しい result では page、sort、copy status を reset します。同じ result の rerender は互換性のある sort/page を維持しますが、row が減った場合は clamp 後の page を保存し、sort 対象 column が削除・置換された場合は sort を解除します。

--- a/examples/docs-site/content/docs/ja/guides/authoring.mdx
+++ b/examples/docs-site/content/docs/ja/guides/authoring.mdx
@@ -32,6 +32,12 @@ Write the body here.
 
 日本語翻訳は英語版と同じ route と大まかな構成を保ちます。一字一句同じ訳である必要はありませんが、同じ動作と例を扱います。
 
+## ページの目次を選ぶ
+
+通常のページには Starlight の目次が表示されます。desktop では右列を折りたたむことができ、Oxiquill は現在の browser tab でその選択を記憶します。mobile では Starlight の既存 disclosure をそのまま使います。
+
+目次も desktop control も不要なページでは、frontmatter に `tableOfContents: false` を指定します。Starlight の splash page でも両方が自動的に省略されます。このページ単位の設定は、desktop collapse control だけを有効・無効にする project-wide の `desktopTableOfContentsToggle` option とは別です。
+
 ## Rust セルを書く
 
 Rust セルは `rust` の fenced code block で、先頭に `//|` または `///|` metadata comment を置きます。metadata comment は cell の先頭から連続させ、source code が始まった後の option comment 風の行は source code のままにします。`id` は lowercase kebab-case でページ内一意にします。英語版と日本語版は同じ local `id` を使えます。build が page-scoped internal ID を作ります。

--- a/examples/docs-site/content/docs/ja/guides/authoring.mdx
+++ b/examples/docs-site/content/docs/ja/guides/authoring.mdx
@@ -101,6 +101,8 @@ standard library module だけを使います。Haskell セルでは外部 packa
 
 top-level ではこれらの field だけを指定できます。dependency array は重複のない空でない string で構成します。対応 input type は `range`、`number`、`integer`、`text`、`textarea`、`checkbox`、`select`、`radio` です。input field、default、constraint、option schema の正確な仕様は[実行可能セル](../../features/interactive-cells/)を参照してください。
 
+integer metadata の portable domain は `-2147483648` 以上 `2147483647` 以下の signed 32-bit です。この制限は `value`、`min`、`max`、`step` に適用され、generated Rust/Haskell/Python binding に同じ正確な integer を渡します。
+
 ## 数式を追加する
 
 inline math は `$...$`、block math は `$$...$$` で書きます。

--- a/examples/docs-site/content/docs/ja/guides/project-configuration.mdx
+++ b/examples/docs-site/content/docs/ja/guides/project-configuration.mdx
@@ -8,9 +8,11 @@ Oxiquill は一つの project config を読み込み、development、check、gen
 ## 最小構成
 
 ```js
+import starlight from '@astrojs/starlight';
 import { defineOxiquillConfig } from 'oxiquill/astro';
 
 export default defineOxiquillConfig({
+  framework: { starlight },
   site: 'https://example.com',
   title: 'My Docs',
   sidebar: [{ label: 'Overview', items: [{ label: 'Home', slug: 'index' }] }]
@@ -19,26 +21,34 @@ export default defineOxiquillConfig({
 
 ```ts
 // content.config.ts
-export { collections } from 'oxiquill/content';
+import { defineCollection } from 'astro:content';
+import { docsLoader } from '@astrojs/starlight/loaders';
+import { docsSchema } from '@astrojs/starlight/schema';
+import { createOxiquillCollections } from 'oxiquill/content';
+
+export const collections = createOxiquillCollections({ defineCollection, docsLoader, docsSchema });
 ```
 
 `defineOxiquillConfig()` は static output、Oxiquill の Markdown transform、Preact、Starlight を設定済みの Astro config を返します。
 
 ## 設定 field
 
-| Field                                     | 意味                                                                                       |
-| ----------------------------------------- | ------------------------------------------------------------------------------------------ |
-| `title`, `description`, `sidebar`         | 対応する Starlight setting の shorthand。                                                  |
-| `starlight`                               | その他の Starlight option。同じ setting はこちらが shorthand より優先されます。            |
-| `framework.preact`, `framework.starlight` | 組み込み用途向けの高度な integration-factory override。                                    |
-| `integrations`                            | Oxiquill、Preact、Starlight の後に追加する Astro integration。                             |
-| `markdown`                                | 追加の Astro Markdown setting/plugin。Oxiquill 必須 plugin が先に動きます。                |
-| `vite`                                    | 追加の Vite setting。必須 alias、dedupe、worker plugin、filesystem access は保持されます。 |
-| `paths`                                   | 下記の source/cache/generated/public path。                                                |
-| `python`                                  | Pyodide download の `offline` と optional `packageMirror`。                                |
-| その他の Astro field                      | Astro に渡されます。Oxiquill の output は常に static です。                                |
+| Field                             | 意味                                                                                       |
+| --------------------------------- | ------------------------------------------------------------------------------------------ |
+| `title`, `description`, `sidebar` | 対応する Starlight setting の shorthand。                                                  |
+| `starlight`                       | その他の Starlight option。同じ setting はこちらが shorthand より優先されます。            |
+| `framework.starlight`             | `@astrojs/starlight` から import する必須の Starlight integration factory。                |
+| `framework.preact`                | 組み込み用途向けの optional Preact integration-factory override。                          |
+| `integrations`                    | Oxiquill、Preact、Starlight の後に追加する Astro integration。                             |
+| `markdown`                        | 対応する Astro Markdown setting/plugin。Oxiquill 必須 plugin が先に動きます。              |
+| `vite`                            | 追加の Vite setting。必須 alias、dedupe、worker plugin、filesystem access は保持されます。 |
+| `paths`                           | 下記の source/cache/generated/public path。                                                |
+| `python`                          | Pyodide download の `offline` と optional `packageMirror`。                                |
+| その他の Astro field              | Astro に渡されます。Oxiquill の output は常に static です。                                |
 
 Astro config を手動で組み立てる場合だけ `oxiquillIntegration()` を使います。受け取る option は `base`、`markdown`、`paths`、`python`、`vite` で、Preact と Starlight は caller が追加します。
+
+interactive cell、Mermaid、KaTeX、public-asset base path には Oxiquill の unified pipeline が必要なため、`markdown.processor` は Oxiquill が管理します。custom processor は未対応で `TypeError` になり、代わりに対応する Markdown field と追加の `remarkPlugins` / `rehypePlugins` を設定します。
 
 ## Path field
 

--- a/examples/docs-site/content/docs/ja/guides/project-configuration.mdx
+++ b/examples/docs-site/content/docs/ja/guides/project-configuration.mdx
@@ -88,7 +88,15 @@ export default defineOxiquillConfig({
 4. Consumer の Markdown、Vite、CSS、component、integration の追加は Oxiquill 必須 entry の後に保持されます。
 5. path の競合、Oxiquill integration の欠落・重複、config 読み込み失敗は generation/clean より前に失敗します。
 
-Oxiquill-owned output に project root や広すぎる directory を指定しないでください。`oxiquill clean` は検証済みの resolved generated path と設定済み Astro output だけを削除します。`downloadCacheDir` は意図的に保持され、clean 対象の output path の外側でなければなりません。
+## Clean の ownership と安全性
+
+`oxiquill clean` が再帰削除する resolved root は `cacheDir`、Astro の `outDir`、`publicAssetsDir` の3つだけです。`downloadCacheDir` は削除しません。default の verified download cache `.cache/oxiquill/downloads/v1` は clean 後も残り、次の generation で再利用できます。
+
+default の `.oxiquill`、`dist`、`public/oxiquill` は生成専用 location として予約され、ownership marker がなくても clean できます。custom cleanup root では、対応する generation/build lifecycle が存在しないか空の directory を claim し、`.oxiquill-ownership.json` を書きます。matching marker のない既存の non-empty custom directory を生成物とは推測しません。marker を手動で作成・編集しないでください。
+
+再帰削除する root はすべて `workspaceRoot` 内になければなりません。cleanup root 同士は disjoint であり、`docsDir`、`cratesDir`、`publicDir`、`frameworkRoot`、選択した Astro config、認識済み project config/manifest/lock file、persistent download cache、`.git` や `node_modules` など検出した VCS/package-installation state とも重複できません。generated child role 同士の重複も拒否します。authored/generated の包含で許可する唯一の例外は、`publicAssetsDir` が `publicDir` の厳密な子である関係です。`publicDir` と同一にはできず、別の authored public subtree の内側にも置けません。
+
+Oxiquill は比較・削除前に既存 path と symlink ancestor を canonicalize します。clean は最初の再帰削除より前に全 root と全 ownership marker を検証します。unsafe/unowned root が一つでもあれば何も削除せず、diagnostic に field、absolute resolved path、conflicting path role、corrective action を示します。
 
 ## Runtime fingerprint
 
@@ -98,6 +106,6 @@ runtime fingerprint には machine-local path ではなく semantic build input 
 
 subpath 配下へ公開するときは Astro の `base` を設定します。Oxiquill は interactive-cell manifest、language runtime、diagram、`/media/...` reference に適用します。authoring では public URL を root-relative のまま記述し、Markdown transform が base を一度だけ追加します。
 
-生成 runtime は `.oxiquill` と `public/oxiquill`、verified download cache は `.cache/oxiquill/downloads/v1`、最終 static site は Astro の `outDir`（通常 `dist`）に置かれます。生成 directory を直接編集しないでください。download cache は build や output 再生成をまたいで保持できますが、file は利用前に毎回検証されます。
+生成 runtime は `.oxiquill` と `public/oxiquill`、verified download cache は `.cache/oxiquill/downloads/v1`、最終 static site は Astro の `outDir`（通常 `dist`）に置かれます。生成 directory と ownership marker を直接編集しないでください。download cache は build や output 再生成をまたいで保持できますが、file は利用前に毎回検証されます。
 
 生成 directory を変更するときは、resolved cache、helper-crate target、output、public-asset path に合わせて `tsconfig.json` の exclusion も更新します。そうしないと `**/*` のような広い include により、Astro/TypeScript が Pyodide などの生成 JavaScript を output ではなく source として解析することがあります。

--- a/examples/docs-site/content/docs/ja/guides/project-configuration.mdx
+++ b/examples/docs-site/content/docs/ja/guides/project-configuration.mdx
@@ -36,6 +36,7 @@ export const collections = createOxiquillCollections({ defineCollection, docsLoa
 | Field                             | 意味                                                                                       |
 | --------------------------------- | ------------------------------------------------------------------------------------------ |
 | `title`, `description`, `sidebar` | 対応する Starlight setting の shorthand。                                                  |
+| `desktopTableOfContentsToggle`    | 永続化される desktop 目次 control を有効にします。default は `true` です。                 |
 | `starlight`                       | その他の Starlight option。同じ setting はこちらが shorthand より優先されます。            |
 | `framework.starlight`             | `@astrojs/starlight` から import する必須の Starlight integration factory。                |
 | `framework.preact`                | 組み込み用途向けの optional Preact integration-factory override。                          |
@@ -49,6 +50,22 @@ export const collections = createOxiquillCollections({ defineCollection, docsLoa
 Astro config を手動で組み立てる場合だけ `oxiquillIntegration()` を使います。受け取る option は `base`、`markdown`、`paths`、`python`、`vite` で、Preact と Starlight は caller が追加します。
 
 interactive cell、Mermaid、KaTeX、public-asset base path には Oxiquill の unified pipeline が必要なため、`markdown.processor` は Oxiquill が管理します。custom processor は未対応で `TypeError` になり、代わりに対応する Markdown field と追加の `remarkPlugins` / `rehypePlugins` を設定します。
+
+## Desktop の目次
+
+目次があるページでは、Starlight の mobile disclosure を保ったまま、Oxiquill が desktop 用の折りたたみ・展開 button を追加します。目次を折りたたむと右列全体がなくなり、main content が空いた幅を使います。設定は現在の browser tab の `sessionStorage` に `oxiquill-table-of-contents-collapsed` key で保存され、左 sidebar の設定とは独立しています。
+
+Starlight の常時表示 desktop 目次を維持するには `desktopTableOfContentsToggle: false` を設定します。
+
+```js
+export default defineOxiquillConfig({
+  desktopTableOfContentsToggle: false,
+  framework: { starlight },
+  title: 'My Docs'
+});
+```
+
+`tableOfContents: false` のページと splash page には control を出力しません。`starlight.components` に consumer が指定した entry は Oxiquill の default より優先され、`PageFrame`、`TableOfContents`、`TwoColumnContent` の override も保持されます。
 
 ## Path field
 

--- a/examples/docs-site/content/docs/ja/guides/python-runtime.mdx
+++ b/examples/docs-site/content/docs/ja/guides/python-runtime.mdx
@@ -33,12 +33,12 @@ download は次の順序で行います。
 
 1. versioned Oxiquill download cache を確認します。
 2. cached file を expected SHA-256 で検証します。
-3. missing/corrupt で offline mode が無効なら temporary file に download します。
-4. 30秒 timeout と bounded backoff を使い、試行は合計3回までです。
-5. completed temporary file を検証してから cache へ atomic に配置します。
-6. verified artifact を resolved public Pyodide directory へ copy します。
+3. missing/corrupt で offline mode が無効なら、response を uniquely named temporary file へ stream しながら SHA-256 を incremental に計算します。
+4. core file と wheel は同時に最大4件まで処理します。retry は同じ worker slot 内で行い、30秒 timeout と bounded backoff を使って試行は合計3回までです。
+5. completed temporary file を検証してから cache name を atomic に claim します。複数の generator が同時に動く場合、loser は partial content で上書きせず verified winner を再利用します。
+6. 必要な cache entry をすべて検証した後、artifact を deterministic な順序で resolved public Pyodide directory へ copy します。
 
-hash mismatch は常にその source の fatal error です。未検証の partial response を publish/cache することはありません。
+hash mismatch は常にその source の fatal error です。failed/interrupted/aborted operation は temporary file を削除します。未検証の partial response を publish/cache せず、必要な cache entry がすべて揃うまで public staging を開始しません。
 
 ## Cache の動作
 

--- a/examples/docs-site/content/docs/ja/guides/support-and-security.mdx
+++ b/examples/docs-site/content/docs/ja/guides/support-and-security.mdx
@@ -36,9 +36,11 @@ image data は browser image decoder に渡されます。SVG は page DOM に i
 
 ## Sandboxed HTML
 
-HTML artifact は空の `sandbox` attribute を持つ iframe 内で表示します。`allow-scripts`、`allow-same-origin`、`allow-forms`、`allow-popups`、`allow-top-navigation`、download permission は与えません。そのため script 実行、parent DOM や same-origin storage/cookie への access、form submit、popup、top-level navigation はできません。
+HTML artifact は空の `sandbox` attribute と `referrerPolicy="no-referrer"` を持つ iframe 内で表示します。`allow-scripts`、`allow-same-origin`、`allow-forms`、`allow-popups`、`allow-top-navigation`、download permission は与えません。そのため script 実行、parent DOM や same-origin storage/cookie への access、form submit、popup、download 開始、top-level navigation はできません。
 
-sandbox は HTML sanitizer ではありません。passive subresource/link が network request を発生させることがあり、browser parser は markup を処理します。可能なら typed text、JSON、table、chart、image artifact を使い、HTML は reviewed author からだけ公開してください。
+Oxiquill は `srcdoc` の先頭に `default-src 'none'; img-src data: blob:; media-src data: blob:; style-src 'unsafe-inline'; font-src data:; base-uri 'none'; form-action 'none'` という Content Security Policy を追加します。reviewed presentation artifact に必要な inline style と data/blob image/media だけを残し、HTTP(S) などの external subresource request を block します。明示的な base/form directive により、markup は URL resolution や form destination を変更できません。iframe policy は referrer も抑止します。
+
+sandbox と CSP は isolation control であり、HTML sanitization ではありません。browser は supplied markup を引き続き parse し、user は isolated frame 内の text/link など通常の content を操作できます。可能なら typed text、JSON、table、chart、image artifact を使い、HTML は reviewed author からだけ公開してください。
 
 ## Security issue の報告
 

--- a/examples/docs-site/content/docs/ja/guides/troubleshooting.mdx
+++ b/examples/docs-site/content/docs/ja/guides/troubleshooting.mdx
@@ -45,7 +45,11 @@ description: install、config、runtime generation、download、timeout、stale 
 
 command ごとに別 directory を使うように見える場合、同じ `--config <path>` を渡し、diagnostic が示す conflicting field を確認します。relative child path は documented parent から解決されます。Astro と `paths` に正規化後の location が異なる値を組み合わせないでください。
 
-`clean` は broad/unsafe target を拒否します。workspace を手動削除せず config を修正してください。
+`clean` は unsafe field、absolute resolved path、conflicting path role を報告します。cleanup root が authored input、public root、project/repository metadata、dependency、framework、persistent download cache、別の generated role と重なる場合は、生成専用 directory へ移してください。symlink alias でも検証を迂回できません。
+
+custom root で `.oxiquill-ownership.json` の欠落・不一致が報告された場合、marker を手動作成しないでください。authored file を保持または移動し、存在しないか空の生成専用 directory を選んで、対応する generation/build command を再実行すると Oxiquill が ownership を確立します。ownership marker 導入前に作られた古い custom output は、内容を確認して明示的に空にしてから claim してください。
+
+clean は削除前に3つの target をすべて preflight します。そのため、一つの target の diagnostic が出ても、他の generated root、authored file、repository/dependency state、`.cache/oxiquill/downloads/v1` は変更されません。報告された config/ownership を修正してから `pnpm clean` を再実行します。
 
 ## Worker timeout と browser failure
 
@@ -55,6 +59,6 @@ browser failure では site rebuild、`public/oxiquill` 下の expected file、d
 
 ## Stale output
 
-source と public output が一致しない場合は `pnpm clean` 後に必要な generation/build command を実行します。generated ownership data は最後の cell が消えた language の stale output を除去します。manifest、Wasm、Pyodide file、license、`dist` を手動修正しないでください。
+source と public output が一致しない場合は `pnpm clean` 後に必要な generation/build command を実行します。generated ownership data は最後の cell が消えた language の stale output を除去します。manifest、ownership marker、Wasm、Pyodide file、license、`dist` を手動修正しないでください。
 
 解決しない場合は [GitHub issue](https://github.com/kakune/oxiquill/issues) に Oxiquill/Node/tool version、OS、command、完全で簡潔な diagnostic、minimal reproducer を添えてください。security-sensitive detail は private vulnerability reporting を使います。

--- a/examples/docs-site/content/docs/ja/reference/package-api.mdx
+++ b/examples/docs-site/content/docs/ja/reference/package-api.mdx
@@ -7,19 +7,19 @@ Oxiquill は ESM-only です。`node_modules/oxiquill` 配下の file を直接 
 
 ## Export
 
-| Export                                    | Public API                                                                                                                                                                |
-| ----------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `oxiquill`                                | `defineOxiquillConfig`, `oxiquillIntegration`                                                                                                                             |
+| Export                                    | Public API                                                                                                                                                                 |
+| ----------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `oxiquill`                                | `defineOxiquillConfig`, `oxiquillIntegration`                                                                                                                              |
 | `oxiquill/astro`                          | 同じ function と `OxiquillConfig`、`OxiquillIntegrationOptions`、`OxiquillFrameworkOptions`、`OxiquillMarkdownConfig`、`OxiquillPathOptions`、`OxiquillPythonOptions` type |
-| `oxiquill/content`                        | `createOxiquillCollections` と `OxiquillContentDependencies`、`OxiquillCollections` type                                                                                  |
-| `oxiquill/runtime/InteractiveCell`        | interactive-cell remark transform が使う Preact component                                                                                                                 |
-| `oxiquill/runtime/MermaidDiagram`         | Mermaid remark transform が使う Preact renderer                                                                                                                           |
-| `oxiquill/runtime/types`                  | cell manifest、input、worker message、artifact、table、chart の TypeScript type                                                                                           |
-| `oxiquill/components/starlight/PageFrame` | Oxiquill の Starlight page-frame override                                                                                                                                 |
-| `oxiquill/styles/katex.css`               | default integration が読み込む KaTeX style                                                                                                                                |
-| `oxiquill/styles/custom.css`              | runtime、output、media、page-frame の style                                                                                                                               |
-| `oxiquill/tsconfigs/strict`               | consumer project 用 strict TypeScript base config                                                                                                                         |
-| `oxiquill/env`                            | Oxiquill virtual module と asset import の ambient declaration                                                                                                            |
+| `oxiquill/content`                        | `createOxiquillCollections` と `OxiquillContentDependencies`、`OxiquillCollections` type                                                                                   |
+| `oxiquill/runtime/InteractiveCell`        | interactive-cell remark transform が使う Preact component                                                                                                                  |
+| `oxiquill/runtime/MermaidDiagram`         | Mermaid remark transform が使う Preact renderer                                                                                                                            |
+| `oxiquill/runtime/types`                  | cell manifest、input、worker message、artifact、table、chart の TypeScript type                                                                                            |
+| `oxiquill/components/starlight/PageFrame` | Oxiquill の Starlight page-frame override                                                                                                                                  |
+| `oxiquill/styles/katex.css`               | default integration が読み込む KaTeX style                                                                                                                                 |
+| `oxiquill/styles/custom.css`              | runtime、output、media、page-frame の style                                                                                                                                |
+| `oxiquill/tsconfigs/strict`               | consumer project 用 strict TypeScript base config                                                                                                                          |
+| `oxiquill/env`                            | Oxiquill virtual module と asset import の ambient declaration                                                                                                             |
 
 component、style、environment export は高度な composition 用の public API です。通常の project では `defineOxiquillConfig()` が読み込むため、手動 import は不要です。
 

--- a/examples/docs-site/content/docs/ja/reference/package-api.mdx
+++ b/examples/docs-site/content/docs/ja/reference/package-api.mdx
@@ -7,39 +7,44 @@ Oxiquill は ESM-only です。`node_modules/oxiquill` 配下の file を直接 
 
 ## Export
 
-| Export                                    | Public API                                                                                                                                       |
-| ----------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `oxiquill`                                | `defineOxiquillConfig`, `oxiquillIntegration`                                                                                                    |
-| `oxiquill/astro`                          | 同じ function と `OxiquillConfig`、`OxiquillIntegrationOptions`、`OxiquillFrameworkOptions`、`OxiquillPathOptions`、`OxiquillPythonOptions` type |
-| `oxiquill/content`                        | そのまま使える `collections` と高度な `createOxiquillCollections`、関連 type                                                                     |
-| `oxiquill/runtime/InteractiveCell`        | interactive-cell remark transform が使う Preact component                                                                                        |
-| `oxiquill/runtime/MermaidDiagram`         | Mermaid remark transform が使う Preact renderer                                                                                                  |
-| `oxiquill/runtime/types`                  | cell manifest、input、worker message、artifact、table、chart の TypeScript type                                                                  |
-| `oxiquill/components/starlight/PageFrame` | Oxiquill の Starlight page-frame override                                                                                                        |
-| `oxiquill/styles/katex.css`               | default integration が読み込む KaTeX style                                                                                                       |
-| `oxiquill/styles/custom.css`              | runtime、output、media、page-frame の style                                                                                                      |
-| `oxiquill/tsconfigs/strict`               | consumer project 用 strict TypeScript base config                                                                                                |
-| `oxiquill/env`                            | Oxiquill virtual module と asset import の ambient declaration                                                                                   |
+| Export                                    | Public API                                                                                                                                                                |
+| ----------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `oxiquill`                                | `defineOxiquillConfig`, `oxiquillIntegration`                                                                                                                             |
+| `oxiquill/astro`                          | 同じ function と `OxiquillConfig`、`OxiquillIntegrationOptions`、`OxiquillFrameworkOptions`、`OxiquillMarkdownConfig`、`OxiquillPathOptions`、`OxiquillPythonOptions` type |
+| `oxiquill/content`                        | `createOxiquillCollections` と `OxiquillContentDependencies`、`OxiquillCollections` type                                                                                  |
+| `oxiquill/runtime/InteractiveCell`        | interactive-cell remark transform が使う Preact component                                                                                                                 |
+| `oxiquill/runtime/MermaidDiagram`         | Mermaid remark transform が使う Preact renderer                                                                                                                           |
+| `oxiquill/runtime/types`                  | cell manifest、input、worker message、artifact、table、chart の TypeScript type                                                                                           |
+| `oxiquill/components/starlight/PageFrame` | Oxiquill の Starlight page-frame override                                                                                                                                 |
+| `oxiquill/styles/katex.css`               | default integration が読み込む KaTeX style                                                                                                                                |
+| `oxiquill/styles/custom.css`              | runtime、output、media、page-frame の style                                                                                                                               |
+| `oxiquill/tsconfigs/strict`               | consumer project 用 strict TypeScript base config                                                                                                                         |
+| `oxiquill/env`                            | Oxiquill virtual module と asset import の ambient declaration                                                                                                            |
 
 component、style、environment export は高度な composition 用の public API です。通常の project では `defineOxiquillConfig()` が読み込むため、手動 import は不要です。
 
 ## Astro API
 
-完全な site には `defineOxiquillConfig(options)` を使います。Oxiquill integration、Preact、Starlight の順に追加し、その後に consumer integration を追加します。field と優先順位は [プロジェクト設定](/ja/guides/project-configuration/) を参照してください。
+完全な site には `defineOxiquillConfig(options)` を使い、必須の `framework.starlight` integration factory を渡します。Oxiquill integration、Preact、Starlight の順に追加し、その後に consumer integration を追加します。field と優先順位は [プロジェクト設定](/ja/guides/project-configuration/) を参照してください。
 
 手動で Astro config を組み立てる場合だけ `oxiquillIntegration(options)` を使います。Markdown transform、virtual module、runtime generation、Wasm build、Vite resolution、license output を提供しますが、Preact と Starlight は自動追加しません。
 
-不正な framework integration factory は `TypeError` になります。config load や path conflict は生成 file を書く前に失敗します。
+不正な framework integration factory と未対応の custom Markdown processor は `TypeError` になります。config load や path conflict は生成 file を書く前に失敗します。
 
 ## Content API
 
-通常は ready collection を再 export します。
+通常は dependency-injected API で Starlight docs collection を作ります。
 
 ```ts
-export { collections } from 'oxiquill/content';
+import { defineCollection } from 'astro:content';
+import { docsLoader } from '@astrojs/starlight/loaders';
+import { docsSchema } from '@astrojs/starlight/schema';
+import { createOxiquillCollections } from 'oxiquill/content';
+
+export const collections = createOxiquillCollections({ defineCollection, docsLoader, docsSchema });
 ```
 
-`createOxiquillCollections({ defineCollection, docsLoader, docsSchema })` は、互換 Astro/Starlight function を注入する test/host 用です。Starlight loader/schema を使う `{ docs }` を返します。
+`createOxiquillCollections({ defineCollection, docsLoader, docsSchema })` が通常の content API です。注入された Starlight loader/schema を使う `{ docs }` を返します。
 
 ## Runtime type
 

--- a/examples/docs-site/content/docs/ja/reference/package-api.mdx
+++ b/examples/docs-site/content/docs/ja/reference/package-api.mdx
@@ -7,19 +7,20 @@ Oxiquill は ESM-only です。`node_modules/oxiquill` 配下の file を直接 
 
 ## Export
 
-| Export                                    | Public API                                                                                                                                                                 |
-| ----------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `oxiquill`                                | `defineOxiquillConfig`, `oxiquillIntegration`                                                                                                                              |
-| `oxiquill/astro`                          | 同じ function と `OxiquillConfig`、`OxiquillIntegrationOptions`、`OxiquillFrameworkOptions`、`OxiquillMarkdownConfig`、`OxiquillPathOptions`、`OxiquillPythonOptions` type |
-| `oxiquill/content`                        | `createOxiquillCollections` と `OxiquillContentDependencies`、`OxiquillCollections` type                                                                                   |
-| `oxiquill/runtime/InteractiveCell`        | interactive-cell remark transform が使う Preact component                                                                                                                  |
-| `oxiquill/runtime/MermaidDiagram`         | Mermaid remark transform が使う Preact renderer                                                                                                                            |
-| `oxiquill/runtime/types`                  | cell manifest、input、worker message、artifact、table、chart の TypeScript type                                                                                            |
-| `oxiquill/components/starlight/PageFrame` | Oxiquill の Starlight page-frame override                                                                                                                                  |
-| `oxiquill/styles/katex.css`               | default integration が読み込む KaTeX style                                                                                                                                 |
-| `oxiquill/styles/custom.css`              | runtime、output、media、page-frame の style                                                                                                                                |
-| `oxiquill/tsconfigs/strict`               | consumer project 用 strict TypeScript base config                                                                                                                          |
-| `oxiquill/env`                            | Oxiquill virtual module と asset import の ambient declaration                                                                                                             |
+| Export                                           | Public API                                                                                                                                                                 |
+| ------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `oxiquill`                                       | `defineOxiquillConfig`, `oxiquillIntegration`                                                                                                                              |
+| `oxiquill/astro`                                 | 同じ function と `OxiquillConfig`、`OxiquillIntegrationOptions`、`OxiquillFrameworkOptions`、`OxiquillMarkdownConfig`、`OxiquillPathOptions`、`OxiquillPythonOptions` type |
+| `oxiquill/content`                               | `createOxiquillCollections` と `OxiquillContentDependencies`、`OxiquillCollections` type                                                                                   |
+| `oxiquill/runtime/InteractiveCell`               | interactive-cell remark transform が使う Preact component                                                                                                                  |
+| `oxiquill/runtime/MermaidDiagram`                | Mermaid remark transform が使う Preact renderer                                                                                                                            |
+| `oxiquill/runtime/types`                         | cell manifest、input、worker message、artifact、table、chart の TypeScript type                                                                                            |
+| `oxiquill/components/starlight/PageFrame`        | Oxiquill の Starlight page-frame override                                                                                                                                  |
+| `oxiquill/components/starlight/TwoColumnContent` | Oxiquill の折りたたみ可能な desktop 目次 layout override                                                                                                                   |
+| `oxiquill/styles/katex.css`                      | default integration が読み込む KaTeX style                                                                                                                                 |
+| `oxiquill/styles/custom.css`                     | runtime、output、media、page-frame の style                                                                                                                                |
+| `oxiquill/tsconfigs/strict`                      | consumer project 用 strict TypeScript base config                                                                                                                          |
+| `oxiquill/env`                                   | Oxiquill virtual module と asset import の ambient declaration                                                                                                             |
 
 component、style、environment export は高度な composition 用の public API です。通常の project では `defineOxiquillConfig()` が読み込むため、手動 import は不要です。
 

--- a/examples/docs-site/content/docs/ja/samples/logistic-map.mdx
+++ b/examples/docs-site/content/docs/ja/samples/logistic-map.mdx
@@ -31,6 +31,7 @@ $$
 //|   r: { type: range, label: r, min: 0, max: 4, step: 0.01, value: 3.2 }
 //|   x0: { type: range, label: x0, min: 0, max: 1, step: 0.01, value: 0.2 }
 //|   steps: { type: integer, label: steps, min: 10, max: 300, step: 10, value: 120 }
+let steps = u32::try_from(steps).map_err(|_| "steps must be non-negative".to_owned())?;
 let points = doc_rust::logistic_series(r, x0, steps).map_err(|error| error.to_string())?;
 let final_point = points.last().ok_or_else(|| "series is empty".to_owned())?;
 

--- a/examples/docs-site/content/docs/ja/tests/no-table-of-contents.mdx
+++ b/examples/docs-site/content/docs/ja/tests/no-table-of-contents.mdx
@@ -1,0 +1,11 @@
+---
+title: 目次なしテストページ
+description: 目次を無効にしたページ用のブラウザテスト fixture です。
+tableOfContents: false
+---
+
+このページでは、Starlight が目次を無効にしたときに desktop 目次 control が出力されないことを検証します。
+
+## 目次に表示されない見出し
+
+この見出しでは desktop control も mobile disclosure も有効になりません。

--- a/examples/docs-site/content/docs/ja/tests/splash.mdx
+++ b/examples/docs-site/content/docs/ja/tests/splash.mdx
@@ -1,0 +1,9 @@
+---
+title: Splash テストページ
+description: Starlight splash template 用のブラウザテスト fixture です。
+template: splash
+hero:
+  tagline: Splash page は目次を表示しません。
+---
+
+このページでは splash layout に desktop 目次 control が出力されないことを検証します。

--- a/examples/docs-site/content/docs/reference/package-api.mdx
+++ b/examples/docs-site/content/docs/reference/package-api.mdx
@@ -7,39 +7,44 @@ Oxiquill is ESM-only. Use the package export map instead of importing files belo
 
 ## Exports
 
-| Export                                    | Public API                                                                                                                                                   |
-| ----------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `oxiquill`                                | `defineOxiquillConfig`, `oxiquillIntegration`                                                                                                                |
-| `oxiquill/astro`                          | The same functions plus `OxiquillConfig`, `OxiquillIntegrationOptions`, `OxiquillFrameworkOptions`, `OxiquillPathOptions`, and `OxiquillPythonOptions` types |
-| `oxiquill/content`                        | Ready-to-use `collections` and advanced `createOxiquillCollections` with their dependency/collection types                                                   |
-| `oxiquill/runtime/InteractiveCell`        | Preact component used by the interactive-cell remark transform                                                                                               |
-| `oxiquill/runtime/MermaidDiagram`         | Preact Mermaid renderer used by the Mermaid remark transform                                                                                                 |
-| `oxiquill/runtime/types`                  | Cell manifest, input, worker message, artifact, table, and chart TypeScript types                                                                            |
-| `oxiquill/components/starlight/PageFrame` | Oxiquill's Starlight page-frame override                                                                                                                     |
-| `oxiquill/styles/katex.css`               | KaTeX styles loaded by the default integration                                                                                                               |
-| `oxiquill/styles/custom.css`              | Oxiquill runtime, output, media, and page-frame styles                                                                                                       |
-| `oxiquill/tsconfigs/strict`               | Strict TypeScript base config for consumer projects                                                                                                          |
-| `oxiquill/env`                            | Ambient declarations for Oxiquill virtual modules and asset imports                                                                                          |
+| Export                                    | Public API                                                                                                                                                                             |
+| ----------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `oxiquill`                                | `defineOxiquillConfig`, `oxiquillIntegration`                                                                                                                                          |
+| `oxiquill/astro`                          | The same functions plus `OxiquillConfig`, `OxiquillIntegrationOptions`, `OxiquillFrameworkOptions`, `OxiquillMarkdownConfig`, `OxiquillPathOptions`, and `OxiquillPythonOptions` types |
+| `oxiquill/content`                        | `createOxiquillCollections` with `OxiquillContentDependencies` and `OxiquillCollections` types                                                                                         |
+| `oxiquill/runtime/InteractiveCell`        | Preact component used by the interactive-cell remark transform                                                                                                                         |
+| `oxiquill/runtime/MermaidDiagram`         | Preact Mermaid renderer used by the Mermaid remark transform                                                                                                                           |
+| `oxiquill/runtime/types`                  | Cell manifest, input, worker message, artifact, table, and chart TypeScript types                                                                                                      |
+| `oxiquill/components/starlight/PageFrame` | Oxiquill's Starlight page-frame override                                                                                                                                               |
+| `oxiquill/styles/katex.css`               | KaTeX styles loaded by the default integration                                                                                                                                         |
+| `oxiquill/styles/custom.css`              | Oxiquill runtime, output, media, and page-frame styles                                                                                                                                 |
+| `oxiquill/tsconfigs/strict`               | Strict TypeScript base config for consumer projects                                                                                                                                    |
+| `oxiquill/env`                            | Ambient declarations for Oxiquill virtual modules and asset imports                                                                                                                    |
 
 The component, style, and environment exports are public for advanced composition, but a normal project gets them through `defineOxiquillConfig()` and should not import them manually.
 
 ## Astro API
 
-Use `defineOxiquillConfig(options)` for a complete site. It installs the Oxiquill integration before Preact and Starlight, then appends consumer integrations. See [Project Configuration](/guides/project-configuration/) for fields and precedence.
+Use `defineOxiquillConfig(options)` for a complete site. Pass the required `framework.starlight` integration factory; Oxiquill installs its integration before Preact and Starlight, then appends consumer integrations. See [Project Configuration](/guides/project-configuration/) for fields and precedence.
 
 Use `oxiquillIntegration(options)` only in a manually composed Astro config. It provides Markdown transforms, virtual modules, runtime generation, Wasm builds, Vite resolution, and license output, but it does not add Preact or Starlight for you.
 
-Invalid framework integration factories throw a `TypeError`. Configuration loading and path conflicts fail before generated files are written.
+Invalid framework integration factories and unsupported custom Markdown processors throw a `TypeError`. Configuration loading and path conflicts fail before generated files are written.
 
 ## Content API
 
-Most sites should re-export the ready collection:
+Most sites should create the Starlight docs collection with the dependency-injected API:
 
 ```ts
-export { collections } from 'oxiquill/content';
+import { defineCollection } from 'astro:content';
+import { docsLoader } from '@astrojs/starlight/loaders';
+import { docsSchema } from '@astrojs/starlight/schema';
+import { createOxiquillCollections } from 'oxiquill/content';
+
+export const collections = createOxiquillCollections({ defineCollection, docsLoader, docsSchema });
 ```
 
-`createOxiquillCollections({ defineCollection, docsLoader, docsSchema })` exists for tests or hosts that must inject compatible Astro/Starlight functions. It returns `{ docs }` using Starlight's loader and schema.
+`createOxiquillCollections({ defineCollection, docsLoader, docsSchema })` is the normal content API. It returns `{ docs }` using the injected Starlight loader and schema.
 
 ## Runtime Types
 

--- a/examples/docs-site/content/docs/reference/package-api.mdx
+++ b/examples/docs-site/content/docs/reference/package-api.mdx
@@ -7,19 +7,20 @@ Oxiquill is ESM-only. Use the package export map instead of importing files belo
 
 ## Exports
 
-| Export                                    | Public API                                                                                                                                                                             |
-| ----------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `oxiquill`                                | `defineOxiquillConfig`, `oxiquillIntegration`                                                                                                                                          |
-| `oxiquill/astro`                          | The same functions plus `OxiquillConfig`, `OxiquillIntegrationOptions`, `OxiquillFrameworkOptions`, `OxiquillMarkdownConfig`, `OxiquillPathOptions`, and `OxiquillPythonOptions` types |
-| `oxiquill/content`                        | `createOxiquillCollections` with `OxiquillContentDependencies` and `OxiquillCollections` types                                                                                         |
-| `oxiquill/runtime/InteractiveCell`        | Preact component used by the interactive-cell remark transform                                                                                                                         |
-| `oxiquill/runtime/MermaidDiagram`         | Preact Mermaid renderer used by the Mermaid remark transform                                                                                                                           |
-| `oxiquill/runtime/types`                  | Cell manifest, input, worker message, artifact, table, and chart TypeScript types                                                                                                      |
-| `oxiquill/components/starlight/PageFrame` | Oxiquill's Starlight page-frame override                                                                                                                                               |
-| `oxiquill/styles/katex.css`               | KaTeX styles loaded by the default integration                                                                                                                                         |
-| `oxiquill/styles/custom.css`              | Oxiquill runtime, output, media, and page-frame styles                                                                                                                                 |
-| `oxiquill/tsconfigs/strict`               | Strict TypeScript base config for consumer projects                                                                                                                                    |
-| `oxiquill/env`                            | Ambient declarations for Oxiquill virtual modules and asset imports                                                                                                                    |
+| Export                                           | Public API                                                                                                                                                                             |
+| ------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `oxiquill`                                       | `defineOxiquillConfig`, `oxiquillIntegration`                                                                                                                                          |
+| `oxiquill/astro`                                 | The same functions plus `OxiquillConfig`, `OxiquillIntegrationOptions`, `OxiquillFrameworkOptions`, `OxiquillMarkdownConfig`, `OxiquillPathOptions`, and `OxiquillPythonOptions` types |
+| `oxiquill/content`                               | `createOxiquillCollections` with `OxiquillContentDependencies` and `OxiquillCollections` types                                                                                         |
+| `oxiquill/runtime/InteractiveCell`               | Preact component used by the interactive-cell remark transform                                                                                                                         |
+| `oxiquill/runtime/MermaidDiagram`                | Preact Mermaid renderer used by the Mermaid remark transform                                                                                                                           |
+| `oxiquill/runtime/types`                         | Cell manifest, input, worker message, artifact, table, and chart TypeScript types                                                                                                      |
+| `oxiquill/components/starlight/PageFrame`        | Oxiquill's Starlight page-frame override                                                                                                                                               |
+| `oxiquill/components/starlight/TwoColumnContent` | Oxiquill's collapsible desktop table-of-contents layout override                                                                                                                       |
+| `oxiquill/styles/katex.css`                      | KaTeX styles loaded by the default integration                                                                                                                                         |
+| `oxiquill/styles/custom.css`                     | Oxiquill runtime, output, media, and page-frame styles                                                                                                                                 |
+| `oxiquill/tsconfigs/strict`                      | Strict TypeScript base config for consumer projects                                                                                                                                    |
+| `oxiquill/env`                                   | Ambient declarations for Oxiquill virtual modules and asset imports                                                                                                                    |
 
 The component, style, and environment exports are public for advanced composition, but a normal project gets them through `defineOxiquillConfig()` and should not import them manually.
 

--- a/examples/docs-site/content/docs/samples/logistic-map.mdx
+++ b/examples/docs-site/content/docs/samples/logistic-map.mdx
@@ -31,6 +31,7 @@ Here, $x_n$ is the state at step $n$, and `r` is the growth rate. Changing `r` o
 //|   r: { type: range, label: r, min: 0, max: 4, step: 0.01, value: 3.2 }
 //|   x0: { type: range, label: x0, min: 0, max: 1, step: 0.01, value: 0.2 }
 //|   steps: { type: integer, label: steps, min: 10, max: 300, step: 10, value: 120 }
+let steps = u32::try_from(steps).map_err(|_| "steps must be non-negative".to_owned())?;
 let points = doc_rust::logistic_series(r, x0, steps).map_err(|error| error.to_string())?;
 let final_point = points.last().ok_or_else(|| "series is empty".to_owned())?;
 

--- a/examples/docs-site/content/docs/tests/no-table-of-contents.mdx
+++ b/examples/docs-site/content/docs/tests/no-table-of-contents.mdx
@@ -1,0 +1,11 @@
+---
+title: No Table of Contents Test Page
+description: Browser fixture for pages with the table of contents disabled.
+tableOfContents: false
+---
+
+This page verifies that the desktop table-of-contents control is omitted when Starlight disables the table of contents.
+
+## Hidden From the Table of Contents
+
+This heading must not activate either the desktop control or the mobile disclosure.

--- a/examples/docs-site/content/docs/tests/splash.mdx
+++ b/examples/docs-site/content/docs/tests/splash.mdx
@@ -1,0 +1,9 @@
+---
+title: Splash Test Page
+description: Browser fixture for the Starlight splash template.
+template: splash
+hero:
+  tagline: Splash pages do not render a table of contents.
+---
+
+This page verifies that the desktop table-of-contents control is omitted from splash layouts.

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "test:wasm": "pnpm build:package && pnpm --dir examples/docs-site test:wasm",
     "test:e2e": "pnpm build:package && playwright test",
     "test:bundle": "node tests/bundle/client-bundle.mjs",
-    "test:docs": "node tests/docs/check-documentation.mjs",
+    "test:docs": "pnpm build:package && node tests/docs/check-documentation.mjs",
     "lint:package": "pnpm build:package && publint packages/oxiquill && attw packages/oxiquill --pack --profile esm-only --entrypoints . ./astro ./content ./runtime/InteractiveCell ./runtime/MermaidDiagram ./runtime/types ./env",
     "test:package": "node tests/package/package-contents.mjs && pnpm lint:package",
     "test:consumer": "pnpm test:consumer:npm && pnpm test:consumer:pnpm",

--- a/packages/oxiquill/README.md
+++ b/packages/oxiquill/README.md
@@ -69,6 +69,8 @@ export const collections = createOxiquillCollections({ defineCollection, docsLoa
 
 Write pages under `content/docs`. Generated internals go under `.oxiquill`, browser assets go under `public/oxiquill`, and the static build normally goes under `dist`. Verified Pyodide downloads are cached under `.cache/oxiquill/downloads/v1`; `oxiquill clean` preserves that cache so later online or offline generation can reconstruct the public runtime.
 
+On desktop, pages with a table of contents include an accessible collapse control that releases the complete right column. The per-tab preference is stored independently from the left sidebar. Set `desktopTableOfContentsToggle: false` in `defineOxiquillConfig()` to keep Starlight's desktop table of contents always visible; mobile, splash, and `tableOfContents: false` behavior is unchanged.
+
 Static projects need only Node.js and a package manager. Rust cells additionally need the pinned Rust toolchain and `wasm-pack`; Haskell generation needs `wasm32-wasi-ghc` on Linux or macOS. Generated sites run in current Chromium, Firefox, and WebKit.
 
 ## Documentation and Support

--- a/packages/oxiquill/package.json
+++ b/packages/oxiquill/package.json
@@ -108,6 +108,7 @@
     "remark-mdx": "3.1.1",
     "remark-parse": "11.0.0",
     "shiki": "4.4.3",
+    "smol-toml": "1.8.0",
     "typescript": "6.0.3",
     "unified": "11.0.5",
     "vite": "8.2.2",

--- a/packages/oxiquill/package.json
+++ b/packages/oxiquill/package.json
@@ -65,6 +65,7 @@
       "default": "./dist/lib/doc-runtime/types.js"
     },
     "./components/starlight/PageFrame": "./dist/components/starlight/PageFrame.astro",
+    "./components/starlight/TwoColumnContent": "./dist/components/starlight/TwoColumnContent.astro",
     "./styles/katex.css": "./dist/styles/katex.css",
     "./styles/custom.css": "./dist/styles/custom.css",
     "./tsconfigs/strict": "./dist/tsconfigs/strict.json",

--- a/packages/oxiquill/scripts/copy-package-assets.mjs
+++ b/packages/oxiquill/scripts/copy-package-assets.mjs
@@ -5,6 +5,7 @@ import { fileURLToPath } from 'node:url';
 const packageRoot = fileURLToPath(new URL('../', import.meta.url));
 const assetFiles = [
   ['src/components/starlight/PageFrame.astro', 'dist/components/starlight/PageFrame.astro'],
+  ['src/components/starlight/TwoColumnContent.astro', 'dist/components/starlight/TwoColumnContent.astro'],
   ['src/env.d.ts', 'dist/env.d.ts'],
   ['src/styles/custom.css', 'dist/styles/custom.css'],
   ['src/styles/katex.css', 'dist/styles/katex.css'],

--- a/packages/oxiquill/src/astro/index.ts
+++ b/packages/oxiquill/src/astro/index.ts
@@ -418,8 +418,15 @@ function mergeMarkdownConfig(
   paths: OxiquillPaths,
   markdown: OxiquillMarkdownConfig
 ) {
-  const { gfm, rehypePlugins = [], remarkRehype, remarkPlugins = [], smartypants, syntaxHighlight, ...markdownRest } =
-    markdown;
+  const {
+    gfm,
+    rehypePlugins = [],
+    remarkRehype,
+    remarkPlugins = [],
+    smartypants,
+    syntaxHighlight,
+    ...markdownRest
+  } = markdown;
 
   return {
     ...markdownRest,

--- a/packages/oxiquill/src/astro/index.ts
+++ b/packages/oxiquill/src/astro/index.ts
@@ -33,6 +33,7 @@ import {
   syncLicenseArtifacts
 } from '../generator/doc-runtime-service.mjs';
 import { createBrowserBundleCollector, syncBrowserBundleReport } from '../generator/browser-bundle-report.mjs';
+import { maintainCleanupOwnership, prepareCleanupOwnership } from '../generator/cleanup-ownership.mjs';
 import remarkInteractiveCells from '../lib/doc-runtime/remark-interactive-cells.mjs';
 import remarkMermaidDiagrams from '../lib/doc-runtime/remark-mermaid-diagrams.mjs';
 import remarkPublicAssetBase from '../lib/doc-runtime/remark-public-asset-base.mjs';
@@ -243,6 +244,7 @@ function createOxiquillIntegration(
   const metadata = createOxiquillIntegrationMetadata({ astro: astroOptions, paths: pathOptions, python });
   let paths: OxiquillPaths | undefined;
   let pythonOptions: Readonly<{ offline: boolean; packageMirror?: string }> | undefined;
+  let buildOwnership: Awaited<ReturnType<typeof prepareCleanupOwnership>> = Object.freeze([]);
   const bundledModules = createBundledModuleCollector();
   const browserBundle = createBrowserBundleCollector();
 
@@ -300,6 +302,7 @@ function createOxiquillIntegration(
       'astro:build:start': async () => {
         if (!paths) return;
 
+        buildOwnership = await prepareCleanupOwnership({ paths });
         bundledModules.reset();
         browserBundle.reset();
         if (process.env.OXIQUILL_RUNTIME_OWNER === 'cli') return;
@@ -321,6 +324,7 @@ function createOxiquillIntegration(
           outputDirectory: dir,
           workspaceRoot: paths.workspaceRoot
         });
+        await maintainCleanupOwnership({ ownership: buildOwnership });
       }
     }
   };

--- a/packages/oxiquill/src/astro/index.ts
+++ b/packages/oxiquill/src/astro/index.ts
@@ -126,6 +126,7 @@ export interface OxiquillConfig<StarlightOptions extends object = object> extend
   'integrations' | 'markdown' | 'vite'
 > {
   description?: StarlightOption<StarlightOptions, 'description', string>;
+  desktopTableOfContentsToggle?: boolean;
   framework: OxiquillFrameworkOptions<StarlightOptions>;
   integrations?: AstroIntegrations;
   markdown?: OxiquillMarkdownConfig;
@@ -165,6 +166,7 @@ export function defineOxiquillConfig<StarlightOptions extends object>(
     paths,
     python,
     description,
+    desktopTableOfContentsToggle = true,
     sidebar,
     starlight: starlightOptions = {},
     title,
@@ -202,7 +204,10 @@ export function defineOxiquillConfig<StarlightOptions extends object>(
     integrations: [
       integration,
       preactIntegration(undefined),
-      callStarlightIntegration(starlightIntegration, createStarlightOptions(mergedStarlightOptions)),
+      callStarlightIntegration(
+        starlightIntegration,
+        createStarlightOptions(mergedStarlightOptions, desktopTableOfContentsToggle)
+      ),
       ...integrations
     ]
   };
@@ -387,7 +392,10 @@ function callStarlightIntegration<StarlightOptions extends object>(
   return (integration as unknown as IntegrationFactory<OxiquillStarlightOptions>)(options);
 }
 
-function createStarlightOptions(options: OxiquillStarlightOptions): OxiquillStarlightOptions {
+function createStarlightOptions(
+  options: OxiquillStarlightOptions,
+  desktopTableOfContentsToggle: boolean
+): OxiquillStarlightOptions {
   const {
     components = {},
     customCss = [],
@@ -403,6 +411,7 @@ function createStarlightOptions(options: OxiquillStarlightOptions): OxiquillStar
     customCss: ['oxiquill/styles/katex.css', 'oxiquill/styles/custom.css', ...customCss],
     components: {
       PageFrame: 'oxiquill/components/starlight/PageFrame',
+      ...(desktopTableOfContentsToggle ? { TwoColumnContent: 'oxiquill/components/starlight/TwoColumnContent' } : {}),
       ...components
     }
   };

--- a/packages/oxiquill/src/astro/index.ts
+++ b/packages/oxiquill/src/astro/index.ts
@@ -105,6 +105,10 @@ export interface OxiquillPythonOptions {
   packageMirror?: string | URL;
 }
 
+export type OxiquillMarkdownConfig = Omit<AstroMarkdownConfig, 'processor'> & {
+  processor?: never;
+};
+
 interface OxiquillStarlightOptions {
   components?: Record<string, string>;
   customCss?: string[];
@@ -121,7 +125,7 @@ export interface OxiquillConfig<StarlightOptions extends object = object> extend
   description?: StarlightOption<StarlightOptions, 'description', string>;
   framework: OxiquillFrameworkOptions<StarlightOptions>;
   integrations?: AstroIntegrations;
-  markdown?: AstroMarkdownConfig;
+  markdown?: OxiquillMarkdownConfig;
   paths?: OxiquillPathOptions;
   python?: OxiquillPythonOptions;
   sidebar?: StarlightOption<StarlightOptions, 'sidebar', unknown>;
@@ -132,7 +136,7 @@ export interface OxiquillConfig<StarlightOptions extends object = object> extend
 
 export interface OxiquillIntegrationOptions {
   base?: BaseAstroUserConfig['base'];
-  markdown?: AstroMarkdownConfig;
+  markdown?: OxiquillMarkdownConfig;
   paths?: OxiquillPathOptions;
   python?: OxiquillPythonOptions;
   vite?: ViteUserConfig;
@@ -241,6 +245,7 @@ function createOxiquillIntegration(
   { base, markdown = {}, paths: pathOptions, python, vite = {} }: OxiquillIntegrationOptions = {},
   astroOptions: Record<string, string | URL> = {}
 ): AstroIntegration {
+  rejectCustomMarkdownProcessor(markdown);
   const metadata = createOxiquillIntegrationMetadata({ astro: astroOptions, paths: pathOptions, python });
   let paths: OxiquillPaths | undefined;
   let pythonOptions: Readonly<{ offline: boolean; packageMirror?: string }> | undefined;
@@ -400,46 +405,52 @@ function createStarlightOptions(options: OxiquillStarlightOptions): OxiquillStar
   };
 }
 
-function mergeMarkdownConfig(base: BaseAstroUserConfig['base'], paths: OxiquillPaths, markdown: AstroMarkdownConfig) {
-  const {
-    gfm,
-    processor,
-    rehypePlugins = [],
-    remarkRehype,
-    remarkPlugins = [],
-    smartypants,
-    syntaxHighlight,
-    ...markdownRest
-  } = markdown;
-  const syntaxHighlightOptions = syntaxHighlightConfig(syntaxHighlight);
+function rejectCustomMarkdownProcessor(markdown: OxiquillMarkdownConfig): void {
+  if ((markdown as AstroMarkdownConfig).processor === undefined) return;
+
+  throw new TypeError(
+    'Oxiquill does not support markdown.processor because it owns the Markdown processor pipeline required for its transforms.'
+  );
+}
+
+function mergeMarkdownConfig(
+  base: BaseAstroUserConfig['base'],
+  paths: OxiquillPaths,
+  markdown: OxiquillMarkdownConfig
+) {
+  const { gfm, rehypePlugins = [], remarkRehype, remarkPlugins = [], smartypants, syntaxHighlight, ...markdownRest } =
+    markdown;
 
   return {
     ...markdownRest,
-    processor:
-      processor ??
-      unified({
-        gfm,
-        rehypePlugins: [rehypeKatex, ...rehypePlugins],
-        remarkPlugins: [
-          remarkMath,
-          [remarkPublicAssetBase, { base }],
-          [remarkInteractiveCells, { root: pathFromUrl(paths.workspaceRoot) }],
-          remarkMermaidDiagrams,
-          ...remarkPlugins
-        ],
-        remarkRehype,
-        smartypants
-      }),
-    syntaxHighlight: {
-      ...syntaxHighlightOptions,
-      type: syntaxHighlightOptions.type ?? 'shiki',
-      excludeLangs: syntaxHighlightOptions.excludeLangs ?? ['math', 'mermaid']
-    }
+    processor: unified({
+      gfm,
+      rehypePlugins: [rehypeKatex, ...rehypePlugins],
+      remarkPlugins: [
+        remarkMath,
+        [remarkPublicAssetBase, { base }],
+        [remarkInteractiveCells, { root: pathFromUrl(paths.workspaceRoot) }],
+        remarkMermaidDiagrams,
+        ...remarkPlugins
+      ],
+      remarkRehype,
+      smartypants
+    }),
+    syntaxHighlight: mergeSyntaxHighlightConfig(syntaxHighlight)
   };
 }
 
-function syntaxHighlightConfig(value: AstroMarkdownConfig['syntaxHighlight']): Partial<SyntaxHighlightObject> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value) ? value : {};
+function mergeSyntaxHighlightConfig(
+  value: AstroMarkdownConfig['syntaxHighlight']
+): AstroMarkdownConfig['syntaxHighlight'] {
+  if (value === false || value === 'prism' || value === 'shiki') return value;
+
+  const options: Partial<SyntaxHighlightObject> = value ?? {};
+  return {
+    ...options,
+    type: options.type ?? 'shiki',
+    excludeLangs: mergeStringList(options.excludeLangs, ['math', 'mermaid'])
+  };
 }
 
 function mergeViteConfig(

--- a/packages/oxiquill/src/astro/index.ts
+++ b/packages/oxiquill/src/astro/index.ts
@@ -81,6 +81,8 @@ const viteManagedPackageNames = [
   'html-escaper',
   'katex',
   'mermaid',
+  'preact',
+  'preact-render-to-string',
   'pyodide'
 ];
 const viteAliasedPackageNames = [
@@ -88,12 +90,13 @@ const viteAliasedPackageNames = [
   '@astrojs/preact',
   '@preact/signals',
   'preact',
+  'preact-render-to-string',
   'aria-query',
   'axobject-query',
   'html-escaper'
 ];
-const viteSsrNoExternalPackageNames = ['@astrojs/preact', 'oxiquill'];
-const viteResolveDedupePackageNames = ['@preact/signals', 'preact'];
+const viteSsrNoExternalPackageNames = ['@astrojs/preact', 'oxiquill', 'preact', 'preact-render-to-string'];
+const viteResolveDedupePackageNames = ['@preact/signals', 'preact', 'preact-render-to-string'];
 
 export interface OxiquillFrameworkOptions<StarlightOptions extends object = object> {
   preact?: PreactIntegrationFactory;

--- a/packages/oxiquill/src/cli/commands.mjs
+++ b/packages/oxiquill/src/cli/commands.mjs
@@ -7,6 +7,7 @@ import { pathFromUrl, pathInUrl } from '../config/paths.mjs';
 import { loadOxiquillProjectConfig } from '../config/project-config.mjs';
 import { createDocRuntimeContext, syncDocRuntime } from '../generator/doc-runtime-service.mjs';
 import { cleanOxiquillWorkspace } from '../generator/clean.mjs';
+import { prepareCleanupOwnership } from '../generator/cleanup-ownership.mjs';
 import { runHelperCargo } from '../generator/run-helper-cargo.mjs';
 import { testGeneratedHaskellCells } from '../generator/doc-runtime/haskell-runtime-test.mjs';
 import { formatCliHelp, parseCliArguments } from './arguments.mjs';
@@ -76,7 +77,7 @@ export async function runCli(commandOrArgs = [], argsOrOptions = {}, legacyOptio
       await generateRuntime({ projectConfig, wasmMode: values.wasm });
       return;
     case 'clean':
-      await cleanOxiquillWorkspace({ paths });
+      await cleanOxiquillWorkspace({ configFile: projectConfig.configFile, paths });
       return;
     case 'test-rust':
       await runHelperCargo({ argv: ['test'], paths });
@@ -139,6 +140,11 @@ function normalizeRunCliArguments(commandOrArgs, argsOrOptions, legacyOptions) {
 
 async function generateRuntime({ projectConfig, tolerateHaskellBuildFailure = false, wasmMode }) {
   const { paths } = projectConfig;
+  await prepareCleanupOwnership({
+    configFile: projectConfig.configFile,
+    fields: ['cacheDir', 'publicAssetsDir'],
+    paths
+  });
   const context = await createDocRuntimeContext({ paths, pythonOptions: projectConfig.python });
   const summary = await syncDocRuntime({
     ...context,

--- a/packages/oxiquill/src/cli/commands.mjs
+++ b/packages/oxiquill/src/cli/commands.mjs
@@ -65,7 +65,11 @@ export async function runCli(commandOrArgs = [], argsOrOptions = {}, legacyOptio
       await runAstro(projectConfig, ['preview', ...astroArgs], { runCommand, selectNode });
       return;
     case 'build':
-      await generateRuntime({ projectConfig, wasmMode: 'build' });
+      await generateRuntime({
+        ownershipFields: ['cacheDir', 'outDir', 'publicAssetsDir'],
+        projectConfig,
+        wasmMode: 'build'
+      });
       await runOxiquillCheck(projectConfig, [], { runCommand, selectNode });
       await runAstro(projectConfig, ['build', ...astroArgs], { runCommand, runtimeOwner: 'cli', selectNode });
       return;
@@ -138,11 +142,16 @@ function normalizeRunCliArguments(commandOrArgs, argsOrOptions, legacyOptions) {
   return { args: commandOrArgs, options: argsOrOptions };
 }
 
-async function generateRuntime({ projectConfig, tolerateHaskellBuildFailure = false, wasmMode }) {
+async function generateRuntime({
+  ownershipFields = ['cacheDir', 'publicAssetsDir'],
+  projectConfig,
+  tolerateHaskellBuildFailure = false,
+  wasmMode
+}) {
   const { paths } = projectConfig;
   await prepareCleanupOwnership({
     configFile: projectConfig.configFile,
-    fields: ['cacheDir', 'publicAssetsDir'],
+    fields: ownershipFields,
     paths
   });
   const context = await createDocRuntimeContext({ paths, pythonOptions: projectConfig.python });

--- a/packages/oxiquill/src/components/doc-runtime/ArtifactErrorBoundary.tsx
+++ b/packages/oxiquill/src/components/doc-runtime/ArtifactErrorBoundary.tsx
@@ -1,4 +1,5 @@
 import { Component, type ComponentChildren } from 'preact';
+import { boundedErrorMessage } from '../../lib/doc-runtime/output-limits.mjs';
 import type { RuntimeLabels } from '../../lib/doc-runtime/runtime-localization.js';
 
 interface ArtifactErrorBoundaryProps {
@@ -16,7 +17,7 @@ export default class ArtifactErrorBoundary extends Component<ArtifactErrorBounda
   state: ArtifactErrorBoundaryState = {};
 
   componentDidCatch(error: unknown): void {
-    this.setState({ error: error instanceof Error ? error.message : String(error) });
+    this.setState({ error: boundedErrorMessage(error) });
   }
 
   componentDidUpdate(previousProps: ArtifactErrorBoundaryProps): void {

--- a/packages/oxiquill/src/components/doc-runtime/CellOutput.tsx
+++ b/packages/oxiquill/src/components/doc-runtime/CellOutput.tsx
@@ -59,7 +59,7 @@ export function CellOutput({
         <p class="empty-state">{idleOutputMessage(runMode, labels)}</p>
       ) : outputResults?.length ? (
         <div class="doc-cell__outputs">
-          <OutputRenderer idPrefix={outputId} labels={labels} outputs={outputResults} />
+          <OutputRenderer idPrefix={outputId} labels={labels} outputs={outputResults} resultIdentity={result} />
         </div>
       ) : (
         <p class="empty-state">{labels.cellCompletedWithoutOutput}</p>

--- a/packages/oxiquill/src/components/doc-runtime/ChartOutput.tsx
+++ b/packages/oxiquill/src/components/doc-runtime/ChartOutput.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'preact/hooks';
+import { boundedErrorMessage } from '../../lib/doc-runtime/output-limits.mjs';
 import type { RuntimeLabels } from '../../lib/doc-runtime/runtime-localization.js';
 import type { ChartArtifact, ChartSpec } from '../../lib/doc-runtime/types.js';
 
@@ -166,7 +167,7 @@ export default function ChartOutput({ artifact, idPrefix, labels }: ChartOutputP
 }
 
 function toError(value: unknown): Error {
-  return value instanceof Error ? value : new Error(String(value));
+  return new Error(boundedErrorMessage(value));
 }
 
 export function currentChartTheme(): ChartTheme {

--- a/packages/oxiquill/src/components/doc-runtime/ChartOutput.tsx
+++ b/packages/oxiquill/src/components/doc-runtime/ChartOutput.tsx
@@ -14,7 +14,26 @@ export type EChartsOptions = Record<string, unknown> & {
   series: readonly Record<string, unknown>[];
 };
 
-const palette = ['#0f766e', '#2563eb', '#9333ea', '#dc2626', '#ca8a04', '#4b5563'];
+export type ChartTheme = 'dark' | 'light';
+
+const chartColors = {
+  dark: {
+    axis: '#d1d5db',
+    border: '#6b7280',
+    palette: ['#5eead4', '#60a5fa', '#c084fc', '#fb7185', '#facc15', '#d1d5db'],
+    splitLine: '#4b5563',
+    text: '#f3f4f6',
+    tooltipBackground: '#111827'
+  },
+  light: {
+    axis: '#374151',
+    border: '#9ca3af',
+    palette: ['#0f766e', '#1d4ed8', '#7e22ce', '#be123c', '#a16207', '#374151'],
+    splitLine: '#d1d5db',
+    text: '#111827',
+    tooltipBackground: '#ffffff'
+  }
+} as const;
 let echartsModule: Promise<EChartsCore> | undefined;
 
 function loadECharts(): Promise<EChartsCore> {
@@ -23,22 +42,27 @@ function loadECharts(): Promise<EChartsCore> {
     import('echarts/charts'),
     import('echarts/components'),
     import('echarts/renderers')
-  ]).then(([echarts, charts, components, renderers]) => {
-    echarts.use([
-      charts.BarChart,
-      charts.HeatmapChart,
-      charts.LineChart,
-      charts.ScatterChart,
-      components.GridComponent,
-      components.LegendComponent,
-      components.TitleComponent,
-      components.TooltipComponent,
-      components.VisualMapComponent,
-      components.DataZoomComponent,
-      renderers.CanvasRenderer
-    ]);
-    return echarts;
-  });
+  ])
+    .then(([echarts, charts, components, renderers]) => {
+      echarts.use([
+        charts.BarChart,
+        charts.HeatmapChart,
+        charts.LineChart,
+        charts.ScatterChart,
+        components.GridComponent,
+        components.LegendComponent,
+        components.TitleComponent,
+        components.TooltipComponent,
+        components.VisualMapComponent,
+        components.DataZoomComponent,
+        renderers.CanvasRenderer
+      ]);
+      return echarts;
+    })
+    .catch((error: unknown) => {
+      echartsModule = undefined;
+      throw error;
+    });
 
   return echartsModule;
 }
@@ -48,10 +72,18 @@ export default function ChartOutput({ artifact, idPrefix, labels }: ChartOutputP
   const element = useRef<HTMLDivElement>(null);
   const chart = useRef<EChartsInstance>();
   const latestSpec = useRef(spec);
+  const [theme, setTheme] = useState<ChartTheme>(() => currentChartTheme());
   const [renderError, setRenderError] = useState<Error>();
+  const [renderAttempt, setRenderAttempt] = useState(0);
   latestSpec.current = spec;
 
-  if (renderError) throw renderError;
+  useEffect(() => {
+    const root = globalThis.document?.documentElement;
+    if (!root) return undefined;
+    const observer = new MutationObserver(() => setTheme(currentChartTheme()));
+    observer.observe(root, { attributeFilter: ['data-theme'], attributes: true });
+    return () => observer.disconnect();
+  }, []);
 
   useEffect(() => {
     const chartElement = element.current;
@@ -64,9 +96,9 @@ export default function ChartOutput({ artifact, idPrefix, labels }: ChartOutputP
       .then((echarts) => {
         if (cancelled) return;
 
-        nextChart = echarts.init(chartElement, undefined, { renderer: 'canvas' });
+        nextChart = echarts.init(chartElement, chartThemeDefinition(theme), { renderer: 'canvas' });
         chart.current = nextChart;
-        nextChart.setOption(chartSpecToEChartsOptions(latestSpec.current), true);
+        nextChart.setOption(chartSpecToEChartsOptions(latestSpec.current, theme), true);
         resizeObserver = new ResizeObserver(() => nextChart?.resize());
         resizeObserver.observe(chartElement);
       })
@@ -80,15 +112,34 @@ export default function ChartOutput({ artifact, idPrefix, labels }: ChartOutputP
       nextChart?.dispose();
       chart.current = undefined;
     };
-  }, []);
+  }, [renderAttempt, theme]);
 
   useEffect(() => {
     try {
-      chart.current?.setOption(chartSpecToEChartsOptions(spec), true);
+      chart.current?.setOption(chartSpecToEChartsOptions(spec, theme), true);
     } catch (error) {
       setRenderError(toError(error));
     }
-  }, [spec]);
+  }, [spec, theme]);
+
+  if (renderError) {
+    return (
+      <div class="doc-chart-output__error">
+        <p class="error-state" data-testid="artifact-error" role="alert">
+          {labels.chartLoadError(renderError.message)}
+        </p>
+        <button
+          type="button"
+          onClick={() => {
+            setRenderError(undefined);
+            setRenderAttempt((attempt) => attempt + 1);
+          }}
+        >
+          {labels.chartRetry}
+        </button>
+      </div>
+    );
+  }
 
   const titleId = `${idPrefix}-title`;
   const captionId = artifact.caption ? `${idPrefix}-caption` : undefined;
@@ -105,7 +156,7 @@ export default function ChartOutput({ artifact, idPrefix, labels }: ChartOutputP
         <strong id={titleId}>{title}</strong>
         {artifact.caption ? <span id={captionId}>{artifact.caption}</span> : null}
       </figcaption>
-      <div ref={element} class="doc-plot" aria-hidden="true" data-testid="doc-plot" />
+      <div ref={element} class="doc-plot" aria-hidden="true" data-chart-theme={theme} data-testid="doc-plot" />
       <p id={descriptionId} class="doc-chart-output__summary">
         <span class="doc-visually-hidden">{labels.chartCaption}: </span>
         {chartDataSummary(spec, labels)}
@@ -118,42 +169,101 @@ function toError(value: unknown): Error {
   return value instanceof Error ? value : new Error(String(value));
 }
 
-export function chartSpecToEChartsOptions(spec: ChartSpec): EChartsOptions {
+export function currentChartTheme(): ChartTheme {
+  return globalThis.document?.documentElement.dataset.theme === 'dark' ? 'dark' : 'light';
+}
+
+export function chartSpecToEChartsOptions(spec: ChartSpec, theme: ChartTheme = 'light'): EChartsOptions {
   const series = chartSeries(spec);
+  const colors = chartColors[theme];
+  const axisStyle = {
+    axisLabel: { color: colors.axis },
+    axisLine: { lineStyle: { color: colors.border } },
+    nameTextStyle: { color: colors.text },
+    splitLine: { lineStyle: { color: colors.splitLine } }
+  };
   const base = {
     animation: false,
-    color: palette,
+    backgroundColor: 'transparent',
+    color: colors.palette,
     grid: { left: 56, right: 24, top: spec.title || shouldShowLegend(spec, series) ? 48 : 24, bottom: 56 },
-    tooltip: spec.tooltip === false ? undefined : { trigger: tooltipTrigger(spec) },
-    legend: shouldShowLegend(spec, series) ? { top: 4 } : undefined,
-    title: spec.title ? { text: spec.title, left: 'center', textStyle: { fontSize: 14, fontWeight: 600 } } : undefined,
-    xAxis: xAxis(spec),
-    yAxis: yAxis(spec),
+    tooltip:
+      spec.tooltip === false
+        ? undefined
+        : {
+            trigger: tooltipTrigger(spec),
+            backgroundColor: colors.tooltipBackground,
+            borderColor: colors.border,
+            textStyle: { color: colors.text }
+          },
+    legend: shouldShowLegend(spec, series) ? { top: 4, textStyle: { color: colors.text } } : undefined,
+    textStyle: { color: colors.text },
+    title: spec.title
+      ? { text: spec.title, left: 'center', textStyle: { color: colors.text, fontSize: 14, fontWeight: 600 } }
+      : undefined,
+    xAxis: { ...xAxis(spec), ...axisStyle },
+    yAxis: { ...yAxis(spec), ...axisStyle },
     dataZoom: spec.dataZoom === false ? undefined : [{ type: 'inside' }],
     series
   };
 
   if (spec.kind === 'heatmap') {
+    const valueRange = numericBounds(spec.data, (item) => item[2]);
     return {
       ...base,
       dataZoom: undefined,
-      visualMap: { calculable: true, orient: 'horizontal', left: 'center', bottom: 0 }
+      visualMap: {
+        calculable: true,
+        orient: 'horizontal',
+        left: 'center',
+        bottom: 0,
+        min: valueRange?.minimum ?? 0,
+        max: valueRange?.maximum ?? 1,
+        textStyle: { color: colors.text }
+      }
     };
   }
 
   return base;
 }
 
+function chartThemeDefinition(theme: ChartTheme): Record<string, unknown> {
+  const colors = chartColors[theme];
+  return {
+    color: colors.palette,
+    backgroundColor: 'transparent',
+    textStyle: { color: colors.text },
+    title: { textStyle: { color: colors.text } },
+    legend: { textStyle: { color: colors.text } },
+    categoryAxis: {
+      axisLabel: { color: colors.axis },
+      axisLine: { lineStyle: { color: colors.border } },
+      splitLine: { lineStyle: { color: colors.splitLine } }
+    },
+    valueAxis: {
+      axisLabel: { color: colors.axis },
+      axisLine: { lineStyle: { color: colors.border } },
+      splitLine: { lineStyle: { color: colors.splitLine } }
+    }
+  };
+}
+
 export function chartDataSummary(spec: ChartSpec, labels: RuntimeLabels): string {
   const details = chartSummaryDetails(spec, labels);
-  return details.dataCount === 0 ? labels.noChartData : labels.chartSummary(details);
+  return boundedSummary(details.dataCount === 0 ? labels.noChartData : labels.chartSummary(details));
 }
 
 function chartSummaryDetails(spec: ChartSpec, labels: RuntimeLabels) {
   const numberFormat = new Intl.NumberFormat(labels.locale === 'ja' ? 'ja-JP' : 'en-US', {
     maximumSignificantDigits: 6
   });
-  const range = (values: readonly unknown[]) => numericRange(values, numberFormat);
+  const dateFormat = new Intl.DateTimeFormat(labels.locale === 'ja' ? 'ja-JP' : 'en-US', {
+    dateStyle: 'medium',
+    timeStyle: 'medium',
+    timeZone: 'UTC'
+  });
+  const range = (values: readonly unknown[], axisType: ChartSpec['xType']) =>
+    coordinateRange(values, axisType ?? 'value', numberFormat, dateFormat);
 
   switch (spec.kind) {
     case 'line':
@@ -164,8 +274,14 @@ function chartSummaryDetails(spec: ChartSpec, labels: RuntimeLabels) {
         dataCount: points.length,
         seriesCount: spec.series.length,
         seriesNames: seriesNames(spec.series),
-        xRange: range(points.map((point) => point[0])),
-        yRange: range(points.map((point) => point[1]))
+        xRange: range(
+          points.map((point) => point[0]),
+          spec.xType
+        ),
+        yRange: range(
+          points.map((point) => point[1]),
+          spec.yType
+        )
       };
     }
     case 'bar': {
@@ -174,7 +290,7 @@ function chartSummaryDetails(spec: ChartSpec, labels: RuntimeLabels) {
         dataCount: values.length,
         seriesCount: spec.series.length,
         seriesNames: seriesNames(spec.series),
-        yRange: range(values)
+        yRange: range(values, spec.yType)
       };
     }
     case 'histogram':
@@ -182,32 +298,85 @@ function chartSummaryDetails(spec: ChartSpec, labels: RuntimeLabels) {
         dataCount: spec.bins.length,
         seriesCount: 1,
         seriesNames: '',
-        xRange: range(spec.bins.flatMap((bin) => [bin[0], bin[1]])),
-        yRange: range(spec.bins.map((bin) => bin[2]))
+        xRange: range(
+          spec.bins.flatMap((bin) => [bin[0], bin[1]]),
+          'value'
+        ),
+        yRange: range(
+          spec.bins.map((bin) => bin[2]),
+          spec.yType
+        )
       };
     case 'heatmap':
       return {
         dataCount: spec.data.length,
         seriesCount: 1,
         seriesNames: '',
-        xRange: range(spec.data.map((item) => item[0])),
-        yRange: range(spec.data.map((item) => item[2]))
+        xRange: range(
+          spec.data.map((item) => item[0]),
+          spec.xCategories ? 'category' : spec.xType
+        ),
+        yRange: range(
+          spec.data.map((item) => item[1]),
+          spec.yCategories ? 'category' : spec.yType
+        ),
+        valueRange: numericRange(
+          spec.data.map((item) => item[2]),
+          numberFormat
+        )
       };
   }
 }
 
 function seriesNames(series: readonly { name?: string }[]): string {
-  return series.flatMap((item) => (item.name ? [item.name] : [])).join(', ');
+  return boundedSummary(series.flatMap((item) => (item.name ? [item.name] : [])).join(', '), 1_000);
 }
 
 function numericRange(values: readonly unknown[], numberFormat: Intl.NumberFormat): string | undefined {
-  const numbers = values.filter((value): value is number => typeof value === 'number' && Number.isFinite(value));
-  if (numbers.length === 0) return undefined;
-  const minimum = Math.min(...numbers);
-  const maximum = Math.max(...numbers);
+  const bounds = numericBounds(values, (value) => value);
+  if (!bounds) return undefined;
+  const { maximum, minimum } = bounds;
   return minimum === maximum
     ? numberFormat.format(minimum)
     : `${numberFormat.format(minimum)}–${numberFormat.format(maximum)}`;
+}
+
+function coordinateRange(
+  values: readonly unknown[],
+  axisType: NonNullable<ChartSpec['xType']>,
+  numberFormat: Intl.NumberFormat,
+  dateFormat: Intl.DateTimeFormat
+): string | undefined {
+  if (axisType === 'category') return undefined;
+  if (axisType !== 'time') return numericRange(values, numberFormat);
+  const bounds = numericBounds(values, (value) => {
+    if (typeof value === 'number') return value;
+    return typeof value === 'string' ? Date.parse(value) : Number.NaN;
+  });
+  if (!bounds) return undefined;
+  const minimum = dateFormat.format(bounds.minimum);
+  const maximum = dateFormat.format(bounds.maximum);
+  return bounds.minimum === bounds.maximum ? minimum : `${minimum}–${maximum}`;
+}
+
+function numericBounds<Value>(
+  values: readonly Value[],
+  numberFromValue: (value: Value) => unknown
+): { maximum: number; minimum: number } | undefined {
+  let minimum = Number.POSITIVE_INFINITY;
+  let maximum = Number.NEGATIVE_INFINITY;
+  for (const value of values) {
+    const candidate = numberFromValue(value);
+    if (typeof candidate !== 'number' || !Number.isFinite(candidate)) continue;
+    const number = Object.is(candidate, -0) ? 0 : candidate;
+    if (number < minimum) minimum = number;
+    if (number > maximum) maximum = number;
+  }
+  return minimum === Number.POSITIVE_INFINITY ? undefined : { maximum, minimum };
+}
+
+function boundedSummary(value: string, maximumLength = 4_000): string {
+  return value.length <= maximumLength ? value : `${value.slice(0, maximumLength - 1)}…`;
 }
 
 function chartSeries(spec: ChartSpec): readonly Record<string, unknown>[] {

--- a/packages/oxiquill/src/components/doc-runtime/InputControl.tsx
+++ b/packages/oxiquill/src/components/doc-runtime/InputControl.tsx
@@ -1,7 +1,15 @@
-import { coerceInputValue, formatInputValue } from '../../lib/doc-runtime/interactive-cell-model.js';
+import {
+  effectiveMaximum,
+  effectiveMinimum,
+  effectiveStep,
+  formatInputValue,
+  isIntegerInput,
+  parseNumericInput,
+  type NumericInputValidation
+} from '../../lib/doc-runtime/interactive-input-validation.js';
 import type { RuntimeLabels } from '../../lib/doc-runtime/runtime-localization.js';
 import type { InputSpec } from '../../lib/doc-runtime/types.js';
-import { useState } from 'preact/hooks';
+import { useEffect, useState } from 'preact/hooks';
 
 type InputValue = string | number | boolean;
 
@@ -10,18 +18,26 @@ export function InputControl({
   input,
   labels,
   value,
-  onChange
+  onChange,
+  onValidityChange = () => undefined
 }: {
   cellId: string;
   input: InputSpec;
   labels: RuntimeLabels;
   onChange: (value: InputValue) => void;
+  onValidityChange?: (valid: boolean) => void;
   value: InputValue;
 }) {
   const ids = inputControlIds(cellId, input.name);
   const [validation, setValidation] = useState<string>();
+  const [editValue, setEditValue] = useState(() => String(value));
   const descriptionId = input.description ? ids.description : undefined;
   const validationId = validation ? ids.validation : undefined;
+  const numeric = input.type === 'number' || input.type === 'integer';
+
+  useEffect(() => {
+    setEditValue(String(value));
+  }, [value]);
 
   if (input.type === 'checkbox') {
     return (
@@ -111,7 +127,7 @@ export function InputControl({
             {input.label}
           </label>
           <output id={ids.value} for={ids.control} data-testid={`${input.name}-value`}>
-            {formatInputValue(value)}
+            {formatInputValue(value, effectiveStep(input))}
           </output>
         </div>
         <input
@@ -129,8 +145,6 @@ export function InputControl({
     );
   }
 
-  const numeric = input.type === 'number' || input.type === 'integer';
-
   return (
     <div class="doc-input">
       <label for={ids.control} id={ids.label}>
@@ -141,14 +155,29 @@ export function InputControl({
         aria-describedby={descriptionId}
         aria-errormessage={validationId}
         aria-invalid={validation ? true : undefined}
-        type={numeric ? 'number' : 'text'}
-        min={input.min}
-        max={input.max}
-        step={input.type === 'integer' ? (input.step ?? 1) : input.step}
-        value={String(value)}
+        aria-valuemax={numeric ? effectiveMaximum(input) : undefined}
+        aria-valuemin={numeric ? effectiveMinimum(input) : undefined}
+        inputMode={numeric ? (isIntegerInput(input) ? 'numeric' : 'decimal') : undefined}
+        role={numeric ? 'spinbutton' : undefined}
+        type="text"
+        min={numeric ? effectiveMinimum(input) : undefined}
+        max={numeric ? effectiveMaximum(input) : undefined}
+        step={numeric ? effectiveStep(input) : undefined}
+        required={numeric}
+        value={numeric ? editValue : String(value)}
         onInput={(event) => {
-          setValidation(numeric ? inputValidationMessage(event.currentTarget.validity, input, labels) : undefined);
-          onChange(coerceInputValue(input, event.currentTarget.value));
+          const rawValue = event.currentTarget.value;
+          if (!numeric) {
+            onChange(rawValue);
+            return;
+          }
+
+          setEditValue(rawValue);
+          const parsed = parseNumericInput(input, rawValue);
+          const nextValidation = parsed.valid ? undefined : inputValidationMessage(parsed.validation, input, labels);
+          setValidation(nextValidation);
+          onValidityChange(parsed.valid);
+          if (parsed.valid) onChange(parsed.value);
         }}
       />
       <InputDescription id={descriptionId} description={input.description} />
@@ -189,11 +218,10 @@ function describedBy(...ids: Array<string | undefined>): string | undefined {
   return value || undefined;
 }
 
-function inputValidationMessage(validity: ValidityState, input: InputSpec, labels: RuntimeLabels): string | undefined {
-  if (validity.valid) return undefined;
-  if (validity.badInput) return labels.inputNumber;
-  if (validity.rangeUnderflow && input.min !== undefined) return labels.inputMinimum(input.min);
-  if (validity.rangeOverflow && input.max !== undefined) return labels.inputMaximum(input.max);
-  if (validity.stepMismatch) return labels.inputStep;
+function inputValidationMessage(validation: NumericInputValidation, input: InputSpec, labels: RuntimeLabels): string {
+  if (validation === 'rangeUnderflow') return labels.inputMinimum(effectiveMinimum(input) as number);
+  if (validation === 'rangeOverflow') return labels.inputMaximum(effectiveMaximum(input) as number);
+  if (validation === 'stepMismatch') return labels.inputStep;
+  if (validation === 'integer' && isIntegerInput(input)) return labels.inputNumber;
   return labels.inputNumber;
 }

--- a/packages/oxiquill/src/components/doc-runtime/InputControl.tsx
+++ b/packages/oxiquill/src/components/doc-runtime/InputControl.tsx
@@ -5,6 +5,7 @@ import {
   formatInputValue,
   isIntegerInput,
   parseNumericInput,
+  stepNumericInputValue,
   type NumericInputValidation
 } from '../../lib/doc-runtime/interactive-input-validation.js';
 import type { RuntimeLabels } from '../../lib/doc-runtime/runtime-localization.js';
@@ -157,6 +158,7 @@ export function InputControl({
         aria-invalid={validation ? true : undefined}
         aria-valuemax={numeric ? effectiveMaximum(input) : undefined}
         aria-valuemin={numeric ? effectiveMinimum(input) : undefined}
+        aria-valuenow={numeric && !validation ? Number(editValue) : undefined}
         inputMode={numeric ? (isIntegerInput(input) ? 'numeric' : 'decimal') : undefined}
         role={numeric ? 'spinbutton' : undefined}
         type="text"
@@ -165,6 +167,18 @@ export function InputControl({
         step={numeric ? effectiveStep(input) : undefined}
         required={numeric}
         value={numeric ? editValue : String(value)}
+        onKeyDown={(event) => {
+          if (!numeric || (event.key !== 'ArrowUp' && event.key !== 'ArrowDown')) return;
+
+          event.preventDefault();
+          const parsed = parseNumericInput(input, editValue);
+          const currentValue = parsed.valid ? parsed.value : Number(value);
+          const nextValue = stepNumericInputValue(input, currentValue, event.key === 'ArrowUp' ? 1 : -1);
+          setEditValue(String(nextValue));
+          setValidation(undefined);
+          onValidityChange(true);
+          onChange(nextValue);
+        }}
         onInput={(event) => {
           const rawValue = event.currentTarget.value;
           if (!numeric) {

--- a/packages/oxiquill/src/components/doc-runtime/InteractiveCell.tsx
+++ b/packages/oxiquill/src/components/doc-runtime/InteractiveCell.tsx
@@ -76,9 +76,10 @@ function InteractiveCellPanel({
               class="run-button"
               aria-busy={runtime.isRunning}
               aria-controls={ids.output}
-              aria-disabled={runtime.isRunning}
+              aria-disabled={runtime.isRunning || !runtime.inputsValid}
+              disabled={runtime.isRunning || !runtime.inputsValid}
               onClick={() => {
-                if (!runtime.isRunning) runtime.run();
+                if (!runtime.isRunning && runtime.inputsValid) runtime.run();
               }}
             >
               {runtime.isRunning ? labels.running : labels.run}
@@ -100,6 +101,7 @@ function InteractiveCellPanel({
               labels={labels}
               value={runtime.values[input.name]}
               onChange={(value) => runtime.setInputValue(input.name, value)}
+              onValidityChange={(valid) => runtime.setInputValidity(input.name, valid)}
             />
           ))}
         </fieldset>

--- a/packages/oxiquill/src/components/doc-runtime/InteractiveCell.tsx
+++ b/packages/oxiquill/src/components/doc-runtime/InteractiveCell.tsx
@@ -77,7 +77,7 @@ function InteractiveCellPanel({
               aria-busy={runtime.isRunning}
               aria-controls={ids.output}
               aria-disabled={runtime.isRunning || !runtime.inputsValid}
-              disabled={runtime.isRunning || !runtime.inputsValid}
+              disabled={!runtime.inputsValid}
               onClick={() => {
                 if (!runtime.isRunning && runtime.inputsValid) runtime.run();
               }}

--- a/packages/oxiquill/src/components/doc-runtime/OutputRenderer.tsx
+++ b/packages/oxiquill/src/components/doc-runtime/OutputRenderer.tsx
@@ -200,11 +200,26 @@ function HtmlOutput({
     <iframe
       class="doc-html-output"
       data-testid="html-output"
+      referrerPolicy="no-referrer"
       sandbox=""
-      srcdoc={output.html}
+      srcdoc={htmlArtifactSrcdoc(output.html)}
       title={output.title ?? labels.htmlOutput}
     />
   );
+}
+
+export const htmlArtifactContentSecurityPolicy = [
+  "default-src 'none'",
+  'img-src data: blob:',
+  'media-src data: blob:',
+  "style-src 'unsafe-inline'",
+  'font-src data:',
+  "base-uri 'none'",
+  "form-action 'none'"
+].join('; ');
+
+export function htmlArtifactSrcdoc(html: string): string {
+  return `<!doctype html><html><head><meta http-equiv="Content-Security-Policy" content="${htmlArtifactContentSecurityPolicy}"><meta name="referrer" content="no-referrer"></head><body>${html}</body></html>`;
 }
 
 function OutputWithTruncation({

--- a/packages/oxiquill/src/components/doc-runtime/OutputRenderer.tsx
+++ b/packages/oxiquill/src/components/doc-runtime/OutputRenderer.tsx
@@ -23,18 +23,25 @@ interface OutputRendererProps {
   idPrefix?: string;
   labels?: RuntimeLabels;
   outputs: readonly ValidatedArtifactResult[];
+  resultIdentity?: object;
 }
 
 export default function OutputRenderer({
   idPrefix = 'doc-output',
   labels = labelsForLanguage(globalThis.document?.documentElement.lang),
-  outputs
+  outputs,
+  resultIdentity
 }: OutputRendererProps) {
   return (
     <>
       {outputs.map((output, index) => (
         <ArtifactErrorBoundary key={artifactKey(output, index)} index={output.index} labels={labels} resetKey={output}>
-          <ArtifactOutput idPrefix={`${idPrefix}-artifact-${output.index}`} labels={labels} output={output} />
+          <ArtifactOutput
+            idPrefix={`${idPrefix}-artifact-${output.index}`}
+            labels={labels}
+            output={output}
+            resultIdentity={resultIdentity}
+          />
         </ArtifactErrorBoundary>
       ))}
     </>
@@ -44,11 +51,13 @@ export default function OutputRenderer({
 function ArtifactOutput({
   idPrefix,
   labels,
-  output
+  output,
+  resultIdentity
 }: {
   idPrefix: string;
   labels: RuntimeLabels;
   output: ValidatedArtifactResult;
+  resultIdentity?: object;
 }) {
   if (output.status === 'error') {
     return <ArtifactError message={labels.artifactError(output.index + 1, labels.diagnosticDetail(output.message))} />;
@@ -64,7 +73,9 @@ function ArtifactOutput({
     case 'chart':
       return <LazyChartOutput artifact={output.artifact} idPrefix={idPrefix} labels={labels} />;
     case 'table':
-      return <TableOutput idPrefix={idPrefix} labels={labels} table={output.artifact} />;
+      return (
+        <TableOutput idPrefix={idPrefix} labels={labels} table={output.artifact} resultIdentity={resultIdentity} />
+      );
     case 'image':
       return <ImageOutput labels={labels} output={output.artifact} />;
   }

--- a/packages/oxiquill/src/components/doc-runtime/OutputRenderer.tsx
+++ b/packages/oxiquill/src/components/doc-runtime/OutputRenderer.tsx
@@ -97,6 +97,7 @@ export function LazyChartOutput({
 }) {
   const chartArtifact = artifact ?? { kind: 'chart' as const, spec: spec as ChartSpec };
   const [state, setState] = useState<ChartRendererState>({ status: 'loading' });
+  const [loadAttempt, setLoadAttempt] = useState(0);
 
   useEffect(() => {
     let cancelled = false;
@@ -119,7 +120,7 @@ export function LazyChartOutput({
     return () => {
       cancelled = true;
     };
-  }, [load]);
+  }, [load, loadAttempt]);
 
   if (state.status === 'loading') {
     return (
@@ -131,9 +132,14 @@ export function LazyChartOutput({
 
   if (state.status === 'error') {
     return (
-      <p class="error-state" data-testid="artifact-error" role="alert">
-        {labels.chartLoadError(state.message)}
-      </p>
+      <div class="doc-chart-output__error">
+        <p class="error-state" data-testid="artifact-error" role="alert">
+          {labels.chartLoadError(state.message)}
+        </p>
+        <button type="button" onClick={() => setLoadAttempt((attempt) => attempt + 1)}>
+          {labels.chartRetry}
+        </button>
+      </div>
     );
   }
 

--- a/packages/oxiquill/src/components/doc-runtime/OutputRenderer.tsx
+++ b/packages/oxiquill/src/components/doc-runtime/OutputRenderer.tsx
@@ -18,6 +18,7 @@ type ChartRendererState =
   { status: 'loading' } | { status: 'ready'; module: ChartOutputModule } | { status: 'error'; message: string };
 
 let chartOutputModuleReady: Promise<ChartOutputModule> | undefined;
+let chartOutputLoadAttempt = 0;
 
 interface OutputRendererProps {
   idPrefix?: string;
@@ -198,6 +199,7 @@ function HtmlOutput({
 }) {
   return (
     <iframe
+      {...{ csp: htmlArtifactContentSecurityPolicy }}
       class="doc-html-output"
       data-testid="html-output"
       referrerPolicy="no-referrer"
@@ -252,9 +254,16 @@ function artifactKey(output: ValidatedArtifactResult, index: number): string {
 }
 
 function loadChartOutput(): Promise<ChartOutputModule> {
-  chartOutputModuleReady ??= import('./ChartOutput.js').catch((error: unknown) => {
+  chartOutputModuleReady ??= importChartOutput(chartOutputLoadAttempt).catch((error: unknown) => {
     chartOutputModuleReady = undefined;
+    chartOutputLoadAttempt += 1;
     throw error;
   });
   return chartOutputModuleReady;
+}
+
+function importChartOutput(attempt: number): Promise<ChartOutputModule> {
+  return attempt === 0
+    ? import('./ChartOutput.js')
+    : (import('./ChartOutput.js?oxiquill-retry') as Promise<ChartOutputModule>);
 }

--- a/packages/oxiquill/src/components/doc-runtime/TableOutput.tsx
+++ b/packages/oxiquill/src/components/doc-runtime/TableOutput.tsx
@@ -275,8 +275,12 @@ function csvCell(value: unknown, labels: RuntimeLabels): string {
   if (typeof value === 'number' && !Number.isFinite(value)) {
     throw new Error(labels.tableFiniteNumberError);
   }
-  const text = String(value);
+  const text = typeof value === 'string' ? spreadsheetSafeString(value) : String(value);
   return /[",\n\r]/u.test(text) ? `"${text.replace(/"/gu, '""')}"` : text;
+}
+
+function spreadsheetSafeString(value: string): string {
+  return /^\s*[=+\-@\t\r]/u.test(value) ? `'${value}` : value;
 }
 
 function ariaSort(sort: SortState | undefined, columnIndex: number): 'ascending' | 'descending' | 'none' {

--- a/packages/oxiquill/src/components/doc-runtime/TableOutput.tsx
+++ b/packages/oxiquill/src/components/doc-runtime/TableOutput.tsx
@@ -1,16 +1,18 @@
-import { useEffect, useMemo, useState } from 'preact/hooks';
+import { useLayoutEffect, useMemo, useRef, useState } from 'preact/hooks';
 import { labelsForLanguage, type RuntimeLabels } from '../../lib/doc-runtime/runtime-localization.js';
 import type { TableArtifact, TableColumn } from '../../lib/doc-runtime/types.js';
 
 interface TableOutputProps {
   idPrefix?: string;
   labels?: RuntimeLabels;
+  resultIdentity?: object;
   table: TableArtifact;
 }
 
 type SortDirection = 'asc' | 'desc';
 type SortState = {
   columnIndex: number;
+  columnKey?: string;
   direction: SortDirection;
 };
 
@@ -26,52 +28,77 @@ const pageSizes = [10, 25, 50, 100] as const;
 export default function TableOutput({
   idPrefix = 'doc-table',
   labels = labelsForLanguage(globalThis.document?.documentElement.lang),
+  resultIdentity,
   table
 }: TableOutputProps) {
   const [pageSize, setPageSize] = useState<(typeof pageSizes)[number]>(pageSizes[0]);
   const [page, setPage] = useState(0);
   const [sort, setSort] = useState<SortState>();
   const [copyStatus, setCopyStatus] = useState<CopyStatus>();
-  const sortedRows = useMemo(() => sortRows(table.rows, sort), [table.rows, sort]);
+  const identity = resultIdentity ?? table;
+  const identityRef = useRef(identity);
+  const resultGenerationRef = useRef(0);
+  const resultChanged = identityRef.current !== identity;
+  if (resultChanged) {
+    identityRef.current = identity;
+    resultGenerationRef.current += 1;
+  }
+  const reconciledSort = resultChanged || !isSortValid(sort, table.columns) ? undefined : sort;
+  const sortedRows = useMemo(() => sortRows(table.rows, reconciledSort), [table.rows, reconciledSort]);
   const pageCount = Math.max(1, Math.ceil(sortedRows.length / pageSize));
-  const safePage = Math.min(page, pageCount - 1);
+  const safePage = resultChanged ? 0 : Math.min(page, pageCount - 1);
   const currentRows = visibleRows(sortedRows, safePage, pageSize);
   const firstRow = sortedRows.length === 0 ? 0 : safePage * pageSize + 1;
   const lastRow = Math.min(sortedRows.length, (safePage + 1) * pageSize);
   const captionId = `${idPrefix}-title`;
   const descriptionId = table.caption ? `${idPrefix}-description` : undefined;
+  const columnKeys = table.columns.map((column) => column.key).join('\0');
 
-  useEffect(() => setCopyStatus(undefined), [table]);
+  useLayoutEffect(() => {
+    setPage((current) => (resultChanged ? 0 : Math.min(current, pageCount - 1)));
+    setSort((current) => (resultChanged || !isSortValid(current, table.columns) ? undefined : current));
+    setCopyStatus(undefined);
+  }, [columnKeys, identity, pageCount, resultChanged, table.columns]);
 
   function updateSort(columnIndex: number): void {
     setPage(0);
     setSort((current) => {
-      if (!current || current.columnIndex !== columnIndex) return { columnIndex, direction: 'asc' };
+      const columnKey = table.columns[columnIndex]?.key;
+      if (!current || current.columnIndex !== columnIndex) return { columnIndex, columnKey, direction: 'asc' };
       return { columnIndex, direction: current.direction === 'asc' ? 'desc' : 'asc' };
     });
   }
 
   async function copyVisibleCsv(): Promise<void> {
     if (copyStatus?.kind === 'copying') return;
+    const resultGeneration = resultGenerationRef.current;
     setCopyStatus({ kind: 'copying', message: labels.copyingCsv });
     const converted = tableToCsv(table.columns, currentRows, labels);
     if (!converted.ok) {
-      setCopyStatus({ kind: 'error', message: labels.copyCsvError(converted.error) });
+      if (resultGenerationRef.current === resultGeneration) {
+        setCopyStatus({ kind: 'error', message: labels.copyCsvError(converted.error) });
+      }
       return;
     }
     try {
       const clipboard = globalThis.navigator.clipboard;
       if (!clipboard) {
-        setCopyStatus({ kind: 'error', message: labels.copyCsvError(labels.clipboardUnavailable) });
+        if (resultGenerationRef.current === resultGeneration) {
+          setCopyStatus({ kind: 'error', message: labels.copyCsvError(labels.clipboardUnavailable) });
+        }
         return;
       }
       await clipboard.writeText(converted.csv);
-      setCopyStatus({ kind: 'success', message: labels.copyCsvSuccess });
+      if (resultGenerationRef.current === resultGeneration) {
+        setCopyStatus({ kind: 'success', message: labels.copyCsvSuccess });
+      }
     } catch (error) {
-      setCopyStatus({
-        kind: 'error',
-        message: labels.copyCsvError(error instanceof Error ? error.message : String(error))
-      });
+      if (resultGenerationRef.current === resultGeneration) {
+        setCopyStatus({
+          kind: 'error',
+          message: labels.copyCsvError(error instanceof Error ? error.message : String(error))
+        });
+      }
     }
   }
 
@@ -90,7 +117,7 @@ export default function TableOutput({
           <thead>
             <tr>
               {table.columns.map((column, columnIndex) => (
-                <th key={column.key} scope="col" aria-sort={ariaSort(sort, columnIndex)}>
+                <th key={column.key} scope="col" aria-sort={ariaSort(reconciledSort, columnIndex)}>
                   <button type="button" onClick={() => updateSort(columnIndex)}>
                     {column.label}
                   </button>
@@ -187,6 +214,12 @@ export function sortRows(rows: readonly unknown[][], sort?: SortState): readonly
 
 export function visibleRows(rows: readonly unknown[][], page: number, pageSize: number): readonly unknown[][] {
   return rows.slice(page * pageSize, (page + 1) * pageSize);
+}
+
+function isSortValid(sort: SortState | undefined, columns: readonly TableColumn[]): boolean {
+  if (!sort) return true;
+  const column = columns[sort.columnIndex];
+  return Boolean(column && (sort.columnKey === undefined || sort.columnKey === column.key));
 }
 
 export function tableToCsv(

--- a/packages/oxiquill/src/components/doc-runtime/useInteractiveCellRun.ts
+++ b/packages/oxiquill/src/components/doc-runtime/useInteractiveCellRun.ts
@@ -26,14 +26,22 @@ const reactiveDebounceMs = 150;
 export function useInteractiveCellRun(cell: CellManifest, runtimeVersion: string) {
   const [values, setValues] = useState<InputValues>(() => initialValues(cell.inputs));
   const [execution, setExecution] = useState<ExecutionState>({ status: 'idle' });
+  const [inputsValid, setInputsValid] = useState(true);
+  const invalidInputsRef = useRef(new Set<string>());
   const valuesRef = useRef(values);
   const schedulerRef =
     useRef<ReturnType<typeof createLatestRequestScheduler<CellRunRequest, NormalizedCellExecutionResult>>>();
 
   schedulerRef.current ??= createLatestRequestScheduler({
-    execute: ({ autorunKey, cell: requestedCell, runtimeVersion: requestedVersion, values: requestedValues }) => {
-      const execute = () => runInteractiveCell(requestedCell, requestedValues, requestedVersion);
+    execute: (
+      { autorunKey, cell: requestedCell, runtimeVersion: requestedVersion, values: requestedValues },
+      signal
+    ) => {
+      const execute = () => runInteractiveCell(requestedCell, requestedValues, requestedVersion, signal);
       return autorunKey ? autorunRequests.getOrCreate(autorunKey, execute) : execute();
+    },
+    onCancelled: () => {
+      setExecution({ status: 'idle' });
     },
     onError: (caught) => {
       setExecution({ error: caught instanceof Error ? caught.message : String(caught), status: 'error' });
@@ -64,6 +72,7 @@ export function useInteractiveCellRun(cell: CellManifest, runtimeVersion: string
   }
 
   function run(): void {
+    if (invalidInputsRef.current.size > 0) return;
     schedule(valuesRef.current);
   }
 
@@ -72,17 +81,36 @@ export function useInteractiveCellRun(cell: CellManifest, runtimeVersion: string
     valuesRef.current = nextValues;
     setValues(nextValues);
 
-    if (cell.run === 'reactive') {
+    if (cell.run === 'reactive' && invalidInputsRef.current.size === 0) {
       schedule(nextValues, reactiveDebounceMs);
+    }
+  }
+
+  function setInputValidity(inputName: string, valid: boolean): void {
+    const nextInvalidInputs = new Set(invalidInputsRef.current);
+    if (valid) {
+      nextInvalidInputs.delete(inputName);
+    } else {
+      nextInvalidInputs.add(inputName);
+    }
+    if (nextInvalidInputs.size === invalidInputsRef.current.size && nextInvalidInputs.has(inputName) === !valid) return;
+
+    invalidInputsRef.current = nextInvalidInputs;
+    setInputsValid(nextInvalidInputs.size === 0);
+    if (!valid) {
+      schedulerRef.current?.cancel();
+      setExecution({ status: 'idle' });
     }
   }
 
   return {
     error: execution.status === 'error' ? execution.error : undefined,
+    inputsValid,
     isRunning: execution.status === 'running',
     result: execution.status === 'success' ? execution.result : undefined,
     run,
     setInputValue,
+    setInputValidity,
     values
   };
 }

--- a/packages/oxiquill/src/components/starlight/PageFrame.astro
+++ b/packages/oxiquill/src/components/starlight/PageFrame.astro
@@ -76,7 +76,7 @@ const presentation = togglePresentation(lang, dir, 'sidebar');
   }
 
   @media (min-width: 50rem) {
-    :global([data-sidebar-collapsed]) {
+    :global([data-has-sidebar][data-sidebar-collapsed]) {
       --sl-content-inline-start: 0rem;
       --sl-content-width: calc(var(--oq-sidebar-base-content-width) + var(--sl-sidebar-width));
     }

--- a/packages/oxiquill/src/components/starlight/PageFrame.astro
+++ b/packages/oxiquill/src/components/starlight/PageFrame.astro
@@ -1,22 +1,10 @@
 ---
 import MobileMenuToggle from '@astrojs/starlight/components/MobileMenuToggle.astro';
 import { Icon } from '@astrojs/starlight/components';
+import { togglePresentation } from './toggle-localization.js';
 
 const { hasSidebar, dir, lang } = Astro.locals.starlightRoute;
-const isRtl = dir === 'rtl';
-const primaryLanguage = lang.trim().split(/[-_]/u)[0]?.toLowerCase();
-const labels =
-  primaryLanguage === 'ja'
-    ? {
-        collapse: 'サイドバーを折りたたむ',
-        expand: 'サイドバーを展開する'
-      }
-    : {
-        collapse: 'Collapse sidebar',
-        expand: 'Expand sidebar'
-      };
-const collapseIcon = isRtl ? 'right-arrow' : 'left-arrow';
-const expandIcon = isRtl ? 'left-arrow' : 'right-arrow';
+const presentation = togglePresentation(lang, dir, 'sidebar');
 ---
 
 {
@@ -30,11 +18,6 @@ const expandIcon = isRtl ? 'left-arrow' : 'right-arrow';
 							sessionStorage.getItem('oxiquill-sidebar-collapsed') === 'true'
 						) {
 							document.documentElement.setAttribute('data-sidebar-collapsed', '');
-							document.documentElement.style.setProperty('--sl-content-inline-start', '0rem');
-							document.documentElement.style.setProperty(
-								'--sl-content-width',
-								'calc(var(--oq-sidebar-base-content-width) + var(--sl-sidebar-width))'
-							);
 						}
 					} catch {}
 				})();
@@ -56,22 +39,22 @@ const expandIcon = isRtl ? 'left-arrow' : 'right-arrow';
         </div>
         <starlight-sidebar-toggle
           class="print:hidden"
-          data-collapse-label={labels.collapse}
-          data-expand-label={labels.expand}
+          data-collapse-label={presentation.collapseLabel}
+          data-expand-label={presentation.expandLabel}
         >
           <button
             type="button"
             class="sidebar-toggle-button sl-flex"
             aria-controls="starlight__sidebar"
             aria-expanded="true"
-            aria-label={labels.collapse}
-            title={labels.collapse}
+            aria-label={presentation.collapseLabel}
+            title={presentation.collapseLabel}
           >
             <span class="collapse-sidebar" aria-hidden="true">
-              <Icon name={collapseIcon} size="1rem" />
+              <Icon name={presentation.collapseIcon} size="1rem" />
             </span>
             <span class="expand-sidebar" aria-hidden="true">
-              <Icon name={expandIcon} size="1rem" />
+              <Icon name={presentation.expandIcon} size="1rem" />
             </span>
           </button>
         </starlight-sidebar-toggle>

--- a/packages/oxiquill/src/components/starlight/PageFrame.astro
+++ b/packages/oxiquill/src/components/starlight/PageFrame.astro
@@ -4,8 +4,9 @@ import { Icon } from '@astrojs/starlight/components';
 
 const { hasSidebar, dir, lang } = Astro.locals.starlightRoute;
 const isRtl = dir === 'rtl';
+const primaryLanguage = lang.trim().split(/[-_]/u)[0]?.toLowerCase();
 const labels =
-  lang === 'ja'
+  primaryLanguage === 'ja'
     ? {
         collapse: 'サイドバーを折りたたむ',
         expand: 'サイドバーを展開する'
@@ -81,86 +82,9 @@ const expandIcon = isRtl ? 'left-arrow' : 'right-arrow';
 </div>
 
 <script>
-  const storageKey = 'oxiquill-sidebar-collapsed';
-  const desktopQuery = matchMedia('(min-width: 50rem)');
+  import { defineStarlightSidebarToggle } from './sidebar-toggle.js';
 
-  class StarlightSidebarToggle extends HTMLElement {
-    button = this.querySelector('button')!;
-    sidebar = document.getElementById(this.button.getAttribute('aria-controls') || '');
-    collapseLabel = this.dataset.collapseLabel || 'Collapse sidebar';
-    expandLabel = this.dataset.expandLabel || 'Expand sidebar';
-
-    connectedCallback() {
-      this.button.addEventListener('click', this.toggleCollapsed);
-      desktopQuery.addEventListener('change', this.applyStoredState);
-      this.applyStoredState();
-    }
-
-    disconnectedCallback() {
-      this.button.removeEventListener('click', this.toggleCollapsed);
-      desktopQuery.removeEventListener('change', this.applyStoredState);
-    }
-
-    applyStoredState = () => {
-      this.setCollapsed(this.getStoredCollapsed());
-    };
-
-    toggleCollapsed = () => {
-      if (!desktopQuery.matches) return;
-      const nextCollapsed = !document.documentElement.hasAttribute('data-sidebar-collapsed');
-      this.storeCollapsed(nextCollapsed);
-      this.setCollapsed(nextCollapsed);
-    };
-
-    getStoredCollapsed(): boolean {
-      try {
-        return sessionStorage.getItem(storageKey) === 'true';
-      } catch {
-        return false;
-      }
-    }
-
-    storeCollapsed(collapsed: boolean) {
-      try {
-        if (collapsed) {
-          sessionStorage.setItem(storageKey, 'true');
-        } else {
-          sessionStorage.removeItem(storageKey);
-        }
-      } catch {}
-    }
-
-    setCollapsed(collapsed: boolean) {
-      const active = desktopQuery.matches && collapsed;
-      const label = active ? this.expandLabel : this.collapseLabel;
-      document.documentElement.toggleAttribute('data-sidebar-collapsed', active);
-      if (active) {
-        document.documentElement.style.setProperty('--sl-content-inline-start', '0rem');
-        document.documentElement.style.setProperty(
-          '--sl-content-width',
-          'calc(var(--oq-sidebar-base-content-width) + var(--sl-sidebar-width))'
-        );
-      } else {
-        document.documentElement.style.removeProperty('--sl-content-inline-start');
-        document.documentElement.style.removeProperty('--sl-content-width');
-      }
-      this.button.setAttribute('aria-expanded', String(!active));
-      this.button.setAttribute('aria-label', label);
-      this.button.title = label;
-      if (this.sidebar) {
-        if (active) {
-          this.sidebar.setAttribute('aria-hidden', 'true');
-        } else {
-          this.sidebar.removeAttribute('aria-hidden');
-        }
-        this.sidebar.toggleAttribute('inert', active);
-      }
-    }
-  }
-
-  if (!customElements.get('starlight-sidebar-toggle')) {
-    customElements.define('starlight-sidebar-toggle', StarlightSidebarToggle);
-  }
+  defineStarlightSidebarToggle();
 </script>
 
 <style>

--- a/packages/oxiquill/src/components/starlight/TwoColumnContent.astro
+++ b/packages/oxiquill/src/components/starlight/TwoColumnContent.astro
@@ -1,0 +1,199 @@
+---
+import { Icon } from '@astrojs/starlight/components';
+import { togglePresentation } from './toggle-localization.js';
+
+const { dir, lang, toc } = Astro.locals.starlightRoute;
+const presentation = togglePresentation(lang, dir, 'tableOfContents');
+---
+
+<script is:inline>
+  {
+    `
+		(() => {
+			let collapsed = false;
+			try {
+				collapsed =
+					${Boolean(toc)} &&
+					matchMedia('(min-width: 72rem)').matches &&
+					sessionStorage.getItem('oxiquill-table-of-contents-collapsed') === 'true';
+			} catch {}
+			document.documentElement.toggleAttribute('data-table-of-contents-collapsed', collapsed);
+		})();
+	`;
+  }
+</script>
+
+<div class="two-column-content lg:sl-flex">
+  {
+    toc && (
+      <>
+        <aside id="starlight__right-sidebar" class="right-sidebar-container print:hidden">
+          <div class="right-sidebar">
+            <slot name="right-sidebar" />
+          </div>
+        </aside>
+        <starlight-table-of-contents-toggle
+          class="print:hidden"
+          data-collapse-label={presentation.collapseLabel}
+          data-expand-label={presentation.expandLabel}
+        >
+          <button
+            type="button"
+            class="table-of-contents-toggle-button sl-flex"
+            aria-controls="starlight__right-sidebar"
+            aria-expanded="true"
+            aria-label={presentation.collapseLabel}
+            title={presentation.collapseLabel}
+          >
+            <span class="collapse-table-of-contents" aria-hidden="true">
+              <Icon name={presentation.collapseIcon} size="1rem" />
+            </span>
+            <span class="expand-table-of-contents" aria-hidden="true">
+              <Icon name={presentation.expandIcon} size="1rem" />
+            </span>
+          </button>
+        </starlight-table-of-contents-toggle>
+      </>
+    )
+  }
+  <div class="main-pane"><slot /></div>
+</div>
+
+<script>
+  import { defineStarlightTableOfContentsToggle } from './table-of-contents-toggle.js';
+
+  defineStarlightTableOfContentsToggle();
+</script>
+
+<style>
+  :global(:root) {
+    --oq-sidebar-base-content-width: 45rem;
+    --oq-wide-base-content-width: 67.5rem;
+  }
+
+  @media (min-width: 72rem) {
+    :global([data-has-sidebar][data-table-of-contents-collapsed]) {
+      --sl-content-width: calc(var(--oq-sidebar-base-content-width) + var(--sl-sidebar-width));
+    }
+
+    :global([data-has-sidebar][data-sidebar-collapsed][data-table-of-contents-collapsed]) {
+      --sl-content-width: calc(var(--oq-sidebar-base-content-width) + 2 * var(--sl-sidebar-width));
+    }
+
+    :global(:not([data-has-sidebar])[data-table-of-contents-collapsed]) {
+      --sl-content-width: calc(var(--oq-wide-base-content-width) + var(--sl-sidebar-width));
+    }
+  }
+</style>
+
+<style>
+  @layer starlight.core {
+    .main-pane {
+      isolation: isolate;
+    }
+
+    starlight-table-of-contents-toggle {
+      display: none;
+    }
+
+    .table-of-contents-toggle-button {
+      align-items: center;
+      justify-content: center;
+      border: 1px solid var(--sl-color-hairline-shade);
+      border-radius: 50%;
+      width: 2rem;
+      height: 2rem;
+      padding: 0;
+      background-color: var(--sl-color-bg-nav);
+      color: var(--sl-color-text);
+      box-shadow: var(--sl-shadow-sm);
+      cursor: pointer;
+    }
+
+    .table-of-contents-toggle-button:hover {
+      border-color: var(--sl-color-gray-4);
+      background-color: var(--sl-color-gray-6);
+    }
+
+    .table-of-contents-toggle-button:focus-visible {
+      outline: 2px solid var(--sl-color-accent);
+      outline-offset: 2px;
+    }
+
+    .table-of-contents-toggle-button[aria-expanded='true'] .expand-table-of-contents,
+    .table-of-contents-toggle-button[aria-expanded='false'] .collapse-table-of-contents {
+      display: none;
+    }
+
+    @media (min-width: 72rem) {
+      .right-sidebar-container {
+        order: 2;
+        position: relative;
+        width: max(
+          var(--sl-sidebar-width),
+          calc(var(--sl-sidebar-width) + (100% - var(--sl-content-width) - var(--sl-sidebar-width)) / 2)
+        );
+      }
+
+      .right-sidebar {
+        position: fixed;
+        top: 0;
+        border-inline-start: 1px solid var(--sl-color-hairline);
+        padding-top: var(--sl-nav-height);
+        width: 100%;
+        height: 100vh;
+        overflow-y: auto;
+        scrollbar-width: none;
+      }
+
+      .main-pane {
+        width: 100%;
+      }
+
+      :global([data-has-sidebar][data-has-toc]) .main-pane {
+        --sl-content-margin-inline: auto 0;
+
+        order: 1;
+        width: min(
+          calc(100% - var(--sl-sidebar-width)),
+          calc(var(--sl-content-width) + (100% - var(--sl-content-width) - var(--sl-sidebar-width)) / 2)
+        );
+      }
+
+      starlight-table-of-contents-toggle {
+        display: block;
+      }
+
+      .table-of-contents-toggle-button {
+        position: fixed;
+        z-index: var(--sl-z-index-navbar);
+        inset-block-start: calc(var(--sl-nav-height) + 0.75rem);
+        inset-inline-end: calc(var(--sl-sidebar-width) - 1rem);
+        transition:
+          background-color 0.15s ease,
+          border-color 0.15s ease,
+          inset-inline-end 0.15s ease;
+      }
+
+      :global([data-table-of-contents-collapsed]) .right-sidebar-container {
+        display: none;
+      }
+
+      :global([data-has-toc][data-table-of-contents-collapsed]) .main-pane {
+        --sl-content-margin-inline: auto;
+
+        width: 100%;
+      }
+
+      :global([data-table-of-contents-collapsed]) .table-of-contents-toggle-button {
+        inset-inline-end: var(--sl-nav-pad-x);
+      }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      .table-of-contents-toggle-button {
+        transition: none;
+      }
+    }
+  }
+</style>

--- a/packages/oxiquill/src/components/starlight/persistent-toggle.ts
+++ b/packages/oxiquill/src/components/starlight/persistent-toggle.ts
@@ -1,0 +1,101 @@
+interface PersistentToggleOptions {
+  collapsedAttribute: string;
+  defaultCollapseLabel: string;
+  defaultExpandLabel: string;
+  mediaQuery: string;
+  storageKey: string;
+}
+
+export function createPersistentToggle(options: PersistentToggleOptions): typeof HTMLElement {
+  return class PersistentToggle extends HTMLElement {
+    private button?: HTMLButtonElement;
+    private collapseLabel = options.defaultCollapseLabel;
+    private controlledElement?: HTMLElement;
+    private expandLabel = options.defaultExpandLabel;
+    private listening = false;
+    private mediaQuery?: MediaQueryList;
+
+    connectedCallback(): void {
+      this.removeListeners();
+
+      const button = this.querySelector('button');
+      const controlledId = button?.getAttribute('aria-controls');
+      const controlledElement = controlledId ? document.getElementById(controlledId) : null;
+      if (!(button instanceof HTMLButtonElement) || !controlledElement) return;
+
+      this.button = button;
+      this.controlledElement = controlledElement;
+      this.collapseLabel = this.dataset.collapseLabel || options.defaultCollapseLabel;
+      this.expandLabel = this.dataset.expandLabel || options.defaultExpandLabel;
+      this.mediaQuery = matchMedia(options.mediaQuery);
+      this.button.addEventListener('click', this.toggleCollapsed);
+      this.mediaQuery.addEventListener('change', this.applyStoredState);
+      this.listening = true;
+      this.applyStoredState();
+    }
+
+    disconnectedCallback(): void {
+      this.removeListeners();
+    }
+
+    private readonly applyStoredState = (): void => {
+      this.setCollapsed(this.getStoredCollapsed());
+    };
+
+    private readonly toggleCollapsed = (): void => {
+      if (!this.mediaQuery?.matches) return;
+      const nextCollapsed = !document.documentElement.hasAttribute(options.collapsedAttribute);
+      this.storeCollapsed(nextCollapsed);
+      this.setCollapsed(nextCollapsed);
+    };
+
+    private getStoredCollapsed(): boolean {
+      try {
+        return sessionStorage.getItem(options.storageKey) === 'true';
+      } catch {
+        return false;
+      }
+    }
+
+    private storeCollapsed(collapsed: boolean): void {
+      try {
+        if (collapsed) {
+          sessionStorage.setItem(options.storageKey, 'true');
+        } else {
+          sessionStorage.removeItem(options.storageKey);
+        }
+      } catch {
+        // Storage can be unavailable in privacy-restricted browsing contexts.
+      }
+    }
+
+    private setCollapsed(collapsed: boolean): void {
+      if (!this.button || !this.controlledElement || !this.mediaQuery) return;
+
+      const active = this.mediaQuery.matches && collapsed;
+      const label = active ? this.expandLabel : this.collapseLabel;
+      if (active && this.controlledElement.contains(document.activeElement)) this.button.focus();
+      document.documentElement.toggleAttribute(options.collapsedAttribute, active);
+      this.button.setAttribute('aria-expanded', String(!active));
+      this.button.setAttribute('aria-label', label);
+      this.button.title = label;
+      if (active) {
+        this.controlledElement.setAttribute('aria-hidden', 'true');
+      } else {
+        this.controlledElement.removeAttribute('aria-hidden');
+      }
+      this.controlledElement.toggleAttribute('inert', active);
+    }
+
+    private removeListeners(): void {
+      if (this.listening) {
+        this.button?.removeEventListener('click', this.toggleCollapsed);
+        this.mediaQuery?.removeEventListener('change', this.applyStoredState);
+      }
+      this.listening = false;
+      this.button = undefined;
+      this.controlledElement = undefined;
+      this.mediaQuery = undefined;
+    }
+  };
+}

--- a/packages/oxiquill/src/components/starlight/sidebar-toggle.ts
+++ b/packages/oxiquill/src/components/starlight/sidebar-toggle.ts
@@ -1,106 +1,14 @@
-const storageKey = 'oxiquill-sidebar-collapsed';
-const desktopMediaQuery = '(min-width: 50rem)';
+import { createPersistentToggle } from './persistent-toggle.js';
 
-export class StarlightSidebarToggle extends HTMLElement {
-  private button?: HTMLButtonElement;
-  private collapseLabel = 'Collapse sidebar';
-  private desktopQuery?: MediaQueryList;
-  private expandLabel = 'Expand sidebar';
-  private listening = false;
-  private sidebar?: HTMLElement;
+const SidebarToggleElement = createPersistentToggle({
+  collapsedAttribute: 'data-sidebar-collapsed',
+  defaultCollapseLabel: 'Collapse sidebar',
+  defaultExpandLabel: 'Expand sidebar',
+  mediaQuery: '(min-width: 50rem)',
+  storageKey: 'oxiquill-sidebar-collapsed'
+});
 
-  connectedCallback(): void {
-    this.removeListeners();
-
-    const button = this.querySelector('button');
-    const sidebarId = button?.getAttribute('aria-controls');
-    const sidebar = sidebarId ? document.getElementById(sidebarId) : null;
-    if (!(button instanceof HTMLButtonElement) || !sidebar) return;
-
-    this.button = button;
-    this.sidebar = sidebar;
-    this.collapseLabel = this.dataset.collapseLabel || 'Collapse sidebar';
-    this.expandLabel = this.dataset.expandLabel || 'Expand sidebar';
-    this.desktopQuery = matchMedia(desktopMediaQuery);
-    this.button.addEventListener('click', this.toggleCollapsed);
-    this.desktopQuery.addEventListener('change', this.applyStoredState);
-    this.listening = true;
-    this.applyStoredState();
-  }
-
-  disconnectedCallback(): void {
-    this.removeListeners();
-  }
-
-  private readonly applyStoredState = (): void => {
-    this.setCollapsed(this.getStoredCollapsed());
-  };
-
-  private readonly toggleCollapsed = (): void => {
-    if (!this.desktopQuery?.matches) return;
-    const nextCollapsed = !document.documentElement.hasAttribute('data-sidebar-collapsed');
-    this.storeCollapsed(nextCollapsed);
-    this.setCollapsed(nextCollapsed);
-  };
-
-  private getStoredCollapsed(): boolean {
-    try {
-      return sessionStorage.getItem(storageKey) === 'true';
-    } catch {
-      return false;
-    }
-  }
-
-  private storeCollapsed(collapsed: boolean): void {
-    try {
-      if (collapsed) {
-        sessionStorage.setItem(storageKey, 'true');
-      } else {
-        sessionStorage.removeItem(storageKey);
-      }
-    } catch {
-      // Storage can be unavailable in privacy-restricted browsing contexts.
-    }
-  }
-
-  private setCollapsed(collapsed: boolean): void {
-    if (!this.button || !this.sidebar || !this.desktopQuery) return;
-
-    const active = this.desktopQuery.matches && collapsed;
-    const label = active ? this.expandLabel : this.collapseLabel;
-    document.documentElement.toggleAttribute('data-sidebar-collapsed', active);
-    if (active) {
-      document.documentElement.style.setProperty('--sl-content-inline-start', '0rem');
-      document.documentElement.style.setProperty(
-        '--sl-content-width',
-        'calc(var(--oq-sidebar-base-content-width) + var(--sl-sidebar-width))'
-      );
-    } else {
-      document.documentElement.style.removeProperty('--sl-content-inline-start');
-      document.documentElement.style.removeProperty('--sl-content-width');
-    }
-    this.button.setAttribute('aria-expanded', String(!active));
-    this.button.setAttribute('aria-label', label);
-    this.button.title = label;
-    if (active) {
-      this.sidebar.setAttribute('aria-hidden', 'true');
-    } else {
-      this.sidebar.removeAttribute('aria-hidden');
-    }
-    this.sidebar.toggleAttribute('inert', active);
-  }
-
-  private removeListeners(): void {
-    if (this.listening) {
-      this.button?.removeEventListener('click', this.toggleCollapsed);
-      this.desktopQuery?.removeEventListener('change', this.applyStoredState);
-    }
-    this.listening = false;
-    this.button = undefined;
-    this.desktopQuery = undefined;
-    this.sidebar = undefined;
-  }
-}
+export class StarlightSidebarToggle extends SidebarToggleElement {}
 
 export function defineStarlightSidebarToggle(): void {
   if (!customElements.get('starlight-sidebar-toggle')) {

--- a/packages/oxiquill/src/components/starlight/sidebar-toggle.ts
+++ b/packages/oxiquill/src/components/starlight/sidebar-toggle.ts
@@ -1,0 +1,109 @@
+const storageKey = 'oxiquill-sidebar-collapsed';
+const desktopMediaQuery = '(min-width: 50rem)';
+
+export class StarlightSidebarToggle extends HTMLElement {
+  private button?: HTMLButtonElement;
+  private collapseLabel = 'Collapse sidebar';
+  private desktopQuery?: MediaQueryList;
+  private expandLabel = 'Expand sidebar';
+  private listening = false;
+  private sidebar?: HTMLElement;
+
+  connectedCallback(): void {
+    this.removeListeners();
+
+    const button = this.querySelector('button');
+    const sidebarId = button?.getAttribute('aria-controls');
+    const sidebar = sidebarId ? document.getElementById(sidebarId) : null;
+    if (!(button instanceof HTMLButtonElement) || !sidebar) return;
+
+    this.button = button;
+    this.sidebar = sidebar;
+    this.collapseLabel = this.dataset.collapseLabel || 'Collapse sidebar';
+    this.expandLabel = this.dataset.expandLabel || 'Expand sidebar';
+    this.desktopQuery = matchMedia(desktopMediaQuery);
+    this.button.addEventListener('click', this.toggleCollapsed);
+    this.desktopQuery.addEventListener('change', this.applyStoredState);
+    this.listening = true;
+    this.applyStoredState();
+  }
+
+  disconnectedCallback(): void {
+    this.removeListeners();
+  }
+
+  private readonly applyStoredState = (): void => {
+    this.setCollapsed(this.getStoredCollapsed());
+  };
+
+  private readonly toggleCollapsed = (): void => {
+    if (!this.desktopQuery?.matches) return;
+    const nextCollapsed = !document.documentElement.hasAttribute('data-sidebar-collapsed');
+    this.storeCollapsed(nextCollapsed);
+    this.setCollapsed(nextCollapsed);
+  };
+
+  private getStoredCollapsed(): boolean {
+    try {
+      return sessionStorage.getItem(storageKey) === 'true';
+    } catch {
+      return false;
+    }
+  }
+
+  private storeCollapsed(collapsed: boolean): void {
+    try {
+      if (collapsed) {
+        sessionStorage.setItem(storageKey, 'true');
+      } else {
+        sessionStorage.removeItem(storageKey);
+      }
+    } catch {
+      // Storage can be unavailable in privacy-restricted browsing contexts.
+    }
+  }
+
+  private setCollapsed(collapsed: boolean): void {
+    if (!this.button || !this.sidebar || !this.desktopQuery) return;
+
+    const active = this.desktopQuery.matches && collapsed;
+    const label = active ? this.expandLabel : this.collapseLabel;
+    document.documentElement.toggleAttribute('data-sidebar-collapsed', active);
+    if (active) {
+      document.documentElement.style.setProperty('--sl-content-inline-start', '0rem');
+      document.documentElement.style.setProperty(
+        '--sl-content-width',
+        'calc(var(--oq-sidebar-base-content-width) + var(--sl-sidebar-width))'
+      );
+    } else {
+      document.documentElement.style.removeProperty('--sl-content-inline-start');
+      document.documentElement.style.removeProperty('--sl-content-width');
+    }
+    this.button.setAttribute('aria-expanded', String(!active));
+    this.button.setAttribute('aria-label', label);
+    this.button.title = label;
+    if (active) {
+      this.sidebar.setAttribute('aria-hidden', 'true');
+    } else {
+      this.sidebar.removeAttribute('aria-hidden');
+    }
+    this.sidebar.toggleAttribute('inert', active);
+  }
+
+  private removeListeners(): void {
+    if (this.listening) {
+      this.button?.removeEventListener('click', this.toggleCollapsed);
+      this.desktopQuery?.removeEventListener('change', this.applyStoredState);
+    }
+    this.listening = false;
+    this.button = undefined;
+    this.desktopQuery = undefined;
+    this.sidebar = undefined;
+  }
+}
+
+export function defineStarlightSidebarToggle(): void {
+  if (!customElements.get('starlight-sidebar-toggle')) {
+    customElements.define('starlight-sidebar-toggle', StarlightSidebarToggle);
+  }
+}

--- a/packages/oxiquill/src/components/starlight/table-of-contents-toggle.ts
+++ b/packages/oxiquill/src/components/starlight/table-of-contents-toggle.ts
@@ -1,0 +1,17 @@
+import { createPersistentToggle } from './persistent-toggle.js';
+
+const TableOfContentsToggleElement = createPersistentToggle({
+  collapsedAttribute: 'data-table-of-contents-collapsed',
+  defaultCollapseLabel: 'Collapse table of contents',
+  defaultExpandLabel: 'Expand table of contents',
+  mediaQuery: '(min-width: 72rem)',
+  storageKey: 'oxiquill-table-of-contents-collapsed'
+});
+
+export class StarlightTableOfContentsToggle extends TableOfContentsToggleElement {}
+
+export function defineStarlightTableOfContentsToggle(): void {
+  if (!customElements.get('starlight-table-of-contents-toggle')) {
+    customElements.define('starlight-table-of-contents-toggle', StarlightTableOfContentsToggle);
+  }
+}

--- a/packages/oxiquill/src/components/starlight/toggle-localization.ts
+++ b/packages/oxiquill/src/components/starlight/toggle-localization.ts
@@ -1,0 +1,41 @@
+type Direction = 'ltr' | 'rtl';
+type ToggleTarget = 'sidebar' | 'tableOfContents';
+type ArrowIcon = 'left-arrow' | 'right-arrow';
+
+interface TogglePresentation {
+  collapseIcon: ArrowIcon;
+  collapseLabel: string;
+  expandIcon: ArrowIcon;
+  expandLabel: string;
+}
+
+const labels = {
+  en: {
+    sidebar: { collapse: 'Collapse sidebar', expand: 'Expand sidebar' },
+    tableOfContents: { collapse: 'Collapse table of contents', expand: 'Expand table of contents' }
+  },
+  ja: {
+    sidebar: { collapse: 'サイドバーを折りたたむ', expand: 'サイドバーを展開する' },
+    tableOfContents: { collapse: '目次を折りたたむ', expand: '目次を展開する' }
+  }
+} as const;
+
+export function togglePresentation(lang: string, direction: Direction, target: ToggleTarget): TogglePresentation {
+  const primaryLanguage = lang.trim().split(/[-_]/u)[0]?.toLowerCase();
+  const localizedLabels = primaryLanguage === 'ja' ? labels.ja[target] : labels.en[target];
+  const collapseIcon =
+    target === 'sidebar'
+      ? direction === 'rtl'
+        ? 'right-arrow'
+        : 'left-arrow'
+      : direction === 'rtl'
+        ? 'left-arrow'
+        : 'right-arrow';
+
+  return {
+    collapseIcon,
+    collapseLabel: localizedLabels.collapse,
+    expandIcon: collapseIcon === 'left-arrow' ? 'right-arrow' : 'left-arrow',
+    expandLabel: localizedLabels.expand
+  };
+}

--- a/packages/oxiquill/src/config/path-safety.mjs
+++ b/packages/oxiquill/src/config/path-safety.mjs
@@ -45,8 +45,11 @@ const protectedEntryRoles = Object.freeze(
   new Map([
     ['.git', 'Git repository metadata'],
     ['.hg', 'Mercurial repository metadata'],
+    ['.jj', 'Jujutsu repository metadata'],
     ['.pnp.cjs', 'Yarn dependency state'],
     ['.pnp.loader.mjs', 'Yarn dependency state'],
+    ['.pnpm', 'pnpm dependency state'],
+    ['.pnpm-store', 'pnpm dependency state'],
     ['.svn', 'Subversion repository metadata'],
     ['.yarn', 'Yarn dependency state'],
     ['node_modules', 'installed package dependencies']
@@ -119,6 +122,29 @@ export async function discoverProtectedPathRoles({ fileSystem = { readdir }, roo
   return protectedPaths.flat();
 }
 
+export async function discoverAuthoredPublicPathRoles({ fileSystem = { readdir }, paths }) {
+  const publicDir = canonicalPath(paths.publicDir);
+  const publicAssetsDir = canonicalPath(paths.publicAssetsDir);
+  const relative = path.relative(publicDir, publicAssetsDir);
+  if (relative === '' || relative.startsWith(`..${path.sep}`) || path.isAbsolute(relative)) return [];
+
+  const segments = relative.split(path.sep);
+  const ancestors = segments.slice(0, -1).map((_, index) => ({
+    expectedChild: segments[index + 1],
+    path: path.join(publicDir, ...segments.slice(0, index + 1))
+  }));
+  const authoredAncestors = await Promise.all(
+    ancestors.map(async (ancestor) => {
+      const entries = await directoryEntryNames(ancestor.path, fileSystem);
+      return entries.some((entryName) => entryName !== ancestor.expectedChild)
+        ? [role('authored public subtree', ancestor.path, 'authored public asset subtree')]
+        : [];
+    })
+  );
+
+  return authoredAncestors.flat();
+}
+
 async function findProtectedEntries(rootPath, fileSystem) {
   let entries;
   try {
@@ -141,6 +167,16 @@ async function findProtectedEntries(rootPath, fileSystem) {
   );
 
   return [...discovered, ...nested.flat()];
+}
+
+async function directoryEntryNames(directory, fileSystem) {
+  try {
+    const entries = await fileSystem.readdir(directory);
+    return entries.map((entry) => (typeof entry === 'string' ? entry : entry.name));
+  } catch (error) {
+    if (error?.code === 'ENOENT' || error?.code === 'ENOTDIR') return [];
+    throw error;
+  }
 }
 
 function assertStrictlyWithin(parentPath, candidatePath, fieldName, parentField) {

--- a/packages/oxiquill/src/config/path-safety.mjs
+++ b/packages/oxiquill/src/config/path-safety.mjs
@@ -1,0 +1,205 @@
+import { readdir } from 'node:fs/promises';
+import path from 'node:path';
+import { canonicalPath, isPathWithin } from './paths.mjs';
+
+const correctiveAction =
+  'Choose a dedicated generated directory that does not overlap authored, protected, persistent-cache, or other generated paths.';
+
+const cleanupRootDefinitions = Object.freeze([
+  { field: 'cacheDir', property: 'cacheDir', role: 'generated cache root' },
+  { field: 'outDir', property: 'outDir', role: 'generated Astro output root' },
+  { field: 'paths.publicAssetsDir', property: 'publicAssetsDir', role: 'generated public asset root' }
+]);
+
+const cacheChildDefinitions = Object.freeze([
+  { field: 'paths.generatedDir', property: 'generatedDir', role: 'generated manifest root' },
+  { field: 'paths.haskellCellsDir', property: 'haskellCellsDir', role: 'generated Haskell root' },
+  { field: 'paths.rustCellsDir', property: 'rustCellsDir', role: 'generated Rust root' }
+]);
+
+const publicChildDefinitions = Object.freeze([
+  { field: 'paths.haskellWasmPublicDir', property: 'haskellWasmPublicDir', role: 'generated Haskell asset root' },
+  { field: 'paths.licensesPublicDir', property: 'licensesPublicDir', role: 'generated license asset root' },
+  { field: 'paths.pyodidePublicDir', property: 'pyodidePublicDir', role: 'generated Pyodide asset root' },
+  { field: 'paths.rustWasmPublicDir', property: 'rustWasmPublicDir', role: 'generated Rust asset root' }
+]);
+
+const workspaceProjectFileNames = Object.freeze([
+  'astro.config.js',
+  'astro.config.mjs',
+  'astro.config.mts',
+  'astro.config.ts',
+  'bun.lock',
+  'bun.lockb',
+  'deno.json',
+  'deno.jsonc',
+  'package-lock.json',
+  'package.json',
+  'pnpm-lock.yaml',
+  'pnpm-workspace.yaml',
+  'tsconfig.json',
+  'yarn.lock'
+]);
+
+const protectedEntryRoles = Object.freeze(
+  new Map([
+    ['.git', 'Git repository metadata'],
+    ['.hg', 'Mercurial repository metadata'],
+    ['.pnp.cjs', 'Yarn dependency state'],
+    ['.pnp.loader.mjs', 'Yarn dependency state'],
+    ['.svn', 'Subversion repository metadata'],
+    ['.yarn', 'Yarn dependency state'],
+    ['node_modules', 'installed package dependencies']
+  ])
+);
+
+export const cleanupRootFields = Object.freeze(cleanupRootDefinitions.map(({ property }) => property));
+
+export function cleanupPathRoles(paths) {
+  return cleanupRootDefinitions.map((definition) => pathRole(definition, paths));
+}
+
+export function validateProjectPathSafety({ configFile, paths, protectedPaths = [] }) {
+  if (!paths) throw new TypeError('Path safety validation requires resolved project paths.');
+
+  const workspaceRoot = canonicalPath(paths.workspaceRoot);
+  const cleanupRoots = cleanupPathRoles(paths);
+  const cacheChildren = cacheChildDefinitions.map((definition) => pathRole(definition, paths));
+  const publicChildren = publicChildDefinitions.map((definition) => pathRole(definition, paths));
+
+  assertStrictlyWithin(workspaceRoot, paths.cacheDir, 'cacheDir', 'workspaceRoot');
+  assertStrictlyWithin(workspaceRoot, paths.outDir, 'outDir', 'workspaceRoot');
+  assertStrictlyWithin(workspaceRoot, paths.publicDir, 'paths.publicDir', 'workspaceRoot');
+  assertStrictlyWithin(workspaceRoot, paths.publicAssetsDir, 'paths.publicAssetsDir', 'workspaceRoot');
+  assertStrictlyWithin(workspaceRoot, paths.downloadCacheDir, 'paths.downloadCacheDir', 'workspaceRoot');
+  assertStrictlyWithin(paths.publicDir, paths.publicAssetsDir, 'paths.publicAssetsDir', 'paths.publicDir');
+
+  cacheChildren.forEach((child) => assertStrictlyWithin(paths.cacheDir, child.path, child.field, 'cacheDir'));
+  publicChildren.forEach((child) =>
+    assertStrictlyWithin(paths.publicAssetsDir, child.path, child.field, 'paths.publicAssetsDir')
+  );
+
+  const authoredAndProtected = [
+    role('docsDir', paths.docsDir, 'authored documentation input'),
+    role('cratesDir', paths.cratesDir, 'authored helper-crate input'),
+    role('paths.publicDir', paths.publicDir, 'authored public asset root'),
+    role('paths.frameworkRoot', paths.frameworkRoot, 'Oxiquill framework input'),
+    role('paths.downloadCacheDir', paths.downloadCacheDir, 'persistent verified download cache'),
+    ...(configFile ? [role('configFile', configFile, 'selected Astro configuration')] : []),
+    ...workspaceProjectFileNames.map((fileName) =>
+      role(`project file ${fileName}`, path.join(workspaceRoot, fileName), 'authored project configuration')
+    ),
+    ...Array.from(protectedEntryRoles, ([entryName, protectedRole]) =>
+      role(entryName, path.join(workspaceRoot, entryName), protectedRole)
+    ),
+    ...protectedPaths.map(({ field, path: protectedPath, role: protectedRole }) =>
+      role(field, protectedPath, protectedRole)
+    )
+  ];
+
+  cleanupRoots.forEach((cleanupRoot) => {
+    authoredAndProtected.forEach((protectedPath) => {
+      if (cleanupRoot.property === 'publicAssetsDir' && protectedPath.field === 'paths.publicDir') return;
+      assertPathsDisjoint(cleanupRoot, protectedPath);
+    });
+
+    const protectedAncestor = protectedPathSegment(workspaceRoot, cleanupRoot.path);
+    if (protectedAncestor) assertPathsDisjoint(cleanupRoot, protectedAncestor);
+  });
+
+  assertPairwiseDisjoint(cleanupRoots);
+  assertPairwiseDisjoint(cacheChildren);
+  assertPairwiseDisjoint(publicChildren);
+
+  return Object.freeze({ cacheChildren, cleanupRoots, publicChildren });
+}
+
+export async function discoverProtectedPathRoles({ fileSystem = { readdir }, roots }) {
+  const protectedPaths = await Promise.all(roots.map((root) => findProtectedEntries(root.path, fileSystem)));
+  return protectedPaths.flat();
+}
+
+async function findProtectedEntries(rootPath, fileSystem) {
+  let entries;
+  try {
+    entries = await fileSystem.readdir(rootPath, { withFileTypes: true });
+  } catch (error) {
+    if (error?.code === 'ENOENT' || error?.code === 'ENOTDIR') return [];
+    throw error;
+  }
+
+  const discovered = entries.flatMap((entry) => {
+    const entryPath = path.join(rootPath, entry.name);
+    const protectedRole = protectedEntryRoles.get(entry.name);
+    if (protectedRole) return [role(entry.name, entryPath, protectedRole)];
+    return [];
+  });
+  const nested = await Promise.all(
+    entries
+      .filter((entry) => entry.isDirectory() && !protectedEntryRoles.has(entry.name))
+      .map((entry) => findProtectedEntries(path.join(rootPath, entry.name), fileSystem))
+  );
+
+  return [...discovered, ...nested.flat()];
+}
+
+function assertStrictlyWithin(parentPath, candidatePath, fieldName, parentField) {
+  const canonicalParent = canonicalPath(parentPath);
+  const canonicalCandidate = canonicalPath(candidatePath);
+  if (isPathWithin(canonicalParent, canonicalCandidate)) return;
+
+  throw new Error(
+    `Unsafe path ${fieldName} at ${canonicalCandidate}: it must be strictly inside ${parentField} at ${canonicalParent}. ${correctiveAction}`
+  );
+}
+
+function assertPairwiseDisjoint(paths) {
+  paths.forEach((left, index) => {
+    paths.slice(index + 1).forEach((right) => assertPathsDisjoint(left, right));
+  });
+}
+
+function assertPathsDisjoint(left, right) {
+  const relationship = pathRelationship(left.path, right.path);
+  if (!relationship) return;
+
+  throw new Error(
+    `Unsafe cleanup path ${left.field} at ${left.path}: it is ${relationship} ${right.field} (${right.role}) at ${right.path}. ${correctiveAction}`
+  );
+}
+
+function pathRelationship(leftPath, rightPath) {
+  const left = canonicalPath(leftPath);
+  const right = canonicalPath(rightPath);
+  if (left === right) return 'equal to';
+  if (isPathWithin(left, right)) return 'an ancestor of';
+  if (isPathWithin(right, left)) return 'a descendant of';
+  return undefined;
+}
+
+function pathRole(definition, paths) {
+  return Object.freeze({
+    ...definition,
+    path: canonicalPath(paths[definition.property])
+  });
+}
+
+function protectedPathSegment(workspaceRoot, candidatePath) {
+  const relative = path.relative(workspaceRoot, candidatePath);
+  if (relative === '' || relative.startsWith(`..${path.sep}`) || path.isAbsolute(relative)) return undefined;
+
+  const segments = relative.split(path.sep);
+  const protectedIndex = segments.findIndex((segment) => protectedEntryRoles.has(segment));
+  if (protectedIndex < 0) return undefined;
+
+  const entryName = segments[protectedIndex];
+  return role(
+    entryName,
+    path.join(workspaceRoot, ...segments.slice(0, protectedIndex + 1)),
+    protectedEntryRoles.get(entryName)
+  );
+}
+
+function role(field, value, roleName) {
+  return Object.freeze({ field, path: canonicalPath(value), role: roleName });
+}

--- a/packages/oxiquill/src/config/path-safety.mjs
+++ b/packages/oxiquill/src/config/path-safety.mjs
@@ -1,6 +1,6 @@
 import { readdir } from 'node:fs/promises';
 import path from 'node:path';
-import { canonicalPath, isPathWithin } from './paths.mjs';
+import { arePathsEqual, canonicalPath, isPathWithin } from './paths.mjs';
 
 const correctiveAction =
   'Choose a dedicated generated directory that does not overlap authored, protected, persistent-cache, or other generated paths.';
@@ -136,7 +136,7 @@ export async function discoverAuthoredPublicPathRoles({ fileSystem = { readdir }
   const authoredAncestors = await Promise.all(
     ancestors.map(async (ancestor) => {
       const entries = await directoryEntryNames(ancestor.path, fileSystem);
-      return entries.some((entryName) => entryName !== ancestor.expectedChild)
+      return entries.some((entryName) => !pathNamesEqual(entryName, ancestor.expectedChild))
         ? [role('authored public subtree', ancestor.path, 'authored public asset subtree')]
         : [];
     })
@@ -156,13 +156,13 @@ async function findProtectedEntries(rootPath, fileSystem) {
 
   const discovered = entries.flatMap((entry) => {
     const entryPath = path.join(rootPath, entry.name);
-    const protectedRole = protectedEntryRoles.get(entry.name);
+    const protectedRole = protectedRoleForEntryName(entry.name);
     if (protectedRole) return [role(entry.name, entryPath, protectedRole)];
     return [];
   });
   const nested = await Promise.all(
     entries
-      .filter((entry) => entry.isDirectory() && !protectedEntryRoles.has(entry.name))
+      .filter((entry) => entry.isDirectory() && !protectedRoleForEntryName(entry.name))
       .map((entry) => findProtectedEntries(path.join(rootPath, entry.name), fileSystem))
   );
 
@@ -207,7 +207,7 @@ function assertPathsDisjoint(left, right) {
 function pathRelationship(leftPath, rightPath) {
   const left = canonicalPath(leftPath);
   const right = canonicalPath(rightPath);
-  if (left === right) return 'equal to';
+  if (arePathsEqual(left, right)) return 'equal to';
   if (isPathWithin(left, right)) return 'an ancestor of';
   if (isPathWithin(right, left)) return 'a descendant of';
   return undefined;
@@ -225,15 +225,25 @@ function protectedPathSegment(workspaceRoot, candidatePath) {
   if (relative === '' || relative.startsWith(`..${path.sep}`) || path.isAbsolute(relative)) return undefined;
 
   const segments = relative.split(path.sep);
-  const protectedIndex = segments.findIndex((segment) => protectedEntryRoles.has(segment));
+  const protectedIndex = segments.findIndex((segment) => protectedRoleForEntryName(segment));
   if (protectedIndex < 0) return undefined;
 
   const entryName = segments[protectedIndex];
   return role(
     entryName,
     path.join(workspaceRoot, ...segments.slice(0, protectedIndex + 1)),
-    protectedEntryRoles.get(entryName)
+    protectedRoleForEntryName(entryName)
   );
+}
+
+function protectedRoleForEntryName(entryName) {
+  const exact = protectedEntryRoles.get(entryName);
+  if (exact || process.platform !== 'win32') return exact;
+  return Array.from(protectedEntryRoles).find(([name]) => name.toLowerCase() === entryName.toLowerCase())?.[1];
+}
+
+function pathNamesEqual(left, right) {
+  return process.platform === 'win32' ? left.toLowerCase() === right.toLowerCase() : left === right;
 }
 
 function role(field, value, roleName) {

--- a/packages/oxiquill/src/config/paths.mjs
+++ b/packages/oxiquill/src/config/paths.mjs
@@ -100,6 +100,10 @@ export function isPathWithin(parentPath, candidatePath) {
   );
 }
 
+export function arePathsEqual(leftPath, rightPath) {
+  return path.relative(canonicalPath(leftPath), canonicalPath(rightPath)) === '';
+}
+
 export function assertPathWithin(parentPath, candidatePath, fieldName) {
   if (!isPathWithin(parentPath, candidatePath)) {
     throw new Error(`${fieldName} must resolve to a directory inside ${parentPath}; received ${candidatePath}.`);

--- a/packages/oxiquill/src/config/project-config.mjs
+++ b/packages/oxiquill/src/config/project-config.mjs
@@ -2,7 +2,7 @@ import { existsSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { loadConfigFromFile } from 'vite';
-import { canonicalPath, createOxiquillPaths, directoryPath } from './paths.mjs';
+import { arePathsEqual, canonicalPath, createOxiquillPaths, directoryPath } from './paths.mjs';
 import { astroDirectoryOptionNames, readOxiquillMetadata } from './metadata.mjs';
 import { validateProjectPathSafety } from './path-safety.mjs';
 
@@ -184,7 +184,7 @@ function reconcileDirectory({
   const astroPath = astroExplicit ? directoryPath(astroOptions[astroField], basePath) : undefined;
   const oxiquillPath = pathExplicit ? directoryPath(pathOptions[pathField], basePath) : undefined;
 
-  if (astroPath && oxiquillPath && astroPath !== oxiquillPath) {
+  if (astroPath && oxiquillPath && !arePathsEqual(astroPath, oxiquillPath)) {
     throw new Error(
       `Conflicting project paths: ${astroField} resolves to ${astroPath}, ` +
         `but paths.${pathField} resolves to ${oxiquillPath}.`

--- a/packages/oxiquill/src/config/project-config.mjs
+++ b/packages/oxiquill/src/config/project-config.mjs
@@ -2,8 +2,9 @@ import { existsSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { loadConfigFromFile } from 'vite';
-import { assertPathWithin, canonicalPath, createOxiquillPaths, directoryPath, isPathWithin } from './paths.mjs';
+import { canonicalPath, createOxiquillPaths, directoryPath } from './paths.mjs';
 import { astroDirectoryOptionNames, readOxiquillMetadata } from './metadata.mjs';
+import { validateProjectPathSafety } from './path-safety.mjs';
 
 const astroConfigFileNames = Object.freeze([
   'astro.config.mjs',
@@ -130,11 +131,10 @@ export function resolveOxiquillProjectConfig({
     outDir
   });
 
-  validateOwnedPaths(paths);
-
   const resolvedConfigFile = configFile
     ? path.resolve(pathFromConfigValue(configFile, invocationCwd, 'configFile'))
     : undefined;
+  validateProjectPathSafety({ configFile: resolvedConfigFile, paths });
   const astroConfigArgs = resolvedConfigFile
     ? Object.freeze(['--root', paths.workspaceRoot, '--config', path.relative(paths.workspaceRoot, resolvedConfigFile)])
     : Object.freeze(['--root', paths.workspaceRoot]);
@@ -192,26 +192,6 @@ function reconcileDirectory({
   }
 
   return astroPath ?? oxiquillPath ?? directoryPath(defaultValue, basePath);
-}
-
-function validateOwnedPaths(paths) {
-  assertPathWithin(paths.workspaceRoot, paths.cacheDir, 'cacheDir');
-  assertPathWithin(paths.workspaceRoot, paths.downloadCacheDir, 'paths.downloadCacheDir');
-  assertPathWithin(paths.workspaceRoot, paths.outDir, 'outDir');
-  assertPathWithin(paths.cacheDir, paths.generatedDir, 'paths.generatedDir');
-  assertPathWithin(paths.cacheDir, paths.haskellCellsDir, 'paths.haskellCellsDir');
-  assertPathWithin(paths.cacheDir, paths.rustCellsDir, 'paths.rustCellsDir');
-  assertPathWithin(paths.publicDir, paths.publicAssetsDir, 'paths.publicAssetsDir');
-  assertPathWithin(paths.publicAssetsDir, paths.haskellWasmPublicDir, 'paths.haskellWasmPublicDir');
-  assertPathWithin(paths.publicAssetsDir, paths.licensesPublicDir, 'paths.licensesPublicDir');
-  assertPathWithin(paths.publicAssetsDir, paths.pyodidePublicDir, 'paths.pyodidePublicDir');
-  assertPathWithin(paths.publicAssetsDir, paths.rustWasmPublicDir, 'paths.rustWasmPublicDir');
-
-  const downloadCache = canonicalPath(paths.downloadCacheDir);
-  const cleanedRoots = [paths.cacheDir, paths.outDir, paths.publicAssetsDir].map(canonicalPath);
-  if (cleanedRoots.some((root) => downloadCache === root || isPathWithin(root, downloadCache))) {
-    throw new Error('paths.downloadCacheDir must resolve outside directories removed by oxiquill clean.');
-  }
 }
 
 function flattenIntegrations(value) {

--- a/packages/oxiquill/src/generator/clean.mjs
+++ b/packages/oxiquill/src/generator/clean.mjs
@@ -1,29 +1,21 @@
 import { rm } from 'node:fs/promises';
 import { pathToFileURL } from 'node:url';
-import { assertPathWithin, canonicalPath, isPathWithin } from '../config/paths.mjs';
+import { verifyCleanupOwnership } from './cleanup-ownership.mjs';
 
 const defaultFileSystem = { rm };
 
-export async function cleanOxiquillWorkspace({ fileSystem = defaultFileSystem, paths } = {}) {
+export async function cleanOxiquillWorkspace({ configFile, fileSystem = defaultFileSystem, paths } = {}) {
   if (!paths) throw new TypeError('cleanOxiquillWorkspace requires resolved project paths.');
 
-  assertPathWithin(paths.workspaceRoot, paths.cacheDir, 'cacheDir');
-  assertPathWithin(paths.workspaceRoot, paths.downloadCacheDir, 'paths.downloadCacheDir');
-  assertPathWithin(paths.workspaceRoot, paths.outDir, 'outDir');
-  assertPathWithin(paths.publicDir, paths.publicAssetsDir, 'paths.publicAssetsDir');
-  const ownedPaths = Array.from(
-    new Set([canonicalPath(paths.cacheDir), canonicalPath(paths.publicAssetsDir), canonicalPath(paths.outDir)])
-  );
-  const downloadCache = canonicalPath(paths.downloadCacheDir);
-  if (ownedPaths.some((targetPath) => downloadCache === targetPath || isPathWithin(targetPath, downloadCache))) {
-    throw new Error('paths.downloadCacheDir must resolve outside directories removed by oxiquill clean.');
-  }
+  const ownedRoots = await verifyCleanupOwnership({ configFile, fileSystem, paths });
 
-  await Promise.all(ownedPaths.map((targetPath) => fileSystem.rm(targetPath, { recursive: true, force: true })));
+  await Promise.all(
+    ownedRoots.map(({ path: targetPath }) => fileSystem.rm(targetPath, { recursive: true, force: true }))
+  );
 }
 
 if (import.meta.url === pathToFileURL(process.argv[1] ?? '').href) {
   const { loadOxiquillProjectConfig } = await import('../config/project-config.mjs');
   const projectConfig = await loadOxiquillProjectConfig({ cwd: process.cwd() });
-  await cleanOxiquillWorkspace({ paths: projectConfig.paths });
+  await cleanOxiquillWorkspace({ configFile: projectConfig.configFile, paths: projectConfig.paths });
 }

--- a/packages/oxiquill/src/generator/cleanup-ownership.mjs
+++ b/packages/oxiquill/src/generator/cleanup-ownership.mjs
@@ -7,7 +7,7 @@ import {
   discoverProtectedPathRoles,
   validateProjectPathSafety
 } from '../config/path-safety.mjs';
-import { canonicalPath, normalizePath } from '../config/paths.mjs';
+import { arePathsEqual, canonicalPath, normalizePath } from '../config/paths.mjs';
 
 export const CLEANUP_OWNERSHIP_MARKER = '.oxiquill-ownership.json';
 
@@ -159,7 +159,7 @@ function isDefaultCleanupRoot(root, paths) {
       : root.property === 'outDir'
         ? path.join(paths.workspaceRoot, 'dist')
         : path.join(paths.publicDir, 'oxiquill');
-  return root.path === canonicalPath(defaultPath);
+  return arePathsEqual(root.path, defaultPath);
 }
 
 function ownershipError(root, reason) {

--- a/packages/oxiquill/src/generator/cleanup-ownership.mjs
+++ b/packages/oxiquill/src/generator/cleanup-ownership.mjs
@@ -1,0 +1,163 @@
+import { lstat, mkdir, readFile, readdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import {
+  cleanupPathRoles,
+  cleanupRootFields,
+  discoverProtectedPathRoles,
+  validateProjectPathSafety
+} from '../config/path-safety.mjs';
+import { canonicalPath, normalizePath } from '../config/paths.mjs';
+
+export const CLEANUP_OWNERSHIP_MARKER = '.oxiquill-ownership.json';
+
+const markerSchemaVersion = 1;
+const defaultFileSystem = { lstat, mkdir, readFile, readdir, writeFile };
+const ownershipCorrection =
+  'Use a missing or empty dedicated directory so Oxiquill can establish ownership, or restore its valid ownership marker.';
+
+export async function prepareCleanupOwnership({
+  configFile,
+  fields = cleanupRootFields,
+  fileSystem = defaultFileSystem,
+  paths
+}) {
+  const services = { ...defaultFileSystem, ...fileSystem };
+  const roots = await validatedCleanupRoots({ configFile, fields, fileSystem: services, paths });
+  const inspections = await Promise.all(
+    roots.map((root) => inspectOwnership(root, paths, services, { allowClaim: true }))
+  );
+
+  await Promise.all(
+    inspections.map(async (inspection) => {
+      if (!inspection.writeMarker) return;
+      await services.mkdir(inspection.root.path, { recursive: true });
+      await services.writeFile(inspection.markerPath, inspection.markerSource, {
+        encoding: 'utf8',
+        flag: 'wx'
+      });
+    })
+  );
+
+  return Object.freeze(
+    inspections.map((inspection) =>
+      Object.freeze({
+        markerPath: inspection.markerPath,
+        markerSource: inspection.markerSource,
+        root: inspection.root
+      })
+    )
+  );
+}
+
+export async function maintainCleanupOwnership({ fileSystem = defaultFileSystem, ownership }) {
+  const services = { ...defaultFileSystem, ...fileSystem };
+  await Promise.all(
+    ownership.map(async ({ markerPath, markerSource, root }) => {
+      await services.mkdir(root.path, { recursive: true });
+      await services.writeFile(markerPath, markerSource, 'utf8');
+    })
+  );
+}
+
+export async function verifyCleanupOwnership({
+  configFile,
+  fields = cleanupRootFields,
+  fileSystem = defaultFileSystem,
+  paths
+}) {
+  const services = { ...defaultFileSystem, ...fileSystem };
+  const roots = await validatedCleanupRoots({ configFile, fields, fileSystem: services, paths });
+  const inspections = await Promise.all(
+    roots.map((root) => inspectOwnership(root, paths, services, { allowClaim: false }))
+  );
+  return Object.freeze(inspections.filter(({ exists }) => exists).map(({ root }) => root));
+}
+
+async function validatedCleanupRoots({ configFile, fields, fileSystem, paths }) {
+  const selectedFields = new Set(fields);
+  const unknownFields = Array.from(selectedFields).filter((field) => !cleanupRootFields.includes(field));
+  if (unknownFields.length > 0) throw new TypeError(`Unknown cleanup root field: ${unknownFields.sort().join(', ')}.`);
+
+  const roots = cleanupPathRoles(paths).filter(({ property }) => selectedFields.has(property));
+  validateProjectPathSafety({ configFile, paths });
+  const protectedPaths = await discoverProtectedPathRoles({ fileSystem, roots });
+  validateProjectPathSafety({ configFile, paths, protectedPaths });
+  return roots;
+}
+
+async function inspectOwnership(root, paths, fileSystem, { allowClaim }) {
+  const markerPath = path.join(root.path, CLEANUP_OWNERSHIP_MARKER);
+  const markerSource = ownershipMarkerSource(root, paths);
+  const targetState = await pathState(root.path, fileSystem);
+  if (!targetState.exists) {
+    return { exists: false, markerPath, markerSource, root, writeMarker: allowClaim };
+  }
+  if (!targetState.directory) {
+    throw ownershipError(root, 'the cleanup target exists but is not a directory');
+  }
+
+  const marker = await readMarker(markerPath, fileSystem);
+  if (marker.exists) {
+    if (marker.source !== markerSource) {
+      throw ownershipError(root, `the ownership marker ${markerPath} does not match this workspace and path role`);
+    }
+    return { exists: true, markerPath, markerSource, root, writeMarker: false };
+  }
+
+  if (isDefaultCleanupRoot(root, paths)) {
+    return { exists: true, markerPath, markerSource, root, writeMarker: allowClaim };
+  }
+
+  const entries = await fileSystem.readdir(root.path);
+  if (allowClaim && entries.length === 0) {
+    return { exists: true, markerPath, markerSource, root, writeMarker: true };
+  }
+
+  throw ownershipError(root, `the custom cleanup target has no ${CLEANUP_OWNERSHIP_MARKER} marker`);
+}
+
+async function pathState(targetPath, fileSystem) {
+  try {
+    const stats = await fileSystem.lstat(targetPath);
+    return { directory: stats.isDirectory(), exists: true };
+  } catch (error) {
+    if (error?.code === 'ENOENT') return { directory: false, exists: false };
+    throw error;
+  }
+}
+
+async function readMarker(markerPath, fileSystem) {
+  try {
+    return { exists: true, source: await fileSystem.readFile(markerPath, 'utf8') };
+  } catch (error) {
+    if (error?.code === 'ENOENT') return { exists: false, source: undefined };
+    throw error;
+  }
+}
+
+function ownershipMarkerSource(root, paths) {
+  return `${JSON.stringify(
+    {
+      field: root.field,
+      owner: 'oxiquill',
+      path: normalizePath(path.relative(canonicalPath(paths.workspaceRoot), root.path)),
+      schemaVersion: markerSchemaVersion
+    },
+    null,
+    2
+  )}\n`;
+}
+
+function isDefaultCleanupRoot(root, paths) {
+  const defaultPath =
+    root.property === 'cacheDir'
+      ? path.join(paths.workspaceRoot, '.oxiquill')
+      : root.property === 'outDir'
+        ? path.join(paths.workspaceRoot, 'dist')
+        : path.join(paths.publicDir, 'oxiquill');
+  return root.path === canonicalPath(defaultPath);
+}
+
+function ownershipError(root, reason) {
+  return new Error(`Unsafe cleanup root ${root.field} at ${root.path}: ${reason}. ${ownershipCorrection}`);
+}

--- a/packages/oxiquill/src/generator/cleanup-ownership.mjs
+++ b/packages/oxiquill/src/generator/cleanup-ownership.mjs
@@ -3,6 +3,7 @@ import path from 'node:path';
 import {
   cleanupPathRoles,
   cleanupRootFields,
+  discoverAuthoredPublicPathRoles,
   discoverProtectedPathRoles,
   validateProjectPathSafety
 } from '../config/path-safety.mjs';
@@ -80,7 +81,10 @@ async function validatedCleanupRoots({ configFile, fields, fileSystem, paths }) 
 
   const roots = cleanupPathRoles(paths).filter(({ property }) => selectedFields.has(property));
   validateProjectPathSafety({ configFile, paths });
-  const protectedPaths = await discoverProtectedPathRoles({ fileSystem, roots });
+  const protectedPaths = [
+    ...(await discoverProtectedPathRoles({ fileSystem, roots })),
+    ...(await discoverAuthoredPublicPathRoles({ fileSystem, paths }))
+  ];
   validateProjectPathSafety({ configFile, paths, protectedPaths });
   return roots;
 }

--- a/packages/oxiquill/src/generator/cleanup-ownership.mjs
+++ b/packages/oxiquill/src/generator/cleanup-ownership.mjs
@@ -17,7 +17,7 @@ const ownershipCorrection =
   'Use a missing or empty dedicated directory so Oxiquill can establish ownership, or restore its valid ownership marker.';
 
 export async function prepareCleanupOwnership({
-  configFile,
+  configFile = undefined,
   fields = cleanupRootFields,
   fileSystem = defaultFileSystem,
   paths
@@ -61,7 +61,7 @@ export async function maintainCleanupOwnership({ fileSystem = defaultFileSystem,
 }
 
 export async function verifyCleanupOwnership({
-  configFile,
+  configFile = undefined,
   fields = cleanupRootFields,
   fileSystem = defaultFileSystem,
   paths

--- a/packages/oxiquill/src/generator/doc-runtime-service.mjs
+++ b/packages/oxiquill/src/generator/doc-runtime-service.mjs
@@ -54,6 +54,7 @@ export {
   copyVendoredPyodidePackages,
   fetchPyodidePackage,
   PYODIDE_DOWNLOAD_ATTEMPTS,
+  PYODIDE_DOWNLOAD_CONCURRENCY,
   PYODIDE_REQUEST_TIMEOUT_MS,
   requiredPyodideFiles,
   resolvePyodideRuntimeInputs,

--- a/packages/oxiquill/src/generator/doc-runtime/file-system.mjs
+++ b/packages/oxiquill/src/generator/doc-runtime/file-system.mjs
@@ -1,13 +1,16 @@
-import { existsSync } from 'node:fs';
-import { copyFile, mkdir, readFile, readdir, rename, rm, writeFile } from 'node:fs/promises';
+import { createReadStream, existsSync } from 'node:fs';
+import { copyFile, link, mkdir, open, readFile, readdir, rename, rm, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { pathFromUrl } from '../../config/paths.mjs';
-import { hashBytes } from './hashing.mjs';
+import { createSha256, hashBytes } from './hashing.mjs';
 
 export const defaultFileSystem = {
   copyFile,
+  createReadStream,
   existsSync,
+  link,
   mkdir,
+  open,
   readFile,
   readdir,
   rename,
@@ -53,11 +56,20 @@ export async function copyFileIfChanged(sourcePath, targetPath, { fileSystem = d
 export async function hasPackageContent(filePath, sha256, { fileSystem = defaultFileSystem } = {}) {
   const targetPath = pathFromUrl(filePath);
   try {
-    return hashBytes(await fileSystem.readFile(targetPath)) === sha256;
+    return (await hashFileSha256(targetPath, { fileSystem })) === sha256;
   } catch (error) {
     if (error && error.code === 'ENOENT') return false;
     throw error;
   }
+}
+
+export async function hashFileSha256(filePath, { fileSystem = defaultFileSystem } = {}) {
+  const targetPath = pathFromUrl(filePath);
+  if (!fileSystem.createReadStream) return hashBytes(await fileSystem.readFile(targetPath));
+
+  const hash = createSha256();
+  for await (const chunk of fileSystem.createReadStream(targetPath)) hash.update(chunk);
+  return hash.digest('hex');
 }
 
 async function hasTextContent(filePath, content, { fileSystem }) {

--- a/packages/oxiquill/src/generator/doc-runtime/hashing.mjs
+++ b/packages/oxiquill/src/generator/doc-runtime/hashing.mjs
@@ -1,13 +1,17 @@
 import { createHash } from 'node:crypto';
 
+export function createSha256() {
+  return createHash('sha256');
+}
+
 export function stableFingerprint(value) {
   return JSON.stringify(value);
 }
 
 export function hashText(value) {
-  return createHash('sha256').update(value).digest('hex');
+  return createSha256().update(value).digest('hex');
 }
 
 export function hashBytes(value) {
-  return createHash('sha256').update(value).digest('hex');
+  return createSha256().update(value).digest('hex');
 }

--- a/packages/oxiquill/src/generator/doc-runtime/haskell-codegen.mjs
+++ b/packages/oxiquill/src/generator/doc-runtime/haskell-codegen.mjs
@@ -122,9 +122,10 @@ readDoubleInput name raw = case readMaybe raw of
   Nothing -> fail ("input " <> show name <> " must be a number, received " <> show raw)
 
 readIntInput :: String -> String -> IO Int
-readIntInput name raw = case readMaybe raw of
-  Just value -> pure value
-  Nothing -> fail ("input " <> show name <> " must be an integer, received " <> show raw)
+readIntInput name raw = case readMaybe raw :: Maybe Integer of
+  Just value
+    | value >= -2147483648 && value <= 2147483647 -> pure (fromInteger value)
+  _ -> fail ("input " <> show name <> " must be a signed 32-bit integer, received " <> show raw)
 
 readBoolInput :: String -> String -> IO Bool
 readBoolInput _ "true" = pure True

--- a/packages/oxiquill/src/generator/doc-runtime/helper-crates.mjs
+++ b/packages/oxiquill/src/generator/doc-runtime/helper-crates.mjs
@@ -9,7 +9,7 @@ export function helperCratesFromManifests(manifests, { rustCellsDir }) {
       manifestPath: manifest.manifestPath,
       name: packageNameFromCargoToml(manifest.content, manifest.manifestPath)
     }))
-    .sort((left, right) => left.name.localeCompare(right.name));
+    .sort((left, right) => left.name.localeCompare(right.name) || left.manifestPath.localeCompare(right.manifestPath));
 
   const duplicate = findDuplicate(helperCrates);
   if (duplicate) {

--- a/packages/oxiquill/src/generator/doc-runtime/helper-crates.mjs
+++ b/packages/oxiquill/src/generator/doc-runtime/helper-crates.mjs
@@ -1,46 +1,81 @@
 import path from 'node:path';
+import { parse } from 'smol-toml';
 import { normalizePath } from './path-utils.mjs';
 
 export function helperCratesFromManifests(manifests, { rustCellsDir }) {
   const helperCrates = manifests
     .map((manifest) => ({
       manifestDir: path.dirname(manifest.manifestPath),
+      manifestPath: manifest.manifestPath,
       name: packageNameFromCargoToml(manifest.content, manifest.manifestPath)
     }))
-    .map(({ manifestDir, name }) => [
+    .sort((left, right) => left.name.localeCompare(right.name));
+
+  const duplicate = findDuplicate(helperCrates);
+  if (duplicate) {
+    throw new Error(
+      `Helper crate manifests ${duplicate.first.manifestPath} and ${duplicate.second.manifestPath} use duplicate package name "${duplicate.first.name}".`
+    );
+  }
+
+  return new Map(
+    helperCrates.map(({ manifestDir, name }) => [
       name,
       {
         name,
         relativePath: normalizePath(path.relative(rustCellsDir, manifestDir))
       }
     ])
-    .sort(([left], [right]) => left.localeCompare(right));
-
-  const duplicateName = findDuplicate(helperCrates.map(([name]) => name));
-  if (duplicateName) {
-    throw new Error(`Duplicate helper crate package name "${duplicateName}" under crates/.`);
-  }
-
-  return new Map(helperCrates);
+  );
 }
 
 export function packageNameFromCargoToml(content, manifestPath) {
-  const packageTable = content.match(/(?:^|\n)\[package\]\s*(?:\n|$)([\s\S]*?)(?=\n\[|$)/u);
-  const nameLine = packageTable?.[1].match(/(?:^|\n)\s*name\s*=\s*"([^"]+)"\s*(?:\n|$)/u);
-  const name = nameLine?.[1]?.trim();
-  if (!name) {
-    throw new Error(`Helper crate manifest ${manifestPath} is missing [package] name.`);
+  let manifest;
+  try {
+    manifest = parse(content);
+  } catch (error) {
+    throw new Error(`Helper crate manifest ${manifestPath} contains malformed TOML: ${errorMessage(error)}`, {
+      cause: error
+    });
+  }
+
+  if (!isTable(manifest.package)) {
+    throw new Error(`Helper crate manifest ${manifestPath} is missing a [package] table.`);
+  }
+  if (!Object.hasOwn(manifest.package, 'name')) {
+    throw new Error(`Helper crate manifest ${manifestPath} is missing package.name.`);
+  }
+
+  const name = manifest.package.name;
+  if (typeof name !== 'string') {
+    throw new Error(`Helper crate manifest ${manifestPath} has a non-string package.name.`);
+  }
+  if (!isValidCargoPackageName(name)) {
+    throw new Error(`Helper crate manifest ${manifestPath} has invalid package.name ${JSON.stringify(name)}.`);
   }
 
   return name;
 }
 
 function findDuplicate(values) {
-  const seen = new Set();
+  const seen = new Map();
   for (const value of values) {
-    if (seen.has(value)) return value;
-    seen.add(value);
+    const first = seen.get(value.name);
+    if (first) return { first, second: value };
+    seen.set(value.name, value);
   }
 
   return undefined;
+}
+
+function isTable(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function isValidCargoPackageName(name) {
+  return name.length > 0 && Array.from(name).every((character) => /^[\p{Alphabetic}\p{Number}_-]$/u.test(character));
+}
+
+function errorMessage(error) {
+  return error instanceof Error && error.message ? error.message : String(error);
 }

--- a/packages/oxiquill/src/generator/doc-runtime/pyodide-assets.mjs
+++ b/packages/oxiquill/src/generator/doc-runtime/pyodide-assets.mjs
@@ -342,20 +342,26 @@ async function streamResponseToFile(response, temporaryPath, asset, { fileSystem
   if (!fileSystem.open) throw new Error('The configured file system does not support streaming writes.');
 
   const hash = createSha256();
-  const fileHandle = await fileSystem.open(temporaryPath, 'w');
+  await fileSystem.rm(temporaryPath, { force: true });
+  const fileHandle = await fileSystem.open(temporaryPath, 'wx');
   try {
-    for await (const chunk of response.body) {
+    try {
+      for await (const chunk of response.body) {
+        throwIfAborted(signal);
+        const bytes = toBytes(chunk, asset.name ?? asset.fileName);
+        hash.update(bytes);
+        await writeAll(fileHandle, bytes);
+      }
       throwIfAborted(signal);
-      const bytes = toBytes(chunk, asset.name ?? asset.fileName);
-      hash.update(bytes);
-      await writeAll(fileHandle, bytes);
+    } finally {
+      await fileHandle.close();
     }
-    throwIfAborted(signal);
-  } finally {
-    await fileHandle.close();
-  }
 
-  assertSha256(hash.digest('hex'), asset.sha256, asset.name ?? asset.fileName);
+    assertSha256(hash.digest('hex'), asset.sha256, asset.name ?? asset.fileName);
+  } catch (error) {
+    await fileSystem.rm(temporaryPath, { force: true });
+    throw error;
+  }
 }
 
 async function writeAll(fileHandle, bytes) {
@@ -375,27 +381,40 @@ function toBytes(chunk, assetName) {
 }
 
 async function publishVerifiedAsset(temporaryPath, cachePath, expectedSha256, { fileSystem, temporaryName }) {
-  const displacedPath = `${cachePath}.corrupt-${temporaryName()}`;
+  const displacedPaths = [];
   try {
     for (;;) {
-      try {
-        await fileSystem.link(temporaryPath, cachePath);
-        return;
-      } catch (error) {
-        if (!isFileSystemError(error, 'EEXIST')) throw error;
-      }
+      if (await linkOrVerify(temporaryPath, cachePath, expectedSha256, { fileSystem })) return;
 
-      if (await hasPackageContent(cachePath, expectedSha256, { fileSystem })) return;
+      const displacedPath = `${cachePath}.corrupt-${temporaryName()}`;
       try {
         await fileSystem.rename(cachePath, displacedPath);
+        displacedPaths.push(displacedPath);
       } catch (error) {
         if (!isFileSystemError(error, 'ENOENT')) throw error;
+        continue;
       }
-      await fileSystem.rm(displacedPath, { force: true });
+
+      if (
+        (await hasPackageContent(displacedPath, expectedSha256, { fileSystem })) &&
+        (await linkOrVerify(displacedPath, cachePath, expectedSha256, { fileSystem }))
+      ) {
+        return;
+      }
     }
   } finally {
-    await fileSystem.rm(displacedPath, { force: true });
+    await Promise.all(displacedPaths.map((filePath) => fileSystem.rm(filePath, { force: true })));
   }
+}
+
+async function linkOrVerify(sourcePath, cachePath, expectedSha256, { fileSystem }) {
+  try {
+    await fileSystem.link(sourcePath, cachePath);
+    return true;
+  } catch (error) {
+    if (!isFileSystemError(error, 'EEXIST')) throw error;
+  }
+  return hasPackageContent(cachePath, expectedSha256, { fileSystem });
 }
 
 async function mapWithConcurrency(values, concurrency, mapper, { signal } = {}) {

--- a/packages/oxiquill/src/generator/doc-runtime/pyodide-assets.mjs
+++ b/packages/oxiquill/src/generator/doc-runtime/pyodide-assets.mjs
@@ -3,13 +3,14 @@ import path from 'node:path';
 import { createRequire } from 'node:module';
 import { pathInUrl } from '../../config/paths.mjs';
 import { vendoredPyodidePackageRoots } from './constants.mjs';
-import { copyFileIfChanged, defaultFileSystem, hasPackageContent } from './file-system.mjs';
-import { hashBytes, stableFingerprint } from './hashing.mjs';
+import { copyFileIfChanged, defaultFileSystem, hashFileSha256, hasPackageContent } from './file-system.mjs';
+import { createSha256, hashBytes, stableFingerprint } from './hashing.mjs';
 
 const require = createRequire(import.meta.url);
 const defaultPackageCdn = 'https://cdn.jsdelivr.net/pyodide/';
 const cacheNamespace = 'pyodide';
 export const PYODIDE_DOWNLOAD_ATTEMPTS = 3;
+export const PYODIDE_DOWNLOAD_CONCURRENCY = 4;
 export const PYODIDE_REQUEST_TIMEOUT_MS = 30_000;
 export const requiredPyodideFiles = [
   'pyodide.mjs',
@@ -43,7 +44,7 @@ export async function resolvePyodideRuntimeInputs({
   const coreAssets = await Promise.all(
     requiredPyodideFiles.map(async (fileName) => {
       const sourcePath = path.join(packageDir, fileName);
-      return Object.freeze({ fileName, sha256: hashBytes(await fileSystem.readFile(sourcePath)), sourcePath });
+      return Object.freeze({ fileName, sha256: await hashFileSha256(sourcePath, { fileSystem }), sourcePath });
     })
   );
   const packages = resolveVendoredPyodidePackages(lockFile, requestedPackages);
@@ -82,6 +83,7 @@ export async function copyPyodideAssets({
   requestedPackages = vendoredPyodidePackageRoots,
   resolvePackageJson = resolvePyodidePackageJson,
   runtimeInputs,
+  signal,
   sleep = defaultSleep,
   temporaryName = randomUUID
 }) {
@@ -99,35 +101,30 @@ export async function copyPyodideAssets({
     }))
   ];
 
-  const cachePromises = assets.map(async (asset) => ({
-    ...asset,
-    cachePath: await ensureCachedAsset(asset, {
-      cacheDirectory,
-      fetchImplementation,
-      fetchPackage,
-      fileSystem,
-      offline: pythonOptions.offline,
-      packageBaseUrl,
-      sleep,
-      temporaryName
-    })
-  }));
-  const cachedAssets = await settleCacheTransactions(cachePromises);
-  const copied = await Promise.all(
-    cachedAssets.map(({ cachePath, fileName }) =>
-      copyFileIfChanged(cachePath, pathInUrl(paths.pyodidePublicDir, fileName), { fileSystem })
-    )
+  const cachedAssets = await mapWithConcurrency(
+    assets,
+    PYODIDE_DOWNLOAD_CONCURRENCY,
+    async (asset, _index, operationSignal) => ({
+      ...asset,
+      cachePath: await ensureCachedAsset(asset, {
+        cacheDirectory,
+        fetchImplementation,
+        fetchPackage,
+        fileSystem,
+        offline: pythonOptions.offline,
+        packageBaseUrl,
+        signal: operationSignal,
+        sleep,
+        temporaryName
+      })
+    }),
+    { signal }
   );
-  return copied.some(Boolean);
-}
-
-async function settleCacheTransactions(cachePromises) {
-  try {
-    return await Promise.all(cachePromises);
-  } catch (error) {
-    await Promise.allSettled(cachePromises);
-    throw error;
+  const copied = [];
+  for (const { cachePath, fileName } of cachedAssets) {
+    copied.push(await copyFileIfChanged(cachePath, pathInUrl(paths.pyodidePublicDir, fileName), { fileSystem }));
   }
+  return copied.some(Boolean);
 }
 
 export async function copyVendoredPyodidePackages({
@@ -138,6 +135,7 @@ export async function copyVendoredPyodidePackages({
   paths,
   pyodideVersion,
   roots = vendoredPyodidePackageRoots,
+  signal,
   sleep = defaultSleep,
   temporaryName = randomUUID
 }) {
@@ -156,6 +154,7 @@ export async function copyVendoredPyodidePackages({
     fileSystem,
     paths,
     runtimeInputs,
+    signal,
     sleep,
     temporaryName
   });
@@ -185,7 +184,17 @@ export function resolveVendoredPyodidePackages(lockFile, roots = vendoredPyodide
 
 async function ensureCachedAsset(
   asset,
-  { cacheDirectory, fetchImplementation, fetchPackage, fileSystem, offline, packageBaseUrl, sleep, temporaryName }
+  {
+    cacheDirectory,
+    fetchImplementation,
+    fetchPackage,
+    fileSystem,
+    offline,
+    packageBaseUrl,
+    signal,
+    sleep,
+    temporaryName
+  }
 ) {
   const cachePath = path.join(cacheDirectory, asset.fileName);
   if (await hasPackageContent(cachePath, asset.sha256, { fileSystem })) return cachePath;
@@ -200,19 +209,18 @@ async function ensureCachedAsset(
   try {
     if (asset.kind === 'installed') {
       await fileSystem.copyFile(asset.sourcePath, temporaryPath);
+      await assertFileSha256(temporaryPath, asset.sha256, asset.name ?? asset.fileName, { fileSystem });
     } else {
-      const content = fetchPackage
-        ? await fetchPackage(asset.fileName)
-        : await fetchPyodidePackage(asset.fileName, {
-            fetchImplementation,
-            packageBaseUrl,
-            sleep
-          });
-      await fileSystem.writeFile(temporaryPath, content);
+      await downloadAssetToFile(asset, temporaryPath, {
+        fetchImplementation,
+        fetchPackage,
+        fileSystem,
+        packageBaseUrl,
+        signal,
+        sleep
+      });
     }
-    await assertFileSha256(temporaryPath, asset.sha256, asset.name ?? asset.fileName, { fileSystem });
-    await fileSystem.rm(cachePath, { force: true });
-    await fileSystem.rename(temporaryPath, cachePath);
+    await publishVerifiedAsset(temporaryPath, cachePath, asset.sha256, { fileSystem, temporaryName });
     return cachePath;
   } finally {
     await fileSystem.rm(temporaryPath, { force: true });
@@ -224,6 +232,8 @@ export async function fetchPyodidePackage(
   {
     fetchImplementation = globalThis.fetch,
     packageBaseUrl,
+    consumeResponse = responseBytes,
+    signal,
     sleep = defaultSleep,
     timeoutMs = PYODIDE_REQUEST_TIMEOUT_MS
   }
@@ -235,7 +245,7 @@ export async function fetchPyodidePackage(
   for (let attempt = 1; attempt <= PYODIDE_DOWNLOAD_ATTEMPTS; attempt += 1) {
     attempts = attempt;
     try {
-      return await fetchOnce(url, { fetchImplementation, timeoutMs });
+      return await fetchOnce(url, { consumeResponse, fetchImplementation, signal, timeoutMs });
     } catch (error) {
       lastError = error;
       if (!isRetryable(error) || attempt === PYODIDE_DOWNLOAD_ATTEMPTS) break;
@@ -248,9 +258,16 @@ export async function fetchPyodidePackage(
   });
 }
 
-async function fetchOnce(url, { fetchImplementation, timeoutMs }) {
+async function fetchOnce(url, { consumeResponse, fetchImplementation, signal, timeoutMs }) {
   const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  let timedOut = false;
+  const abortRequest = () => controller.abort(signal?.reason);
+  if (signal?.aborted) abortRequest();
+  else signal?.addEventListener('abort', abortRequest, { once: true });
+  const timeout = setTimeout(() => {
+    timedOut = true;
+    controller.abort();
+  }, timeoutMs);
   try {
     const response = await fetchImplementation(url, { signal: controller.signal });
     if (!response.ok) {
@@ -258,16 +275,22 @@ async function fetchOnce(url, { fetchImplementation, timeoutMs }) {
       error.retryable = response.status === 408 || response.status === 429 || response.status >= 500;
       throw error;
     }
-    return Buffer.from(await response.arrayBuffer());
+    return await consumeResponse(response, { signal: controller.signal });
   } catch (error) {
-    if (controller.signal.aborted) {
+    if (timedOut) {
       const timeoutError = new Error(`request timed out after ${timeoutMs}ms`);
       timeoutError.retryable = true;
       throw timeoutError;
     }
+    if (signal?.aborted) {
+      const abortError = signal.reason instanceof Error ? signal.reason : new Error('operation aborted');
+      abortError.retryable = false;
+      throw abortError;
+    }
     throw error;
   } finally {
     clearTimeout(timeout);
+    signal?.removeEventListener('abort', abortRequest);
   }
 }
 
@@ -276,12 +299,156 @@ function isRetryable(error) {
 }
 
 async function assertFileSha256(filePath, expectedSha256, assetName, { fileSystem }) {
-  const actualSha256 = hashBytes(await fileSystem.readFile(filePath));
+  const actualSha256 = await hashFileSha256(filePath, { fileSystem });
+  assertSha256(actualSha256, expectedSha256, assetName);
+}
+
+function assertSha256(actualSha256, expectedSha256, assetName) {
   if (actualSha256 !== expectedSha256) {
     const error = new Error(`Pyodide asset "${assetName}" has sha256 ${actualSha256}; expected ${expectedSha256}.`);
     error.retryable = false;
     throw error;
   }
+}
+
+async function downloadAssetToFile(
+  asset,
+  temporaryPath,
+  { fetchImplementation, fetchPackage, fileSystem, packageBaseUrl, signal, sleep }
+) {
+  if (fetchPackage) {
+    const content = await fetchPackage(asset.fileName);
+    if (content?.body) {
+      await streamResponseToFile(content, temporaryPath, asset, { fileSystem, signal });
+    } else {
+      await fileSystem.writeFile(temporaryPath, content);
+      await assertFileSha256(temporaryPath, asset.sha256, asset.name ?? asset.fileName, { fileSystem });
+    }
+    return;
+  }
+
+  await fetchPyodidePackage(asset.fileName, {
+    consumeResponse: (response, { signal: requestSignal }) =>
+      streamResponseToFile(response, temporaryPath, asset, { fileSystem, signal: requestSignal }),
+    fetchImplementation,
+    packageBaseUrl,
+    signal,
+    sleep
+  });
+}
+
+async function streamResponseToFile(response, temporaryPath, asset, { fileSystem, signal }) {
+  if (!response.body) throw new Error(`Pyodide asset "${asset.name ?? asset.fileName}" has no response body.`);
+  if (!fileSystem.open) throw new Error('The configured file system does not support streaming writes.');
+
+  const hash = createSha256();
+  const fileHandle = await fileSystem.open(temporaryPath, 'w');
+  try {
+    for await (const chunk of response.body) {
+      throwIfAborted(signal);
+      const bytes = toBytes(chunk, asset.name ?? asset.fileName);
+      hash.update(bytes);
+      await writeAll(fileHandle, bytes);
+    }
+    throwIfAborted(signal);
+  } finally {
+    await fileHandle.close();
+  }
+
+  assertSha256(hash.digest('hex'), asset.sha256, asset.name ?? asset.fileName);
+}
+
+async function writeAll(fileHandle, bytes) {
+  let offset = 0;
+  while (offset < bytes.length) {
+    const { bytesWritten } = await fileHandle.write(bytes, offset, bytes.length - offset);
+    if (bytesWritten === 0) throw new Error('Unable to make progress while writing a Pyodide asset.');
+    offset += bytesWritten;
+  }
+}
+
+function toBytes(chunk, assetName) {
+  if (typeof chunk === 'string' || ArrayBuffer.isView(chunk) || chunk instanceof ArrayBuffer) {
+    return Buffer.from(chunk);
+  }
+  throw new TypeError(`Pyodide asset "${assetName}" returned a non-byte stream chunk.`);
+}
+
+async function publishVerifiedAsset(temporaryPath, cachePath, expectedSha256, { fileSystem, temporaryName }) {
+  const displacedPath = `${cachePath}.corrupt-${temporaryName()}`;
+  try {
+    for (;;) {
+      try {
+        await fileSystem.link(temporaryPath, cachePath);
+        return;
+      } catch (error) {
+        if (!isFileSystemError(error, 'EEXIST')) throw error;
+      }
+
+      if (await hasPackageContent(cachePath, expectedSha256, { fileSystem })) return;
+      try {
+        await fileSystem.rename(cachePath, displacedPath);
+      } catch (error) {
+        if (!isFileSystemError(error, 'ENOENT')) throw error;
+      }
+      await fileSystem.rm(displacedPath, { force: true });
+    }
+  } finally {
+    await fileSystem.rm(displacedPath, { force: true });
+  }
+}
+
+async function mapWithConcurrency(values, concurrency, mapper, { signal } = {}) {
+  const results = new Array(values.length);
+  const controller = new AbortController();
+  let nextIndex = 0;
+  let failure;
+  const abortWorkers = () => controller.abort(signal?.reason);
+  if (signal?.aborted) abortWorkers();
+  else signal?.addEventListener('abort', abortWorkers, { once: true });
+
+  async function worker() {
+    while (!controller.signal.aborted) {
+      const index = nextIndex;
+      nextIndex += 1;
+      if (index >= values.length) return;
+      try {
+        results[index] = await mapper(values[index], index, controller.signal);
+      } catch (error) {
+        failure ??= error;
+        controller.abort(error);
+      }
+    }
+  }
+
+  try {
+    await Promise.all(Array.from({ length: Math.min(concurrency, values.length) }, () => worker()));
+  } finally {
+    signal?.removeEventListener('abort', abortWorkers);
+  }
+
+  if (failure) throw failure;
+  if (signal?.aborted) throw signal.reason instanceof Error ? signal.reason : new Error('operation aborted');
+  return results;
+}
+
+async function responseBytes(response, { signal }) {
+  if (!response.body) return Buffer.from(await response.arrayBuffer());
+  const chunks = [];
+  for await (const chunk of response.body) {
+    throwIfAborted(signal);
+    chunks.push(toBytes(chunk, 'download'));
+  }
+  return Buffer.concat(chunks);
+}
+
+function throwIfAborted(signal) {
+  if (!signal?.aborted) return;
+  throw signal.reason instanceof Error ? signal.reason : new Error('operation aborted');
+}
+
+function isFileSystemError(error, code) {
+  return Boolean(error && error.code === code);
 }
 
 function resolvePyodidePackageJson() {

--- a/packages/oxiquill/src/generator/doc-runtime/rust-codegen/capabilities.mjs
+++ b/packages/oxiquill/src/generator/doc-runtime/rust-codegen/capabilities.mjs
@@ -31,7 +31,8 @@ export function rustSourceCapabilities(source) {
     ...Object.fromEntries(sourceFeatureDescriptors.map(([key, tokens]) => [key, hasAnyToken(source, tokens)])),
     chart: hasAnyToken(source, chartTokens),
     image: hasAnyToken(source, imageTokens),
-    table: hasAnyToken(source, tableTokens)
+    table: hasAnyToken(source, tableTokens),
+    text: hasAnyToken(source, ['emit_text!'])
   };
 }
 

--- a/packages/oxiquill/src/generator/doc-runtime/rust-codegen/chart-helpers.mjs
+++ b/packages/oxiquill/src/generator/doc-runtime/rust-codegen/chart-helpers.mjs
@@ -1,5 +1,8 @@
+import { outputArtifactLimits } from '../../../lib/doc-runtime/output-limits.mjs';
+
 export function generateRustChartHelpers(capabilities) {
   return [
+    generateChartLimitHelper(),
     capabilities.lineChart || capabilities.scatterChart ? generateXyChartHelpers() : '',
     capabilities.barChart ? generateBarChartHelpers() : '',
     capabilities.histogramChart ? generateHistogramChartHelper() : '',
@@ -30,7 +33,9 @@ function generateXyChartHelpers() {
     if let Some(y_label) = y_label {
         spec.insert("yLabel".to_owned(), Value::String(y_label));
     }
-    Ok(Value::Object(spec))
+    let spec = Value::Object(spec);
+    ensure_chart_data_limit(&spec)?;
+    Ok(spec)
 }
 
 fn normalize_xy_series(value: Value) -> Result<Value, String> {
@@ -59,12 +64,14 @@ function generateBarChartHelpers() {
   return `fn bar_chart_spec(categories: Value, series: Value) -> Result<Value, String> {
     let categories = normalize_string_array(categories, "bar chart categories")?;
     let series = normalize_bar_series(series)?;
-    Ok(serde_json::json!({
+    let spec = serde_json::json!({
         "kind": "bar",
         "categories": categories,
         "series": series,
         "tooltip": true
-    }))
+    });
+    ensure_chart_data_limit(&spec)?;
+    Ok(spec)
 }
 
 fn normalize_bar_series(value: Value) -> Result<Value, String> {
@@ -105,11 +112,15 @@ fn normalize_string_array(value: Value, label: &str) -> Result<Vec<String>, Stri
 function generateHistogramChartHelper() {
   return `fn histogram_chart_spec(bins: Value) -> Result<Value, String> {
     match bins {
-        value @ Value::Array(_) => Ok(serde_json::json!({
-            "kind": "histogram",
-            "bins": value,
-            "tooltip": true
-        })),
+        value @ Value::Array(_) => {
+            let spec = serde_json::json!({
+                "kind": "histogram",
+                "bins": value,
+                "tooltip": true
+            });
+            ensure_chart_data_limit(&spec)?;
+            Ok(spec)
+        }
         _ => Err("histogram bins must serialize as an array".to_owned()),
     }
 }
@@ -119,13 +130,66 @@ function generateHistogramChartHelper() {
 function generateHeatmapChartHelper() {
   return `fn heatmap_chart_spec(data: Value) -> Result<Value, String> {
     match data {
-        value @ Value::Array(_) => Ok(serde_json::json!({
-            "kind": "heatmap",
-            "data": value,
-            "tooltip": true
-        })),
+        value @ Value::Array(_) => {
+            let spec = serde_json::json!({
+                "kind": "heatmap",
+                "data": value,
+                "tooltip": true
+            });
+            ensure_chart_data_limit(&spec)?;
+            Ok(spec)
+        }
         _ => Err("heatmap data must serialize as an array".to_owned()),
     }
+}
+`;
+}
+
+function generateChartLimitHelper() {
+  return `fn ensure_chart_data_limit(spec: &Value) -> Result<(), String> {
+    let kind = spec.get("kind").and_then(Value::as_str).unwrap_or_default();
+    let data_items = match kind {
+        "line" | "scatter" | "area" => spec
+            .get("series")
+            .and_then(Value::as_array)
+            .map(|series| {
+                series
+                    .iter()
+                    .map(|item| {
+                        item.get("points")
+                            .and_then(Value::as_array)
+                            .map(|points| points.len().max(1))
+                            .unwrap_or(1)
+                    })
+                    .sum()
+            })
+            .unwrap_or(0),
+        "bar" => spec
+            .get("series")
+            .and_then(Value::as_array)
+            .map(|series| {
+                series
+                    .iter()
+                    .map(|item| item.get("values").and_then(Value::as_array).map(Vec::len).unwrap_or(0))
+                    .sum()
+            })
+            .unwrap_or(0),
+        "histogram" => spec.get("bins").and_then(Value::as_array).map(Vec::len).unwrap_or(0),
+        "heatmap" => spec.get("data").and_then(Value::as_array).map(Vec::len).unwrap_or(0),
+        _ => 0,
+    };
+    let category_items = spec
+        .get("categories")
+        .and_then(Value::as_array)
+        .map(Vec::len)
+        .unwrap_or(0);
+    if data_items > ${outputArtifactLimits.chartDataItems} || category_items > ${outputArtifactLimits.chartDataItems} {
+        return Err(format!(
+            "chart contains more than {} data items",
+            ${outputArtifactLimits.chartDataItems}
+        ));
+    }
+    Ok(())
 }
 `;
 }

--- a/packages/oxiquill/src/generator/doc-runtime/rust-codegen/functions.mjs
+++ b/packages/oxiquill/src/generator/doc-runtime/rust-codegen/functions.mjs
@@ -1,6 +1,7 @@
 import { generateRustInputBinding } from '../rust-readers.mjs';
 import { rustFunctionName, rustIdentifier } from '../rust-identifiers.mjs';
 import { generateRustPreludeMacros } from './macros.mjs';
+import { outputArtifactLimits } from '../../../lib/doc-runtime/output-limits.mjs';
 
 export function generateRustFunction(cell) {
   const inputBindings = cell.inputs.map((input) => `    ${generateRustInputBinding(input)}`).join('\n');
@@ -9,16 +10,14 @@ export function generateRustFunction(cell) {
   const inputsParameter = cell.inputs.length > 0 ? 'inputs' : '_inputs';
 
   return `fn ${rustFunctionName(cell.id)}(${inputsParameter}: &Value) -> Result<CellOutput, String> {
-${inputBindings ? `${inputBindings}\n` : ''}    let __stdout = std::cell::RefCell::new(String::new());
-    let __plots = std::cell::RefCell::new(Vec::new());
-    let __outputs = std::cell::RefCell::new(Vec::new());
+${inputBindings ? `${inputBindings}\n` : ''}    let __stdout = std::cell::RefCell::new(BoundedText::new());
+    let __outputs = std::cell::RefCell::new(OutputCollector::new());
 ${macros ? `\n${macros}\n` : ''}
 
 ${escapedSource}
 
     Ok(finish_cell_output(
         __stdout.into_inner(),
-        __plots.into_inner(),
         __outputs.into_inner(),
     ))
 }`;
@@ -32,6 +31,36 @@ mod tests {
     use wasm_bindgen_test::wasm_bindgen_test;
 
 ${tests}
+
+    #[wasm_bindgen_test]
+    fn generated_output_limits_are_enforced() {
+        use std::fmt::Write as _;
+
+        let mut exact = super::BoundedText::new();
+        write!(&mut exact, "{}", "x".repeat(${outputArtifactLimits.bytesPerStream}))
+            .expect("exact-limit stdout should be writable");
+        assert_eq!(
+            exact.content.len(),
+            ${outputArtifactLimits.bytesPerStream},
+            "exact-limit stdout should be retained"
+        );
+        assert!(!exact.truncated, "exact-limit stdout should not be marked truncated");
+
+        let mut oversized = super::BoundedText::new();
+        write!(&mut oversized, "{}", "x".repeat(${outputArtifactLimits.bytesPerStream + 1}))
+            .expect("oversized stdout should be bounded without a formatting error");
+        assert!(
+            oversized.content.len() <= ${outputArtifactLimits.bytesPerStream},
+            "oversized stdout should remain within its byte budget"
+        );
+        assert!(oversized.truncated, "oversized stdout should be marked truncated");
+
+        let error = super::bounded_error_message(&"x".repeat(${outputArtifactLimits.bytesPerError + 1}));
+        assert!(
+            error.len() <= ${outputArtifactLimits.bytesPerError},
+            "generated errors should remain within their byte budget"
+        );
+    }
 }`;
 }
 

--- a/packages/oxiquill/src/generator/doc-runtime/rust-codegen/lib.mjs
+++ b/packages/oxiquill/src/generator/doc-runtime/rust-codegen/lib.mjs
@@ -3,6 +3,7 @@ import { rustFunctionName } from '../rust-identifiers.mjs';
 import { generatedBanner } from './banners.mjs';
 import { generateRustFunction, generateRustTests } from './functions.mjs';
 import { generateRustOutputTypes } from './output-types.mjs';
+import { outputArtifactLimits } from '../../../lib/doc-runtime/output-limits.mjs';
 
 export function generateRustLib(rustCells) {
   const matchArms = rustCells
@@ -25,7 +26,7 @@ ${matchArms}
     }
     .map_err(|error| JsValue::from_str(&error))?;
 
-    serde_json::to_string(&output).map_err(to_js_error)
+    serialize_cell_output(output).map_err(to_js_error)
 }`;
 
   const functions = rustCells.map(generateRustFunction).join('\n\n');
@@ -33,6 +34,20 @@ ${matchArms}
   const readers = generateRustReaders(rustCells);
   const outputTypes = generateRustOutputTypes(rustCells);
   const serdeImport = rustCells.length === 0 ? '' : 'use serde::Serialize;\n';
+  const jsErrorMessage =
+    rustCells.length === 0
+      ? `{
+        let message = error.to_string();
+        message
+            .chars()
+            .scan(0_usize, |bytes, character| {
+                *bytes += character.len_utf8();
+                Some((*bytes <= ${outputArtifactLimits.bytesPerError}).then_some(character))
+            })
+            .flatten()
+            .collect::<String>()
+    }`
+      : 'bounded_error_message(&error.to_string())';
 
   return `${generatedBanner()}${serdeImport}use serde_json::Value;
 use wasm_bindgen::prelude::*;
@@ -46,7 +61,8 @@ pub fn start() {
 ${runFunction}
 
 fn to_js_error(error: impl std::fmt::Display) -> JsValue {
-    JsValue::from_str(&error.to_string())
+    let message = ${jsErrorMessage};
+    JsValue::from_str(&message)
 }
 
 ${readers}

--- a/packages/oxiquill/src/generator/doc-runtime/rust-codegen/macros.mjs
+++ b/packages/oxiquill/src/generator/doc-runtime/rust-codegen/macros.mjs
@@ -46,6 +46,7 @@ function generateTextMacro() {
             __outputs.borrow_mut().push(OutputArtifact::Text(TextArtifact {
                 stream: "display",
                 content: ($content).to_string(),
+                truncated: false,
             }));
         }};
     }`;
@@ -250,11 +251,6 @@ function generateLinePlotMacro() {
                 .iter()
                 .map(|point| [f64::from(point.n), point.x])
                 .collect();
-            __plots.borrow_mut().push(PlotSpec::Line(LinePlotSpec {
-                x_label: x_label.clone(),
-                y_label: y_label.clone(),
-                points: points.clone(),
-            }));
             __outputs.borrow_mut().push(OutputArtifact::Chart(ChartArtifact {
                 spec: serde_json::json!({
                     "kind": "line",

--- a/packages/oxiquill/src/generator/doc-runtime/rust-codegen/output-types.mjs
+++ b/packages/oxiquill/src/generator/doc-runtime/rust-codegen/output-types.mjs
@@ -34,6 +34,114 @@ export function generateRustOutputTypes(rustCells) {
   ]
     .filter(Boolean)
     .join('\n');
+  const boundedArtifactArms = [
+    `        OutputArtifact::Text(text) => {
+            text.truncated |= truncate_string(&mut text.content, ${outputArtifactLimits.bytesPerTextJsonOrHtml});
+        }`,
+    capabilities.json
+      ? `        OutputArtifact::Json(json) => {
+            let oversized = serde_json::to_string(&json.value)
+                .map(|serialized| serialized.len() > ${outputArtifactLimits.bytesPerTextJsonOrHtml})
+                .unwrap_or(true);
+            if oversized {
+                json.value = Value::String("[Truncated]".to_owned());
+                json.truncated = true;
+            }
+        }`
+      : '',
+    capabilities.html
+      ? `        OutputArtifact::Html(html) if html.html.len() > ${outputArtifactLimits.bytesPerTextJsonOrHtml} => {
+            return producer_error("Rust HTML output exceeded the per-artifact byte limit");
+        }`
+      : '',
+    capabilities.image
+      ? `        OutputArtifact::Image(image) if image.data.len() > ${Math.ceil((outputArtifactLimits.decodedBytesPerImage * 4) / 3) + 4} => {
+            return producer_error("Rust image output exceeded the per-artifact byte limit");
+        }`
+      : ''
+  ]
+    .filter(Boolean)
+    .join('\n');
+  const emitsArtifacts =
+    capabilities.text ||
+    capabilities.json ||
+    capabilities.html ||
+    capabilities.image ||
+    capabilities.table ||
+    capabilities.chart;
+  const outputCollector = emitsArtifacts
+    ? `struct OutputCollector {
+    byte_length: usize,
+    omitted: bool,
+    outputs: Vec<OutputArtifact>,
+}
+
+impl OutputCollector {
+    fn new() -> Self {
+        Self {
+            byte_length: 0,
+            omitted: false,
+            outputs: Vec::new(),
+        }
+    }
+
+    fn push(&mut self, artifact: OutputArtifact) {
+        if self.outputs.len() >= ${outputArtifactLimits.artifactsPerRun} {
+            self.omitted = true;
+            return;
+        }
+        let artifact = bound_output_artifact(artifact);
+        let Ok(serialized) = serde_json::to_string(&artifact) else {
+            self.omitted = true;
+            return;
+        };
+        if serialized.len() > ${outputArtifactLimits.validatedBytesPerRun}_usize.saturating_sub(self.byte_length) {
+            self.omitted = true;
+            return;
+        }
+        self.byte_length += serialized.len();
+        self.outputs.push(artifact);
+    }
+
+    fn finish(mut self) -> Vec<OutputArtifact> {
+        if self.omitted {
+            self.outputs.truncate(${outputArtifactLimits.artifactsPerRun - 1});
+            self.outputs.push(producer_error("Rust output exceeded its artifact or byte limit"));
+        }
+        self.outputs
+    }
+}`
+    : `struct OutputCollector {
+    outputs: Vec<OutputArtifact>,
+}
+
+impl OutputCollector {
+    fn new() -> Self {
+        Self { outputs: Vec::new() }
+    }
+
+    fn finish(self) -> Vec<OutputArtifact> {
+        self.outputs
+    }
+}`;
+  const boundOutputArtifact = emitsArtifacts
+    ? `fn bound_output_artifact(mut artifact: OutputArtifact) -> OutputArtifact {
+    match &mut artifact {
+${boundedArtifactArms}
+        _ => {}
+    }
+    artifact
+}
+
+fn truncate_string(value: &mut String, max_bytes: usize) -> bool {
+    if value.len() <= max_bytes {
+        return false;
+    }
+    let original = std::mem::take(value);
+    push_truncated(value, &original, max_bytes);
+    true
+}`
+    : '';
 
   return `
 type PlotSpec = Value;
@@ -86,72 +194,9 @@ impl std::fmt::Write for BoundedText {
     }
 }
 
-struct OutputCollector {
-    byte_length: usize,
-    omitted: bool,
-    outputs: Vec<OutputArtifact>,
-}
+${outputCollector}
 
-impl OutputCollector {
-    fn new() -> Self {
-        Self {
-            byte_length: 0,
-            omitted: false,
-            outputs: Vec::new(),
-        }
-    }
-
-    fn push(&mut self, artifact: OutputArtifact) {
-        if self.outputs.len() >= ${outputArtifactLimits.artifactsPerRun} {
-            self.omitted = true;
-            return;
-        }
-        let artifact = bound_output_artifact(artifact);
-        let Ok(serialized) = serde_json::to_string(&artifact) else {
-            self.omitted = true;
-            return;
-        };
-        if serialized.len() > ${outputArtifactLimits.validatedBytesPerRun}_usize.saturating_sub(self.byte_length) {
-            self.omitted = true;
-            return;
-        }
-        self.byte_length += serialized.len();
-        self.outputs.push(artifact);
-    }
-
-    fn finish(mut self) -> Vec<OutputArtifact> {
-        if self.omitted {
-            self.outputs.truncate(${outputArtifactLimits.artifactsPerRun - 1});
-            self.outputs.push(producer_error("Rust output exceeded its artifact or byte limit"));
-        }
-        self.outputs
-    }
-}
-
-fn bound_output_artifact(mut artifact: OutputArtifact) -> OutputArtifact {
-    match &mut artifact {
-        OutputArtifact::Text(text) => {
-            text.truncated |= truncate_string(&mut text.content, ${outputArtifactLimits.bytesPerTextJsonOrHtml});
-        }
-        OutputArtifact::Json(json) => {
-            let oversized = serde_json::to_string(&json.value)
-                .map(|serialized| serialized.len() > ${outputArtifactLimits.bytesPerTextJsonOrHtml})
-                .unwrap_or(true);
-            if oversized {
-                json.value = Value::String("[Truncated]".to_owned());
-                json.truncated = true;
-            }
-        }
-        OutputArtifact::Html(html) if html.html.len() > ${outputArtifactLimits.bytesPerTextJsonOrHtml} => {
-            return producer_error("Rust HTML output exceeded the per-artifact byte limit");
-        }
-        OutputArtifact::Image(image) if image.data.len() > ${Math.ceil((outputArtifactLimits.decodedBytesPerImage * 4) / 3) + 4} => {
-            return producer_error("Rust image output exceeded the per-artifact byte limit");
-        }
-        _ => {}
-    }
-    artifact
-}
+${boundOutputArtifact}
 
 fn producer_error(message: &str) -> OutputArtifact {
     OutputArtifact::ProducerError(ProducerErrorArtifact {
@@ -163,15 +208,6 @@ fn bounded_error_message(message: &str) -> String {
     let mut bounded = String::new();
     push_truncated(&mut bounded, message, ${outputArtifactLimits.bytesPerError});
     bounded
-}
-
-fn truncate_string(value: &mut String, max_bytes: usize) -> bool {
-    if value.len() <= max_bytes {
-        return false;
-    }
-    let original = std::mem::take(value);
-    push_truncated(value, &original, max_bytes);
-    true
 }
 
 fn push_truncated(output: &mut String, value: &str, max_bytes: usize) {

--- a/packages/oxiquill/src/generator/doc-runtime/rust-codegen/output-types.mjs
+++ b/packages/oxiquill/src/generator/doc-runtime/rust-codegen/output-types.mjs
@@ -1,11 +1,14 @@
 import { rustOutputCapabilities } from './capabilities.mjs';
 import { generateRustChartHelpers } from './chart-helpers.mjs';
+import { outputArtifactLimits } from '../../../lib/doc-runtime/output-limits.mjs';
 
 export function generateRustOutputTypes(rustCells) {
   if (rustCells.length === 0) return '';
 
   const capabilities = rustOutputCapabilities(rustCells);
   const outputVariants = [
+    `    #[serde(rename = "__oxiquill_error")]
+    ProducerError(ProducerErrorArtifact),`,
     `    #[serde(rename = "text")]
     Text(TextArtifact),`,
     capabilities.json
@@ -33,25 +36,8 @@ export function generateRustOutputTypes(rustCells) {
     .join('\n');
 
   return `
-${
-  capabilities.legacyPlot
-    ? `#[derive(Debug, Serialize)]
-#[serde(tag = "kind")]
-enum PlotSpec {
-    #[serde(rename = "line")]
-    Line(LinePlotSpec),
-}
+type PlotSpec = Value;
 
-#[derive(Debug, Serialize)]
-struct LinePlotSpec {
-    x_label: String,
-    y_label: String,
-    points: Vec<[f64; 2]>,
-}
-`
-    : `type PlotSpec = Value;
-`
-}
 #[derive(Debug, Serialize)]
 #[serde(tag = "kind")]
 enum OutputArtifact {
@@ -62,6 +48,148 @@ ${outputVariants}
 struct TextArtifact {
     stream: &'static str,
     content: String,
+    truncated: bool,
+}
+
+#[derive(Debug, Serialize)]
+struct ProducerErrorArtifact {
+    message: String,
+}
+
+struct BoundedText {
+    content: String,
+    truncated: bool,
+}
+
+impl BoundedText {
+    fn new() -> Self {
+        Self {
+            content: String::new(),
+            truncated: false,
+        }
+    }
+}
+
+impl std::fmt::Write for BoundedText {
+    fn write_str(&mut self, value: &str) -> std::fmt::Result {
+        if self.truncated {
+            return Ok(());
+        }
+        let remaining = ${outputArtifactLimits.bytesPerStream}_usize.saturating_sub(self.content.len());
+        if value.len() <= remaining {
+            self.content.push_str(value);
+            return Ok(());
+        }
+        push_truncated(&mut self.content, value, remaining);
+        self.truncated = true;
+        Ok(())
+    }
+}
+
+struct OutputCollector {
+    byte_length: usize,
+    omitted: bool,
+    outputs: Vec<OutputArtifact>,
+}
+
+impl OutputCollector {
+    fn new() -> Self {
+        Self {
+            byte_length: 0,
+            omitted: false,
+            outputs: Vec::new(),
+        }
+    }
+
+    fn push(&mut self, artifact: OutputArtifact) {
+        if self.outputs.len() >= ${outputArtifactLimits.artifactsPerRun} {
+            self.omitted = true;
+            return;
+        }
+        let artifact = bound_output_artifact(artifact);
+        let Ok(serialized) = serde_json::to_string(&artifact) else {
+            self.omitted = true;
+            return;
+        };
+        if serialized.len() > ${outputArtifactLimits.validatedBytesPerRun}_usize.saturating_sub(self.byte_length) {
+            self.omitted = true;
+            return;
+        }
+        self.byte_length += serialized.len();
+        self.outputs.push(artifact);
+    }
+
+    fn finish(mut self) -> Vec<OutputArtifact> {
+        if self.omitted {
+            self.outputs.truncate(${outputArtifactLimits.artifactsPerRun - 1});
+            self.outputs.push(producer_error("Rust output exceeded its artifact or byte limit"));
+        }
+        self.outputs
+    }
+}
+
+fn bound_output_artifact(mut artifact: OutputArtifact) -> OutputArtifact {
+    match &mut artifact {
+        OutputArtifact::Text(text) => {
+            text.truncated |= truncate_string(&mut text.content, ${outputArtifactLimits.bytesPerTextJsonOrHtml});
+        }
+        OutputArtifact::Json(json) => {
+            let oversized = serde_json::to_string(&json.value)
+                .map(|serialized| serialized.len() > ${outputArtifactLimits.bytesPerTextJsonOrHtml})
+                .unwrap_or(true);
+            if oversized {
+                json.value = Value::String("[Truncated]".to_owned());
+                json.truncated = true;
+            }
+        }
+        OutputArtifact::Html(html) if html.html.len() > ${outputArtifactLimits.bytesPerTextJsonOrHtml} => {
+            return producer_error("Rust HTML output exceeded the per-artifact byte limit");
+        }
+        OutputArtifact::Image(image) if image.data.len() > ${Math.ceil((outputArtifactLimits.decodedBytesPerImage * 4) / 3) + 4} => {
+            return producer_error("Rust image output exceeded the per-artifact byte limit");
+        }
+        _ => {}
+    }
+    artifact
+}
+
+fn producer_error(message: &str) -> OutputArtifact {
+    OutputArtifact::ProducerError(ProducerErrorArtifact {
+        message: bounded_error_message(message),
+    })
+}
+
+fn bounded_error_message(message: &str) -> String {
+    let mut bounded = String::new();
+    push_truncated(&mut bounded, message, ${outputArtifactLimits.bytesPerError});
+    bounded
+}
+
+fn truncate_string(value: &mut String, max_bytes: usize) -> bool {
+    if value.len() <= max_bytes {
+        return false;
+    }
+    let original = std::mem::take(value);
+    push_truncated(value, &original, max_bytes);
+    true
+}
+
+fn push_truncated(output: &mut String, value: &str, max_bytes: usize) {
+    if value.len() <= max_bytes {
+        output.push_str(value);
+        return;
+    }
+    let marker = '…';
+    let marker_bytes = marker.len_utf8();
+    if max_bytes < marker_bytes {
+        return;
+    }
+    let mut end = max_bytes - marker_bytes;
+    while !value.is_char_boundary(end) {
+        end = end.saturating_sub(1);
+    }
+    output.push_str(&value[..end]);
+    output.push(marker);
 }
 
 ${
@@ -69,10 +197,11 @@ ${
     ? `#[derive(Debug, Serialize)]
 struct JsonArtifact {
     value: Value,
+    truncated: bool,
 }
 
 fn json_artifact(value: Value) -> JsonArtifact {
-    JsonArtifact { value }
+    JsonArtifact { value, truncated: false }
 }
 `
     : ''
@@ -135,24 +264,50 @@ struct CellOutput {
 }
 
 fn finish_cell_output(
-    stdout: String,
-    plots: Vec<PlotSpec>,
-    mut outputs: Vec<OutputArtifact>,
+    stdout: BoundedText,
+    outputs: OutputCollector,
 ) -> CellOutput {
+    let BoundedText { content: stdout, truncated } = stdout;
+    let mut outputs = outputs.finish();
     if !stdout.is_empty() {
         outputs.insert(
             0,
             OutputArtifact::Text(TextArtifact {
                 stream: "stdout",
                 content: stdout.clone(),
+                truncated,
             }),
         );
+        outputs.truncate(${outputArtifactLimits.artifactsPerRun});
     }
     CellOutput {
         stdout,
-        plots,
+        plots: Vec::new(),
         value: Value::Null,
         outputs,
+    }
+}
+
+fn serialize_cell_output(mut output: CellOutput) -> Result<String, String> {
+    let mut omitted = false;
+    loop {
+        let serialized = serde_json::to_string(&output).map_err(|error| bounded_error_message(&error.to_string()))?;
+        if serialized.len() <= ${outputArtifactLimits.workerResponseBytes} {
+            if omitted && output.outputs.len() < ${outputArtifactLimits.artifactsPerRun} {
+                output.outputs.push(producer_error("Rust response exceeded the complete response byte limit"));
+                let with_diagnostic = serde_json::to_string(&output)
+                    .map_err(|error| bounded_error_message(&error.to_string()))?;
+                if with_diagnostic.len() <= ${outputArtifactLimits.workerResponseBytes} {
+                    return Ok(with_diagnostic);
+                }
+                output.outputs.pop();
+            }
+            return Ok(serialized);
+        }
+        if output.outputs.pop().is_none() {
+            return Err("Rust response exceeded the complete response byte limit".to_owned());
+        }
+        omitted = true;
     }
 }
 `;
@@ -182,8 +337,8 @@ fn table_artifact_from_value(value: Value) -> Result<TableArtifact, String> {
         _ => return Err("emit_table! expects a serializable array".to_owned()),
     };
     let row_count = rows.len();
-    let truncated = row_count > 10_000;
-    let preview: Vec<Value> = rows.into_iter().take(10_000).collect();
+    let truncated = row_count > ${outputArtifactLimits.rowsPerTable};
+    let preview: Vec<Value> = rows.into_iter().take(${outputArtifactLimits.rowsPerTable}).collect();
     let columns = infer_table_columns(&preview);
     let table_rows = table_rows_for_columns(preview, &columns);
     Ok(TableArtifact {
@@ -201,8 +356,8 @@ fn table_artifact_with_columns(columns: Value, rows: Value) -> Result<TableArtif
         _ => return Err("emit_table_with_columns! expects rows to serialize as an array".to_owned()),
     };
     let row_count = rows.len();
-    let truncated = row_count > 10_000;
-    let preview: Vec<Value> = rows.into_iter().take(10_000).collect();
+    let truncated = row_count > ${outputArtifactLimits.rowsPerTable};
+    let preview: Vec<Value> = rows.into_iter().take(${outputArtifactLimits.rowsPerTable}).collect();
     let table_rows = table_rows_for_columns(preview, &columns);
     Ok(TableArtifact {
         columns,
@@ -219,6 +374,7 @@ fn infer_table_columns(rows: &[Value]) -> Vec<TableColumn> {
     match first {
         Value::Object(object) => object
             .iter()
+            .take(${outputArtifactLimits.columnsPerTable})
             .map(|(key, value)| TableColumn {
                 key: key.clone(),
                 label: key.clone(),
@@ -227,6 +383,7 @@ fn infer_table_columns(rows: &[Value]) -> Vec<TableColumn> {
             .collect(),
         Value::Array(values) => values
             .iter()
+            .take(${outputArtifactLimits.columnsPerTable})
             .enumerate()
             .map(|(index, value)| TableColumn {
                 key: index.to_string(),
@@ -248,6 +405,7 @@ fn parse_table_columns(value: Value) -> Result<Vec<TableColumn>, String> {
     };
     columns
         .into_iter()
+        .take(${outputArtifactLimits.columnsPerTable})
         .enumerate()
         .map(|(index, column)| parse_table_column(index, column))
         .collect()

--- a/packages/oxiquill/src/generator/doc-runtime/rust-identifiers.mjs
+++ b/packages/oxiquill/src/generator/doc-runtime/rust-identifiers.mjs
@@ -2,7 +2,7 @@ import { rustReservedIdentifiers } from './constants.mjs';
 
 export function rustReaderName(input) {
   if (input.type === 'checkbox') return 'read_bool';
-  if (input.type === 'integer' || input.integer) return 'read_u32';
+  if (input.type === 'integer' || input.integer) return 'read_i32';
   if (input.type === 'range' || input.type === 'number') return 'read_f64';
   return 'read_string';
 }

--- a/packages/oxiquill/src/generator/doc-runtime/rust-readers.mjs
+++ b/packages/oxiquill/src/generator/doc-runtime/rust-readers.mjs
@@ -5,7 +5,7 @@ export function generateRustReaders(rustCells) {
 
   return [
     readers.has('read_f64') ? rustReadF64() : '',
-    readers.has('read_u32') ? rustReadU32() : '',
+    readers.has('read_i32') ? rustReadI32() : '',
     readers.has('read_bool') ? rustReadBool() : '',
     readers.has('read_string') ? rustReadString() : ''
   ]
@@ -28,13 +28,13 @@ function rustReadF64() {
 }`;
 }
 
-function rustReadU32() {
-  return `fn read_u32(inputs: &Value, key: &str) -> Result<u32, String> {
+function rustReadI32() {
+  return `fn read_i32(inputs: &Value, key: &str) -> Result<i32, String> {
     let value = inputs
         .get(key)
-        .and_then(Value::as_u64)
+        .and_then(Value::as_i64)
         .ok_or_else(|| format!("input {key} must be an integer"))?;
-    u32::try_from(value).map_err(|_| format!("input {key} is too large"))
+    i32::try_from(value).map_err(|_| format!("input {key} must be a signed 32-bit integer"))
 }`;
 }
 

--- a/packages/oxiquill/src/generator/watch-doc-runtime.mjs
+++ b/packages/oxiquill/src/generator/watch-doc-runtime.mjs
@@ -4,6 +4,7 @@ import { parseArgs } from 'node:util';
 import { pathFromUrl } from '../config/paths.mjs';
 import { loadOxiquillProjectConfig } from '../config/project-config.mjs';
 import { createDocRuntimeContext, syncDocRuntime } from './doc-runtime-service.mjs';
+import { prepareCleanupOwnership } from './cleanup-ownership.mjs';
 import {
   classifyChangedPath,
   createRuntimeWatchPaths,
@@ -17,6 +18,7 @@ import {
 const defaultServices = {
   createDocRuntimeContext,
   loadProjectConfig: loadOxiquillProjectConfig,
+  prepareCleanupOwnership,
   syncDocRuntime,
   watch: chokidar.watch
 };
@@ -44,6 +46,11 @@ export async function main(argv = process.argv.slice(2), serviceOverrides = {}) 
 export async function watchDocRuntime({ projectConfig, serviceOverrides = {}, skipInitial = false }) {
   const services = { ...defaultServices, ...serviceOverrides };
   const { paths } = projectConfig;
+  await services.prepareCleanupOwnership({
+    configFile: projectConfig.configFile,
+    fields: ['cacheDir', 'publicAssetsDir'],
+    paths
+  });
   const initialContext = await services.createDocRuntimeContext({ paths });
   const workspaceRoot = pathFromUrl(initialContext.paths.workspaceRoot);
   let changeKinds = skipInitial ? new Set() : new Set(['docs']);

--- a/packages/oxiquill/src/lib/doc-runtime/cell-authoring.mjs
+++ b/packages/oxiquill/src/lib/doc-runtime/cell-authoring.mjs
@@ -1,5 +1,6 @@
 import YAML from 'yaml';
 import { scopedCellId } from './authoring-ids.mjs';
+import { isPortableInteger, PORTABLE_INTEGER_MAX, PORTABLE_INTEGER_MIN } from './portable-integer.mjs';
 
 export const inputTypes = ['range', 'number', 'integer', 'text', 'textarea', 'checkbox', 'select', 'radio'];
 export const runModes = ['button', 'reactive', 'autorun'];
@@ -481,8 +482,14 @@ function validateNumericConstraints(input, inputPath, context, diagnostics) {
   }
   if (input.integer) {
     for (const field of ['value', 'min', 'max', 'step']) {
-      if (input[field] !== undefined && !Number.isInteger(input[field])) {
-        diagnostics.push(diagnostic(context, `${inputPath}.${field}`, 'Expected an integer.'));
+      if (input[field] !== undefined && !isPortableInteger(input[field])) {
+        diagnostics.push(
+          diagnostic(
+            context,
+            `${inputPath}.${field}`,
+            `Expected a signed 32-bit integer from ${PORTABLE_INTEGER_MIN} through ${PORTABLE_INTEGER_MAX}.`
+          )
+        );
       }
     }
   }

--- a/packages/oxiquill/src/lib/doc-runtime/execution-cancellation.ts
+++ b/packages/oxiquill/src/lib/doc-runtime/execution-cancellation.ts
@@ -1,0 +1,13 @@
+export class ExecutionCancellationError extends Error {
+  constructor(message = 'Interactive cell execution was cancelled') {
+    super(message);
+    this.name = 'AbortError';
+  }
+}
+
+export function isExecutionCancellation(error: unknown): boolean {
+  return (
+    error instanceof ExecutionCancellationError ||
+    (typeof error === 'object' && error !== null && 'name' in error && error.name === 'AbortError')
+  );
+}

--- a/packages/oxiquill/src/lib/doc-runtime/haskell-worker.ts
+++ b/packages/oxiquill/src/lib/doc-runtime/haskell-worker.ts
@@ -1,6 +1,8 @@
 import { ConsoleStdout, File, OpenFile, WASI } from '@bjorn3/browser_wasi_shim';
 import { haskellWasmPath } from 'virtual:oxiquill/runtime-paths';
+import { boundedErrorMessage, outputArtifactLimits, truncateUtf8 } from './output-limits.mjs';
 import type { RawCellExecutionResult, RuntimeWorkerRequest, RuntimeWorkerResponse, TextArtifact } from './types.js';
+import { boundWorkerResult } from './worker-output.js';
 
 type WorkerScope = {
   addEventListener(type: 'message', listener: (event: MessageEvent<RuntimeWorkerRequest>) => void): void;
@@ -58,12 +60,12 @@ export function createHaskellWorkerRequestHandler({
       const module = await loadModule(request.haskellFingerprintHash);
       const result = await runCell(module, request);
 
-      postMessage({ requestId: request.requestId, ok: true, result });
+      postMessage({ requestId: request.requestId, ok: true, result: boundWorkerResult(result) });
     } catch (error) {
       postMessage({
         requestId: request.requestId,
         ok: false,
-        error: error instanceof Error ? error.message : String(error)
+        error: boundedErrorMessage(error)
       });
     }
   };
@@ -84,9 +86,13 @@ export async function runHaskellCell(
     wasi_snapshot_preview1: wasi.wasiImport
   })) as WasiInstance;
   const exitCode = wasi.start(instance);
+  const stdoutResult = stdout.take();
+  const stderrResult = stderr.take();
   const result = createHaskellCellResult({
-    stdout: stdout.take(),
-    stderr: stderr.take()
+    stdout: stdoutResult.value,
+    stdoutTruncated: stdoutResult.truncated,
+    stderr: stderrResult.value,
+    stderrTruncated: stderrResult.truncated
   });
 
   if (exitCode !== 0) {
@@ -98,14 +104,36 @@ export async function runHaskellCell(
 
 export function createHaskellCellResult({
   stderr,
-  stdout
+  stderrTruncated = false,
+  stdout,
+  stdoutTruncated = false
 }: {
   stderr: string;
+  stderrTruncated?: boolean;
   stdout: string;
+  stdoutTruncated?: boolean;
 }): RawCellExecutionResult {
   const outputs: TextArtifact[] = [
-    stdout ? [{ kind: 'text', stream: 'stdout', content: stdout } satisfies TextArtifact] : [],
-    stderr ? [{ kind: 'text', stream: 'stderr', content: stderr } satisfies TextArtifact] : []
+    stdout
+      ? [
+          {
+            kind: 'text',
+            stream: 'stdout',
+            content: stdout,
+            ...(stdoutTruncated ? { truncated: true } : {})
+          } satisfies TextArtifact
+        ]
+      : [],
+    stderr
+      ? [
+          {
+            kind: 'text',
+            stream: 'stderr',
+            content: stderr,
+            ...(stderrTruncated ? { truncated: true } : {})
+          } satisfies TextArtifact
+        ]
+      : []
   ].flat();
 
   return {
@@ -221,17 +249,28 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null;
 }
 
-function createOutputCapture(): {
+export function createOutputCapture(maxBytes = outputArtifactLimits.bytesPerStream): {
   file: ConsoleStdout;
-  take: () => string;
+  take: () => { truncated: boolean; value: string };
 } {
   const chunks: string[] = [];
   const decoder = new TextDecoder();
+  let byteLength = 0;
+  let truncated = false;
 
   return {
     file: new ConsoleStdout((buffer) => {
-      chunks.push(decoder.decode(buffer, { stream: true }));
+      if (truncated) return;
+      const retained = buffer.subarray(0, Math.max(0, maxBytes - byteLength));
+      if (retained.byteLength > 0) {
+        chunks.push(decoder.decode(retained, { stream: true }));
+        byteLength += retained.byteLength;
+      }
+      truncated = retained.byteLength < buffer.byteLength;
     }),
-    take: () => `${chunks.join('')}${decoder.decode()}`.trimEnd()
+    take: () => {
+      const bounded = truncateUtf8(`${chunks.join('')}${decoder.decode()}`.trimEnd(), maxBytes);
+      return { value: bounded.value, truncated: truncated || bounded.truncated };
+    }
   };
 }

--- a/packages/oxiquill/src/lib/doc-runtime/interactive-cell-model.ts
+++ b/packages/oxiquill/src/lib/doc-runtime/interactive-cell-model.ts
@@ -2,7 +2,12 @@ import type { RuntimeLabels } from './runtime-localization.js';
 import { labelsForLanguage } from './runtime-localization.js';
 import type { CellManifest, InputSpec, InputValues, RunMode } from './types.js';
 
-export { formatInputValue, parseNumericInput, validateNumericInputValue } from './interactive-input-validation.js';
+export {
+  formatInputValue,
+  parseNumericInput,
+  stepNumericInputValue,
+  validateNumericInputValue
+} from './interactive-input-validation.js';
 
 export { labelsForLanguage, localeFromLanguage } from './runtime-localization.js';
 export type { RuntimeLabels, RuntimeLocale } from './runtime-localization.js';

--- a/packages/oxiquill/src/lib/doc-runtime/interactive-cell-model.ts
+++ b/packages/oxiquill/src/lib/doc-runtime/interactive-cell-model.ts
@@ -2,15 +2,13 @@ import type { RuntimeLabels } from './runtime-localization.js';
 import { labelsForLanguage } from './runtime-localization.js';
 import type { CellManifest, InputSpec, InputValues, RunMode } from './types.js';
 
+export { formatInputValue, parseNumericInput, validateNumericInputValue } from './interactive-input-validation.js';
+
 export { labelsForLanguage, localeFromLanguage } from './runtime-localization.js';
 export type { RuntimeLabels, RuntimeLocale } from './runtime-localization.js';
 
 export function initialValues(inputs: readonly InputSpec[]): InputValues {
   return Object.fromEntries(inputs.map((input) => [input.name, input.value]));
-}
-
-export function formatInputValue(value: string | number | boolean): string {
-  return typeof value === 'number' ? value.toFixed(Number.isInteger(value) ? 0 : 2) : String(value);
 }
 
 export function shouldShowRunButton(runMode: RunMode): boolean {
@@ -29,6 +27,9 @@ export function idleOutputMessage(
 }
 
 export function coerceInputValue(input: InputSpec, rawValue: string): string | number {
-  if (input.type === 'number' || input.type === 'integer') return Number(rawValue);
+  if (input.type === 'number' || input.type === 'integer') {
+    const value = Number(rawValue);
+    return rawValue.trim() !== '' && Number.isFinite(value) ? value : rawValue;
+  }
   return rawValue;
 }

--- a/packages/oxiquill/src/lib/doc-runtime/interactive-cell-scheduler.ts
+++ b/packages/oxiquill/src/lib/doc-runtime/interactive-cell-scheduler.ts
@@ -1,3 +1,5 @@
+import { ExecutionCancellationError, isExecutionCancellation } from './execution-cancellation.js';
+
 type SchedulerTimer = ReturnType<typeof setTimeout>;
 
 type ScheduledRequest<Request> = {
@@ -7,7 +9,8 @@ type ScheduledRequest<Request> = {
 };
 
 type LatestRequestSchedulerOptions<Request, Result> = {
-  execute: (request: Request) => Promise<Result>;
+  execute: (request: Request, signal: AbortSignal) => Promise<Result>;
+  onCancelled?: () => void;
   onError: (error: unknown) => void;
   onResult: (result: Result) => void;
   onScheduled: () => void;
@@ -23,8 +26,10 @@ export function createLatestRequestScheduler<Request, Result>(
   dependencies: SchedulerDependencies = defaultSchedulerDependencies
 ): {
   dispose: () => void;
+  cancel: () => void;
   schedule: (request: Request, delayMs?: number) => void;
 } {
+  let activeController: AbortController | undefined;
   let activeGeneration: number | undefined;
   let generation = 0;
   let listeners: LatestRequestSchedulerOptions<Request, Result> | undefined = callbacks;
@@ -38,6 +43,7 @@ export function createLatestRequestScheduler<Request, Result>(
     clearPendingTimer();
     pending = { generation, ready: delayMs <= 0, request };
     listeners.onScheduled();
+    activeController?.abort();
 
     if (delayMs > 0) {
       const scheduledGeneration = generation;
@@ -58,11 +64,12 @@ export function createLatestRequestScheduler<Request, Result>(
     if (!listeners || activeGeneration !== undefined || !pending?.ready) return;
 
     const active = pending;
+    const controller = new AbortController();
     pending = undefined;
     activeGeneration = active.generation;
+    activeController = controller;
 
-    void Promise.resolve()
-      .then(() => callbacks.execute(active.request))
+    void executeWithCancellation(active.request, controller)
       .then(
         (result) => {
           if (listeners && generation === active.generation) {
@@ -71,15 +78,33 @@ export function createLatestRequestScheduler<Request, Result>(
         },
         (error: unknown) => {
           if (listeners && generation === active.generation) {
-            listeners.onError(error);
+            if (isExecutionCancellation(error)) {
+              listeners.onCancelled?.();
+            } else {
+              listeners.onError(error);
+            }
           }
         }
       )
       .finally(() => {
-        activeGeneration = undefined;
+        if (activeController === controller) {
+          activeController = undefined;
+          activeGeneration = undefined;
+        }
         drain();
       })
       .catch(() => undefined);
+  }
+
+  function executeWithCancellation(request: Request, controller: AbortController): Promise<Result> {
+    const execution = Promise.resolve().then(() => {
+      if (controller.signal.aborted) throw new ExecutionCancellationError();
+      return callbacks.execute(request, controller.signal);
+    });
+    const cancellation = new Promise<never>((_, reject) => {
+      controller.signal.addEventListener('abort', () => reject(new ExecutionCancellationError()), { once: true });
+    });
+    return Promise.race([execution, cancellation]);
   }
 
   function clearPendingTimer(): void {
@@ -89,14 +114,19 @@ export function createLatestRequestScheduler<Request, Result>(
     timer = undefined;
   }
 
-  function dispose(): void {
+  function cancel(): void {
     generation += 1;
     clearPendingTimer();
     pending = undefined;
+    activeController?.abort();
+  }
+
+  function dispose(): void {
+    cancel();
     listeners = undefined;
   }
 
-  return { dispose, schedule };
+  return { cancel, dispose, schedule };
 }
 
 export function createRunOnceCache<Key, Result>(): {
@@ -111,6 +141,9 @@ export function createRunOnceCache<Key, Result>(): {
 
       const request = Promise.resolve().then(execute);
       requests.set(key, request);
+      void request.catch((error: unknown) => {
+        if (isExecutionCancellation(error) && requests.get(key) === request) requests.delete(key);
+      });
       return request;
     }
   };

--- a/packages/oxiquill/src/lib/doc-runtime/interactive-input-validation.ts
+++ b/packages/oxiquill/src/lib/doc-runtime/interactive-input-validation.ts
@@ -1,0 +1,93 @@
+import type { CellManifest, InputSpec, InputValues } from './types.js';
+import { isPortableInteger, PORTABLE_INTEGER_MAX, PORTABLE_INTEGER_MIN } from './portable-integer.mjs';
+
+export type NumericInputValidation =
+  'required' | 'number' | 'integer' | 'rangeUnderflow' | 'rangeOverflow' | 'stepMismatch';
+
+export type ParsedNumericInput = { valid: false; validation: NumericInputValidation } | { valid: true; value: number };
+
+export function parseNumericInput(input: InputSpec, rawValue: string): ParsedNumericInput {
+  if (rawValue.trim() === '') return { valid: false, validation: 'required' };
+
+  const value = Number(rawValue);
+  const validation = validateNumericInputValue(input, value);
+  return validation ? { valid: false, validation } : { valid: true, value };
+}
+
+export function validateNumericInputValue(input: InputSpec, value: unknown): NumericInputValidation | undefined {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return 'number';
+  if (isIntegerInput(input) && !isPortableInteger(value)) return 'integer';
+
+  const minimum = effectiveMinimum(input);
+  const maximum = effectiveMaximum(input);
+  if (minimum !== undefined && value < minimum) return 'rangeUnderflow';
+  if (maximum !== undefined && value > maximum) return 'rangeOverflow';
+  if (hasStepMismatch(input, value)) return 'stepMismatch';
+  return undefined;
+}
+
+export function assertValidInputValues(cell: CellManifest, values: InputValues): void {
+  for (const input of cell.inputs) {
+    const value = values[input.name];
+    if (isNumericInput(input)) {
+      const validation = validateNumericInputValue(input, value);
+      if (validation) {
+        throw new Error(`input ${input.name} has an invalid committed numeric value (${validation})`);
+      }
+      continue;
+    }
+
+    if (input.type === 'checkbox' ? typeof value !== 'boolean' : typeof value !== 'string') {
+      throw new Error(`input ${input.name} has an invalid committed value`);
+    }
+  }
+}
+
+export function completeInputValues(cell: CellManifest, values: InputValues): InputValues {
+  return Object.fromEntries(cell.inputs.map((input) => [input.name, values[input.name] ?? input.value]));
+}
+
+export function formatInputValue(value: string | number | boolean, step?: number): string {
+  if (typeof value !== 'number') return String(value);
+  if (!Number.isFinite(value)) return String(value);
+  if (step === undefined) return value.toFixed(Number.isInteger(value) ? 0 : 2);
+
+  const precision = decimalPlaces(step);
+  return precision === 0 ? value.toFixed(0) : value.toFixed(Math.min(precision, 100));
+}
+
+export function effectiveMinimum(input: InputSpec): number | undefined {
+  return isIntegerInput(input) ? Math.max(input.min ?? PORTABLE_INTEGER_MIN, PORTABLE_INTEGER_MIN) : input.min;
+}
+
+export function effectiveMaximum(input: InputSpec): number | undefined {
+  return isIntegerInput(input) ? Math.min(input.max ?? PORTABLE_INTEGER_MAX, PORTABLE_INTEGER_MAX) : input.max;
+}
+
+export function effectiveStep(input: InputSpec): number {
+  return input.step ?? 1;
+}
+
+export function isIntegerInput(input: InputSpec): boolean {
+  return input.type === 'integer' || input.integer === true;
+}
+
+export function isNumericInput(input: InputSpec): boolean {
+  return input.type === 'range' || input.type === 'number' || input.type === 'integer';
+}
+
+function hasStepMismatch(input: InputSpec, value: number): boolean {
+  const step = effectiveStep(input);
+  const base = input.min ?? (typeof input.value === 'number' ? input.value : 0);
+  const steps = (value - base) / step;
+  const tolerance = Number.EPSILON * Math.max(1, Math.abs(steps)) * 8;
+  return Math.abs(steps - Math.round(steps)) > tolerance;
+}
+
+function decimalPlaces(value: number): number {
+  const text = String(value).toLowerCase();
+  const [coefficient, exponentText] = text.split('e');
+  const exponent = exponentText ? Number(exponentText) : 0;
+  const fractionLength = coefficient.split('.')[1]?.length ?? 0;
+  return Math.max(0, fractionLength - exponent);
+}

--- a/packages/oxiquill/src/lib/doc-runtime/interactive-input-validation.ts
+++ b/packages/oxiquill/src/lib/doc-runtime/interactive-input-validation.ts
@@ -68,6 +68,15 @@ export function effectiveStep(input: InputSpec): number {
   return input.step ?? 1;
 }
 
+export function stepNumericInputValue(input: InputSpec, value: number, direction: -1 | 1): number {
+  const precision = Math.min(
+    Math.max(decimalPlaces(effectiveStep(input)), decimalPlaces(value), decimalPlaces(input.min ?? 0)),
+    100
+  );
+  const stepped = Number((value + direction * effectiveStep(input)).toFixed(precision));
+  return Math.min(effectiveMaximum(input) ?? stepped, Math.max(effectiveMinimum(input) ?? stepped, stepped));
+}
+
 export function isIntegerInput(input: InputSpec): boolean {
   return input.type === 'integer' || input.integer === true;
 }

--- a/packages/oxiquill/src/lib/doc-runtime/output-artifact-validation.ts
+++ b/packages/oxiquill/src/lib/doc-runtime/output-artifact-validation.ts
@@ -11,16 +11,9 @@ import type {
   TableColumnType,
   TextArtifact
 } from './types.js';
+import { outputArtifactLimits, truncateUtf8, utf8ByteLength } from './output-limits.mjs';
 
-export const outputArtifactLimits = Object.freeze({
-  artifactsPerRun: 100,
-  bytesPerTextJsonOrHtml: 1024 * 1024,
-  chartDataItems: 100_000,
-  columnsPerTable: 100,
-  decodedBytesPerImage: 10 * 1024 * 1024,
-  rowsPerTable: 10_000,
-  validatedBytesPerRun: 16 * 1024 * 1024
-});
+export { outputArtifactLimits } from './output-limits.mjs';
 
 export interface ValidatedJsonArtifact extends JsonArtifact {
   formattedValue: string;
@@ -108,15 +101,19 @@ const tableColumnTypes = new Set<TableColumnType>([
   'null',
   'unknown'
 ]);
-const utf8Encoder = new TextEncoder();
 const utf8Decoder = new TextDecoder('utf-8', { fatal: true });
 const maximumJsonNestingDepth = 100;
 
-class ArtifactValidationError extends Error {}
+class ArtifactValidationError extends Error {
+  constructor(message: string) {
+    super(truncateUtf8(message, outputArtifactLimits.bytesPerDiagnostic).value);
+  }
+}
 
 export function validateOutputArtifacts(outputs: readonly unknown[]): readonly ValidatedArtifactResult[] {
   const results: ValidatedArtifactResult[] = [];
   let validatedBytes = 0;
+  let diagnosticBytes = 0;
   const artifactCount = Math.min(outputs.length, outputArtifactLimits.artifactsPerRun);
 
   for (let index = 0; index < artifactCount; index += 1) {
@@ -128,18 +125,24 @@ export function validateOutputArtifacts(outputs: readonly unknown[]): readonly V
       validatedBytes += validated.byteLength;
       results.push({ status: 'valid', ...validated, index });
     } catch (error) {
+      const message = boundedDiagnostic(error, outputArtifactLimits.diagnosticBytesPerRun - diagnosticBytes);
+      diagnosticBytes += utf8ByteLength(message);
       results.push({
         status: 'error',
-        message: error instanceof Error ? error.message : String(error),
+        message,
         index
       });
     }
   }
 
   if (outputs.length > outputArtifactLimits.artifactsPerRun) {
+    const message = boundedDiagnostic(
+      `Artifact limit exceeded: received ${outputs.length}, maximum ${outputArtifactLimits.artifactsPerRun}.`,
+      outputArtifactLimits.diagnosticBytesPerRun - diagnosticBytes
+    );
     results.push({
       status: 'error',
-      message: `Artifact limit exceeded: received ${outputs.length}, maximum ${outputArtifactLimits.artifactsPerRun}.`,
+      message,
       index: outputArtifactLimits.artifactsPerRun
     });
   }
@@ -164,6 +167,8 @@ function validateOutputArtifact(value: unknown, remainingBytes: number): Validat
       return validateImageArtifact(record, remainingBytes);
     case 'html':
       return validateHtmlArtifact(record, remainingBytes);
+    case '__oxiquill_error':
+      throw new ArtifactValidationError(requiredString(record, 'message', 'Producer artifact error'));
     default:
       throw new ArtifactValidationError(`Unsupported artifact kind ${quoted(kind)}.`);
   }
@@ -380,9 +385,13 @@ function validateTableColumn(value: unknown, index: number): TableColumn {
   if (type != null && !tableColumnTypes.has(type as TableColumnType)) {
     throw new ArtifactValidationError(`Table artifact column ${index + 1} type ${quoted(type)} is not supported.`);
   }
+  const key = requiredString(record, 'key', `Table artifact column ${index + 1}`);
+  const label = requiredString(record, 'label', `Table artifact column ${index + 1}`);
+  requireMetadataBudget(key, `Table artifact column ${index + 1} key`);
+  requireMetadataBudget(label, `Table artifact column ${index + 1} label`);
   return {
-    key: requiredString(record, 'key', `Table artifact column ${index + 1}`),
-    label: requiredString(record, 'label', `Table artifact column ${index + 1}`),
+    key,
+    label,
     ...(type == null ? {} : { type: type as TableColumnType })
   };
 }
@@ -646,7 +655,7 @@ function safeJsonFormat(value: unknown, maxBytes: number, context: string): Json
       tasks.push({
         kind: 'visit',
         input: descriptor.value,
-        path: `${task.path}.${key}`,
+        path: jsonObjectPath(task.path, key),
         depth: task.depth + 1,
         assign: (next) => {
           Object.defineProperty(task.output, key, {
@@ -748,7 +757,9 @@ function validateBase64Image(
   const parsed = parseDataUrl(data);
   const payload = parsed ? parsed.payload : data;
   if (parsed && parsed.mime !== mime) {
-    throw new ArtifactValidationError(`Image artifact MIME mismatch: field is ${mime}, data URL is ${parsed.mime}.`);
+    throw new ArtifactValidationError(
+      `Image artifact MIME mismatch: field is ${quoted(mime)}, data URL is ${quoted(parsed.mime)}.`
+    );
   }
   if (parsed && !parsed.base64) {
     throw new ArtifactValidationError(`${mime} image data URLs must use base64 encoding.`);
@@ -766,7 +777,7 @@ function validateSvgImage(data: string): { data: string; decodedBytes: number; s
   const parsed = parseDataUrl(data);
   if (parsed && parsed.mime !== 'image/svg+xml') {
     throw new ArtifactValidationError(
-      `Image artifact MIME mismatch: field is image/svg+xml, data URL is ${parsed.mime}.`
+      `Image artifact MIME mismatch: field is image/svg+xml, data URL is ${quoted(parsed.mime)}.`
     );
   }
   let svg = data;
@@ -873,31 +884,6 @@ function payloadByteLength(value: unknown): number {
   return utf8ByteLength(JSON.stringify(value));
 }
 
-function truncateUtf8(value: string, maxBytes: number): { byteLength: number; truncated: boolean; value: string } {
-  const byteLength = utf8ByteLength(value);
-  if (byteLength <= maxBytes) return { value, byteLength, truncated: false };
-  if (maxBytes <= 0) return { value: '', byteLength: 0, truncated: true };
-  const marker = '…';
-  const markerBytes = utf8ByteLength(marker);
-  if (maxBytes < markerBytes) return { value: '', byteLength: 0, truncated: true };
-  let low = 0;
-  let high = value.length;
-  while (low < high) {
-    const middle = Math.ceil((low + high) / 2);
-    const candidate = value.slice(0, middle);
-    if (utf8ByteLength(candidate) + markerBytes <= maxBytes) low = middle;
-    else high = middle - 1;
-  }
-  const lastCodeUnit = value.charCodeAt(low - 1);
-  if (low > 0 && lastCodeUnit >= 0xd800 && lastCodeUnit <= 0xdbff) low -= 1;
-  const bounded = `${value.slice(0, low)}${marker}`;
-  return { value: bounded, byteLength: utf8ByteLength(bounded), truncated: true };
-}
-
-function utf8ByteLength(value: string): number {
-  return utf8Encoder.encode(value).byteLength;
-}
-
 function plainRecord(value: unknown, context: string): Record<string, unknown> {
   if (typeof value !== 'object' || value === null || Array.isArray(value)) {
     throw new ArtifactValidationError(`${context} must be a plain record.`);
@@ -950,6 +936,7 @@ function optionalString(record: Record<string, unknown>, key: string, context: s
   if (typeof value !== 'string') {
     throw new ArtifactValidationError(`${context} field ${quoted(key)} must be a string when provided.`);
   }
+  requireMetadataBudget(value, `${context} field ${quoted(key)}`);
   return value;
 }
 
@@ -1116,5 +1103,23 @@ function chartLimitError(dataItems: number): ArtifactValidationError {
 }
 
 function quoted(value: string): string {
-  return JSON.stringify(value);
+  return JSON.stringify(truncateUtf8(value, 256).value);
+}
+
+function requireMetadataBudget(value: string, context: string): void {
+  const byteLength = utf8ByteLength(value);
+  if (byteLength > outputArtifactLimits.bytesPerMetadataField) {
+    throw new ArtifactValidationError(
+      `${context} is ${byteLength} bytes; maximum is ${outputArtifactLimits.bytesPerMetadataField}.`
+    );
+  }
+}
+
+function jsonObjectPath(path: string, key: string): string {
+  return truncateUtf8(`${path}.${key}`, outputArtifactLimits.bytesPerDiagnostic / 2).value;
+}
+
+function boundedDiagnostic(value: unknown, remainingBytes: number): string {
+  const message = value instanceof Error ? value.message : String(value);
+  return truncateUtf8(message, Math.min(outputArtifactLimits.bytesPerDiagnostic, Math.max(0, remainingBytes))).value;
 }

--- a/packages/oxiquill/src/lib/doc-runtime/output-artifact-validation.ts
+++ b/packages/oxiquill/src/lib/doc-runtime/output-artifact-validation.ts
@@ -429,9 +429,18 @@ function validateChartSpec(value: unknown): ChartSpec {
   switch (kind) {
     case 'line':
     case 'scatter':
-    case 'area':
-      return { ...base, kind, series: validateXySeries(requiredOwnValue(record, 'series', `${kind} chart`)) };
+    case 'area': {
+      const xType = base.xType ?? 'value';
+      const yType = base.yType ?? 'value';
+      return {
+        ...base,
+        kind,
+        series: validateXySeries(requiredOwnValue(record, 'series', `${kind} chart`), xType, yType)
+      };
+    }
     case 'bar': {
+      requireEffectiveAxis(base.xType, 'category', 'Bar chart x axis');
+      const yType = numericAxisType(base.yType, 'Bar chart y axis');
       const categories = stringArray(requiredOwnValue(record, 'categories', 'Bar chart'), 'Bar chart categories');
       if (categories.length > outputArtifactLimits.chartDataItems) {
         throw chartLimitError(categories.length);
@@ -450,7 +459,7 @@ function validateChartSpec(value: unknown): ChartSpec {
         }
         const validatedValues = values.map((item, valueIndex) => {
           if (item === null) return null;
-          return finiteNumber(item, `Bar chart series ${seriesIndex + 1} value ${valueIndex + 1}`);
+          return numericCoordinate(item, yType, `Bar chart series ${seriesIndex + 1} value ${valueIndex + 1}`);
         });
         if (validatedValues.length !== categories.length) {
           throw new ArtifactValidationError(
@@ -464,31 +473,44 @@ function validateChartSpec(value: unknown): ChartSpec {
       return { ...base, kind, categories, series };
     }
     case 'histogram': {
+      requireEffectiveAxis(base.xType, 'category', 'Histogram chart x axis');
+      const yType = numericAxisType(base.yType, 'Histogram chart y axis');
       const rawBins = plainArray(requiredOwnValue(record, 'bins', 'Histogram chart'), 'Histogram chart bins');
       if (rawBins.length > outputArtifactLimits.chartDataItems) throw chartLimitError(rawBins.length);
       const bins = rawBins.map((bin, binIndex) => {
         const tuple = fixedTuple(bin, 3, `Histogram chart bin ${binIndex + 1}`);
-        return [
-          finiteNumber(tuple[0], `Histogram chart bin ${binIndex + 1} lower bound`),
-          finiteNumber(tuple[1], `Histogram chart bin ${binIndex + 1} upper bound`),
-          finiteNumber(tuple[2], `Histogram chart bin ${binIndex + 1} count`)
-        ] as const;
+        const lower = finiteNumber(tuple[0], `Histogram chart bin ${binIndex + 1} lower bound`);
+        const upper = finiteNumber(tuple[1], `Histogram chart bin ${binIndex + 1} upper bound`);
+        if (lower >= upper) {
+          throw new ArtifactValidationError(
+            `Histogram chart bin ${binIndex + 1} lower bound must be smaller than its upper bound.`
+          );
+        }
+        const count = numericCoordinate(tuple[2], yType, `Histogram chart bin ${binIndex + 1} count`);
+        if (count < 0) {
+          throw new ArtifactValidationError(`Histogram chart bin ${binIndex + 1} count must not be negative.`);
+        }
+        return [lower, upper, count] as const;
       });
       return { ...base, kind, bins };
     }
     case 'heatmap': {
+      const xCategories = optionalStringArray(record, 'xCategories', 'Heatmap chart');
+      const yCategories = optionalStringArray(record, 'yCategories', 'Heatmap chart');
+      if (xCategories) requireUniqueCategories(xCategories, 'Heatmap chart xCategories');
+      if (yCategories) requireUniqueCategories(yCategories, 'Heatmap chart yCategories');
+      const xType = heatmapAxisType(base.xType, xCategories, 'x');
+      const yType = heatmapAxisType(base.yType, yCategories, 'y');
       const rawData = plainArray(requiredOwnValue(record, 'data', 'Heatmap chart'), 'Heatmap chart data');
       if (rawData.length > outputArtifactLimits.chartDataItems) throw chartLimitError(rawData.length);
       const data = rawData.map((cell, cellIndex) => {
         const tuple = fixedTuple(cell, 3, `Heatmap chart cell ${cellIndex + 1}`);
         return [
-          chartCoordinate(tuple[0], `Heatmap chart cell ${cellIndex + 1} x coordinate`),
-          chartCoordinate(tuple[1], `Heatmap chart cell ${cellIndex + 1} y coordinate`),
+          chartCoordinate(tuple[0], xType, `Heatmap chart cell ${cellIndex + 1} x coordinate`, xCategories),
+          chartCoordinate(tuple[1], yType, `Heatmap chart cell ${cellIndex + 1} y coordinate`, yCategories),
           finiteNumber(tuple[2], `Heatmap chart cell ${cellIndex + 1} value`)
         ] as const;
       });
-      const xCategories = optionalStringArray(record, 'xCategories', 'Heatmap chart');
-      const yCategories = optionalStringArray(record, 'yCategories', 'Heatmap chart');
       return {
         ...base,
         kind,
@@ -529,7 +551,11 @@ function validateBaseChartSpec(record: Record<string, unknown>): Omit<ChartSpec,
   } as Omit<ChartSpec, 'kind'>;
 }
 
-function validateXySeries(value: unknown): Extract<ChartSpec, { kind: 'line' }>['series'] {
+function validateXySeries(
+  value: unknown,
+  xType: ChartAxisType,
+  yType: ChartAxisType
+): Extract<ChartSpec, { kind: 'line' }>['series'] {
   const rawSeries = plainArray(value, 'XY chart series');
   if (rawSeries.length > outputArtifactLimits.chartDataItems) throw chartLimitError(rawSeries.length);
   let dataItems = 0;
@@ -544,8 +570,8 @@ function validateXySeries(value: unknown): Extract<ChartSpec, { kind: 'line' }>[
     const points = rawPoints.map((point, pointIndex) => {
       const tuple = fixedTuple(point, 2, `XY chart series ${seriesIndex + 1} point ${pointIndex + 1}`);
       return [
-        chartCoordinate(tuple[0], `XY chart series ${seriesIndex + 1} point ${pointIndex + 1} x coordinate`),
-        chartCoordinate(tuple[1], `XY chart series ${seriesIndex + 1} point ${pointIndex + 1} y coordinate`)
+        chartCoordinate(tuple[0], xType, `XY chart series ${seriesIndex + 1} point ${pointIndex + 1} x coordinate`),
+        chartCoordinate(tuple[1], yType, `XY chart series ${seriesIndex + 1} point ${pointIndex + 1} y coordinate`)
       ] as const;
     });
     const name = optionalString(record, 'name', `XY chart series ${seriesIndex + 1}`);
@@ -984,9 +1010,103 @@ function finiteNumber(value: unknown, context: string): number {
   return value;
 }
 
-function chartCoordinate(value: unknown, context: string): number | string {
-  if (typeof value === 'string') return value;
-  return finiteNumber(value, context);
+function chartCoordinate(
+  value: unknown,
+  axisType: ChartAxisType,
+  context: string,
+  categories?: readonly string[]
+): number | string {
+  switch (axisType) {
+    case 'value':
+    case 'log':
+      return numericCoordinate(value, axisType, context);
+    case 'time':
+      if (typeof value === 'number') return finiteNumber(value, context);
+      if (typeof value === 'string' && isSupportedIsoDateTime(value)) return value;
+      throw new ArtifactValidationError(
+        `${context} must be finite epoch milliseconds or an ISO-8601 date-time with an explicit time zone.`
+      );
+    case 'category': {
+      if (typeof value !== 'string' && (typeof value !== 'number' || !Number.isFinite(value))) {
+        throw new ArtifactValidationError(`${context} must be a string or finite numeric category coordinate.`);
+      }
+      if (categories && !isCategoryMember(value, categories)) {
+        throw new ArtifactValidationError(`${context} is not present in the declared categories.`);
+      }
+      return value;
+    }
+  }
+}
+
+function numericCoordinate(value: unknown, axisType: 'value' | 'log' | 'time', context: string): number {
+  const number = finiteNumber(value, context);
+  if (axisType === 'log' && number <= 0) {
+    throw new ArtifactValidationError(`${context} must be strictly positive for a log axis.`);
+  }
+  return number;
+}
+
+function heatmapAxisType(
+  declaredType: ChartAxisType | undefined,
+  categories: readonly string[] | undefined,
+  axis: 'x' | 'y'
+): ChartAxisType {
+  if (!categories) return declaredType ?? 'value';
+  requireEffectiveAxis(declaredType, 'category', `Heatmap chart ${axis} axis`);
+  return 'category';
+}
+
+function requireEffectiveAxis(
+  declaredType: ChartAxisType | undefined,
+  effectiveType: ChartAxisType,
+  context: string
+): void {
+  if (declaredType != null && declaredType !== effectiveType) {
+    throw new ArtifactValidationError(`${context} is always ${effectiveType}; received ${declaredType}.`);
+  }
+}
+
+function numericAxisType(declaredType: ChartAxisType | undefined, context: string): 'value' | 'log' | 'time' {
+  if (declaredType === 'category') {
+    throw new ArtifactValidationError(`${context} cannot be category because its data is numeric.`);
+  }
+  return declaredType ?? 'value';
+}
+
+function requireUniqueCategories(categories: readonly string[], context: string): void {
+  if (new Set(categories).size !== categories.length) {
+    throw new ArtifactValidationError(`${context} must not contain duplicate values.`);
+  }
+}
+
+function isCategoryMember(value: string | number, categories: readonly string[]): boolean {
+  if (typeof value === 'string') return categories.includes(value);
+  return Number.isSafeInteger(value) && value >= 0 && value < categories.length;
+}
+
+function isSupportedIsoDateTime(value: string): boolean {
+  const match = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.(\d{1,3}))?(Z|[+-]\d{2}:\d{2})$/u.exec(value);
+  if (!match) return false;
+  const [, yearText, monthText, dayText, hourText, minuteText, secondText, , zone] = match;
+  const year = Number(yearText);
+  const month = Number(monthText);
+  const day = Number(dayText);
+  const hour = Number(hourText);
+  const minute = Number(minuteText);
+  const second = Number(secondText);
+  if (month < 1 || month > 12 || day < 1 || day > daysInMonth(year, month)) return false;
+  if (hour > 23 || minute > 59 || second > 59) return false;
+  if (zone !== 'Z') {
+    const offsetHours = Number(zone?.slice(1, 3));
+    const offsetMinutes = Number(zone?.slice(4, 6));
+    if (offsetHours > 23 || offsetMinutes > 59) return false;
+  }
+  return Number.isFinite(Date.parse(value));
+}
+
+function daysInMonth(year: number, month: number): number {
+  const leapYear = year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0);
+  return [31, leapYear ? 29 : 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31][month - 1] ?? 0;
 }
 
 function chartLimitError(dataItems: number): ArtifactValidationError {

--- a/packages/oxiquill/src/lib/doc-runtime/output-artifacts.ts
+++ b/packages/oxiquill/src/lib/doc-runtime/output-artifacts.ts
@@ -51,16 +51,9 @@ export function normalizeCellExecutionResult(result: RawCellExecutionResult): No
     output.status === 'valid' ? [publicOutputArtifact(output.artifact)] : []
   );
   const legacy = outputsToLegacyResult(outputs);
-  const rawStdout = ownDataField(result, 'stdout').value;
-  const rawStderr = ownDataField(result, 'stderr').value;
-  const rawValue = ownDataField(result, 'value');
-  const rawPlots = ownDataField(result, 'plots');
 
   return {
-    stdout: typeof rawStdout === 'string' ? rawStdout : legacy.stdout,
-    ...(typeof rawStderr === 'string' ? { stderr: rawStderr } : legacy.stderr ? { stderr: legacy.stderr } : {}),
-    ...(rawValue.present ? { value: rawValue.value } : Object.hasOwn(legacy, 'value') ? { value: legacy.value } : {}),
-    plots: rawPlots.present && Array.isArray(rawPlots.value) ? validatedLegacyPlots(rawPlots.value) : legacy.plots,
+    ...legacy,
     outputs,
     outputResults
   };
@@ -77,12 +70,6 @@ function legacyResultToOutputCandidates(result: RawCellExecutionResult): readonl
     value.present && value.value != null && value.value !== '' ? [{ kind: 'json', value: value.value }] : [],
     ...(Array.isArray(plots) ? plots.map((plot) => [legacyPlotCandidate(plot)]) : [])
   ].flat();
-}
-
-function validatedLegacyPlots(values: readonly unknown[]): readonly PlotSpec[] {
-  return validateOutputArtifacts(values.map(legacyPlotCandidate)).flatMap((result) =>
-    result.status === 'valid' ? chartArtifactToLegacyPlot(result.artifact) : []
-  );
 }
 
 function legacyPlotCandidate(value: unknown): unknown {

--- a/packages/oxiquill/src/lib/doc-runtime/output-limits.mjs
+++ b/packages/oxiquill/src/lib/doc-runtime/output-limits.mjs
@@ -1,0 +1,67 @@
+export const outputArtifactLimits = Object.freeze({
+  artifactsPerRun: 100,
+  bytesPerDiagnostic: 8 * 1024,
+  bytesPerError: 16 * 1024,
+  bytesPerMetadataField: 16 * 1024,
+  bytesPerStream: 1024 * 1024,
+  bytesPerTextJsonOrHtml: 1024 * 1024,
+  chartDataItems: 100_000,
+  columnsPerTable: 100,
+  decodedBytesPerImage: 10 * 1024 * 1024,
+  diagnosticBytesPerRun: 64 * 1024,
+  rowsPerTable: 10_000,
+  validatedBytesPerRun: 16 * 1024 * 1024,
+  workerResponseBytes: 16 * 1024 * 1024
+});
+
+const utf8Encoder = new TextEncoder();
+
+export function utf8ByteLength(value) {
+  return utf8Encoder.encode(value).byteLength;
+}
+
+export function truncateUtf8(value, maxBytes) {
+  const byteLength = utf8ByteLength(value);
+  if (byteLength <= maxBytes) return { value, byteLength, truncated: false };
+  if (maxBytes <= 0) return { value: '', byteLength: 0, truncated: true };
+  const marker = '…';
+  const markerBytes = utf8ByteLength(marker);
+  if (maxBytes < markerBytes) return { value: '', byteLength: 0, truncated: true };
+  let low = 0;
+  let high = value.length;
+  while (low < high) {
+    const middle = Math.ceil((low + high) / 2);
+    const candidate = value.slice(0, middle);
+    if (utf8ByteLength(candidate) + markerBytes <= maxBytes) low = middle;
+    else high = middle - 1;
+  }
+  const lastCodeUnit = value.charCodeAt(low - 1);
+  if (low > 0 && lastCodeUnit >= 0xd800 && lastCodeUnit <= 0xdbff) low -= 1;
+  const bounded = `${value.slice(0, low)}${marker}`;
+  return { value: bounded, byteLength: utf8ByteLength(bounded), truncated: true };
+}
+
+export function boundedErrorMessage(value) {
+  const message = value instanceof Error ? value.message : String(value);
+  return truncateUtf8(message, outputArtifactLimits.bytesPerError).value;
+}
+
+export function createBoundedTextAccumulator(maxBytes = outputArtifactLimits.bytesPerStream, separator = '') {
+  const chunks = [];
+  let byteLength = 0;
+  let truncated = false;
+
+  return {
+    append(value) {
+      if (truncated) return;
+      const candidate = chunks.length > 0 ? `${separator}${value}` : value;
+      const bounded = truncateUtf8(candidate, maxBytes - byteLength);
+      if (bounded.value) chunks.push(bounded.value);
+      byteLength += bounded.byteLength;
+      truncated = bounded.truncated;
+    },
+    take() {
+      return { value: chunks.join(''), truncated };
+    }
+  };
+}

--- a/packages/oxiquill/src/lib/doc-runtime/portable-integer.mjs
+++ b/packages/oxiquill/src/lib/doc-runtime/portable-integer.mjs
@@ -1,0 +1,15 @@
+export const PORTABLE_INTEGER_MIN = -(2 ** 31);
+export const PORTABLE_INTEGER_MAX = 2 ** 31 - 1;
+
+/**
+ * @param {unknown} value
+ * @returns {value is number}
+ */
+export function isPortableInteger(value) {
+  return (
+    typeof value === 'number' &&
+    Number.isSafeInteger(value) &&
+    value >= PORTABLE_INTEGER_MIN &&
+    value <= PORTABLE_INTEGER_MAX
+  );
+}

--- a/packages/oxiquill/src/lib/doc-runtime/python-cell-result.ts
+++ b/packages/oxiquill/src/lib/doc-runtime/python-cell-result.ts
@@ -5,16 +5,25 @@ export function createPythonCellResult({
   displayOutputs,
   plots,
   stderr,
+  stderrTruncated = false,
   stdout,
+  stdoutTruncated = false,
   value
 }: {
   displayOutputs: readonly unknown[];
   plots: NonNullable<RawCellExecutionResult['plots']>;
   stderr: string;
+  stderrTruncated?: boolean;
   stdout: string;
+  stdoutTruncated?: boolean;
   value: unknown;
 }): RawCellExecutionResult {
-  const streamOutputs = legacyResultToOutputs({ stdout, stderr, plots: [] });
+  const streamOutputs = legacyResultToOutputs({ stdout, stderr, plots: [] }).map((output) =>
+    output.kind === 'text' &&
+    ((output.stream === 'stdout' && stdoutTruncated) || (output.stream === 'stderr' && stderrTruncated))
+      ? { ...output, truncated: true }
+      : output
+  );
   const valueOutputs = legacyResultToOutputs({ value, plots: [] });
 
   return {

--- a/packages/oxiquill/src/lib/doc-runtime/python-display-support.ts
+++ b/packages/oxiquill/src/lib/doc-runtime/python-display-support.ts
@@ -1,3 +1,5 @@
+import { outputArtifactLimits } from './output-limits.mjs';
+
 const pythonDisplayJsonAndScalarSupport = String.raw`
 import base64
 import builtins
@@ -8,6 +10,42 @@ __oxiquill_outputs = []
 __oxiquill_displayed_figures = set()
 __oxiquill_table_limit = 10000
 __oxiquill_table_column_limit = 100
+__oxiquill_artifact_limit = ${outputArtifactLimits.artifactsPerRun}
+__oxiquill_output_byte_limit = ${outputArtifactLimits.validatedBytesPerRun}
+__oxiquill_diagnostic_byte_limit = ${outputArtifactLimits.bytesPerDiagnostic}
+__oxiquill_output_bytes = 0
+__oxiquill_output_omission = None
+
+def __oxiquill_bound_text(value, max_bytes):
+    text = str(value)
+    encoded = text.encode("utf-8")
+    if len(encoded) <= max_bytes:
+        return text
+    marker = "…"
+    prefix = encoded[:max(0, max_bytes - len(marker.encode("utf-8")))]
+    return prefix.decode("utf-8", errors="ignore") + marker
+
+def __oxiquill_error_artifact(message):
+    return {
+        "kind": "__oxiquill_error",
+        "message": __oxiquill_bound_text(message, __oxiquill_diagnostic_byte_limit),
+    }
+
+def __oxiquill_append_output(artifact):
+    global __oxiquill_output_bytes, __oxiquill_output_omission
+    if len(__oxiquill_outputs) >= __oxiquill_artifact_limit:
+        __oxiquill_output_omission = "Python output exceeded the artifact count limit."
+        return
+    try:
+        artifact_bytes = len(json.dumps(artifact, ensure_ascii=False, separators=(",", ":")).encode("utf-8"))
+    except Exception as error:
+        artifact = __oxiquill_error_artifact(f"Python output could not be serialized: {error}")
+        artifact_bytes = len(json.dumps(artifact, ensure_ascii=False, separators=(",", ":")).encode("utf-8"))
+    if artifact_bytes > __oxiquill_output_byte_limit - __oxiquill_output_bytes:
+        __oxiquill_output_omission = "Python output exceeded the cumulative artifact byte limit."
+        return
+    __oxiquill_outputs.append(artifact)
+    __oxiquill_output_bytes += artifact_bytes
 
 def __oxiquill_meta(artifact, title=None, caption=None):
     if title is not None:
@@ -356,6 +394,8 @@ def __oxiquill_collect_matplotlib_outputs(preferred="svg", close_figures=True):
         return []
     outputs = []
     for number in list(plt.get_fignums()):
+        if len(outputs) >= __oxiquill_artifact_limit:
+            break
         fig = plt.figure(number)
         if id(fig) in __oxiquill_displayed_figures:
             continue
@@ -414,24 +454,24 @@ def __oxiquill_artifact(value, title=None, caption=None):
 
 const pythonDisplayPublicFunctions = String.raw`
 def display(value, *, title=None, caption=None):
-    __oxiquill_outputs.append(__oxiquill_artifact(value, title, caption))
+    __oxiquill_append_output(__oxiquill_artifact(value, title, caption))
 
 def display_json(value, *, title=None):
-    __oxiquill_outputs.append(__oxiquill_json_artifact(value, title))
+    __oxiquill_append_output(__oxiquill_json_artifact(value, title))
 
 def display_html(html, *, title=None):
-    __oxiquill_outputs.append(__oxiquill_meta({"kind": "html", "html": str(html), "sandboxed": True}, title))
+    __oxiquill_append_output(__oxiquill_meta({"kind": "html", "html": str(html), "sandboxed": True}, title))
 
 def display_image(data, mime, *, alt=None, title=None):
     artifact = {"kind": "image", "mime": str(mime), "data": __oxiquill_image_data(data)}
     if alt is not None:
         artifact["alt"] = str(alt)
-    __oxiquill_outputs.append(__oxiquill_meta(artifact, title))
+    __oxiquill_append_output(__oxiquill_meta(artifact, title))
 
 def display_table(value, *, title=None, caption=None):
     dataframe_artifact = __oxiquill_dataframe_artifact(value, title=title, caption=caption)
     if dataframe_artifact is not None:
-        __oxiquill_outputs.append(dataframe_artifact)
+        __oxiquill_append_output(dataframe_artifact)
         return
     rows = list(value)
     truncated = len(rows) > __oxiquill_table_limit
@@ -447,7 +487,7 @@ def display_table(value, *, title=None, caption=None):
             [__oxiquill_jsonable(row[index]) if isinstance(row, (list, tuple)) and index < len(row) else None for index in range(width)]
             for row in preview
         ]
-    __oxiquill_outputs.append(__oxiquill_meta({
+    __oxiquill_append_output(__oxiquill_meta({
         "kind": "table",
         "columns": columns,
         "rows": table_rows,
@@ -458,8 +498,11 @@ def display_table(value, *, title=None, caption=None):
 
 const pythonDisplayBootstrapSupport = String.raw`
 def __oxiquill_reset_outputs():
+    global __oxiquill_output_bytes, __oxiquill_output_omission
     __oxiquill_outputs.clear()
     __oxiquill_displayed_figures.clear()
+    __oxiquill_output_bytes = 0
+    __oxiquill_output_omission = None
 
 def __oxiquill_prepare_cell():
     __oxiquill_reset_outputs()
@@ -467,6 +510,9 @@ def __oxiquill_prepare_cell():
 
 def __oxiquill_take_outputs():
     outputs = list(__oxiquill_outputs)
+    if __oxiquill_output_omission is not None:
+        outputs = outputs[:max(0, __oxiquill_artifact_limit - 1)]
+        outputs.append(__oxiquill_error_artifact(__oxiquill_output_omission))
     __oxiquill_outputs.clear()
     return outputs
 

--- a/packages/oxiquill/src/lib/doc-runtime/python-worker.ts
+++ b/packages/oxiquill/src/lib/doc-runtime/python-worker.ts
@@ -66,6 +66,9 @@ export function createPythonWorkerRequestHandler({
       let value: unknown = null;
 
       try {
+        for (const inputName of request.integerInputNames ?? []) {
+          pyodide.runPython(pythonIntegerConversionCode(inputName), { globals });
+        }
         value = toSerializable(await pyodide.runPythonAsync(request.source ?? '', { globals }));
       } finally {
         globals.destroy();
@@ -115,6 +118,11 @@ export function createPythonRuntimeLoader({
     });
     return pyodideReady;
   };
+}
+
+export function pythonIntegerConversionCode(inputName: string): string {
+  if (!/^[a-z][a-z0-9_]*$/u.test(inputName)) throw new Error(`Invalid integer input name: ${inputName}`);
+  return `${inputName} = int(${inputName})`;
 }
 
 export async function importPyodideModule(

--- a/packages/oxiquill/src/lib/doc-runtime/python-worker.ts
+++ b/packages/oxiquill/src/lib/doc-runtime/python-worker.ts
@@ -1,8 +1,10 @@
 import { pyodidePath } from 'virtual:oxiquill/runtime-paths';
+import { boundedErrorMessage, createBoundedTextAccumulator, outputArtifactLimits } from './output-limits.mjs';
 import { pythonDisplaySupportCode } from './python-display-support.js';
 import { createPythonCellResult, toOutputArtifacts } from './python-cell-result.js';
 import { createSerialRequestQueue } from './python-worker-queue.js';
 import type { RuntimeWorkerRequest, RuntimeWorkerResponse } from './types.js';
+import { boundWorkerResult } from './worker-output.js';
 
 export { pythonDisplaySupportCode } from './python-display-support.js';
 export { createPythonCellResult } from './python-cell-result.js';
@@ -48,11 +50,11 @@ export function createPythonWorkerRequestHandler({
   return async (request) => {
     try {
       const pyodide = await ensurePyodide();
-      const stdout: string[] = [];
-      const stderr: string[] = [];
+      const stdout = createBoundedTextAccumulator(outputArtifactLimits.bytesPerStream, '\n');
+      const stderr = createBoundedTextAccumulator(outputArtifactLimits.bytesPerStream, '\n');
 
-      pyodide.setStdout({ batched: (output) => stdout.push(output) });
-      pyodide.setStderr({ batched: (output) => stderr.push(output) });
+      pyodide.setStdout({ batched: stdout.append });
+      pyodide.setStderr({ batched: stderr.append });
 
       if (request.packages && request.packages.length > 0) {
         await pyodide.loadPackage(Array.from(request.packages));
@@ -78,20 +80,26 @@ export function createPythonWorkerRequestHandler({
         toSerializable(pyodide.runPython('__oxiquill_collect_matplotlib_outputs()'))
       );
 
-      const result = createPythonCellResult({
-        stdout: stdout.join('\n').trimEnd(),
-        stderr: stderr.join('\n').trimEnd(),
-        value,
-        plots: [],
-        displayOutputs: [...displayOutputs, ...matplotlibOutputs]
-      });
+      const stdoutResult = stdout.take();
+      const stderrResult = stderr.take();
+      const result = boundWorkerResult(
+        createPythonCellResult({
+          stdout: stdoutResult.value.trimEnd(),
+          stdoutTruncated: stdoutResult.truncated,
+          stderr: stderrResult.value.trimEnd(),
+          stderrTruncated: stderrResult.truncated,
+          value,
+          plots: [],
+          displayOutputs: [...displayOutputs, ...matplotlibOutputs]
+        })
+      );
 
       postMessage({ requestId: request.requestId, ok: true, result });
     } catch (error) {
       postMessage({
         requestId: request.requestId,
         ok: false,
-        error: error instanceof Error ? error.message : String(error)
+        error: boundedErrorMessage(error)
       });
     }
   };

--- a/packages/oxiquill/src/lib/doc-runtime/query-modules.d.ts
+++ b/packages/oxiquill/src/lib/doc-runtime/query-modules.d.ts
@@ -1,0 +1,1 @@
+declare module '*?oxiquill-retry';

--- a/packages/oxiquill/src/lib/doc-runtime/runtime-client.ts
+++ b/packages/oxiquill/src/lib/doc-runtime/runtime-client.ts
@@ -241,7 +241,10 @@ function isRuntimeWorkerResponse(value: unknown): value is RuntimeWorkerResponse
 }
 
 function toError(value: unknown): Error {
-  return new Error(boundedErrorMessage(value));
+  const message = boundedErrorMessage(value);
+  return value instanceof Error && value.name === 'AbortError'
+    ? new ExecutionCancellationError(message)
+    : new Error(message);
 }
 
 function inputArgument(input: CellManifest['inputs'][number], inputs: InputValues): string {

--- a/packages/oxiquill/src/lib/doc-runtime/runtime-client.ts
+++ b/packages/oxiquill/src/lib/doc-runtime/runtime-client.ts
@@ -1,4 +1,6 @@
 import type { CellLanguage, CellManifest, InputValues, RuntimeWorkerRequest, RuntimeWorkerResponse } from './types.js';
+import { ExecutionCancellationError } from './execution-cancellation.js';
+import { assertValidInputValues, completeInputValues } from './interactive-input-validation.js';
 import { normalizeCellExecutionResult, type NormalizedCellExecutionResult } from './output-artifacts.js';
 
 type PendingRequest = {
@@ -6,6 +8,7 @@ type PendingRequest = {
   resolve: (value: NormalizedCellExecutionResult) => void;
   timeout: ReturnType<typeof setTimeout>;
   worker: Worker;
+  removeAbortListener: () => void;
 };
 
 type RuntimeClientDependencies = {
@@ -17,10 +20,11 @@ type RuntimeClientDependencies = {
 export function runInteractiveCell(
   cell: CellManifest,
   inputs: InputValues,
-  runtimeVersion?: string
+  runtimeVersion?: string,
+  signal?: AbortSignal
 ): Promise<NormalizedCellExecutionResult> {
   /* v8 ignore next -- the factory is unit-tested; this delegates to browser Worker adapters. */
-  return defaultRuntimeClient.runInteractiveCell(cell, inputs, runtimeVersion);
+  return defaultRuntimeClient.runInteractiveCell(cell, inputs, runtimeVersion, signal);
 }
 
 export function resetInteractiveRuntime(language?: CellLanguage): void {
@@ -42,10 +46,19 @@ export function createInteractiveCellRunner(dependencies: RuntimeClientDependenc
   function runCell(
     cell: CellManifest,
     inputs: InputValues,
-    runtimeVersion?: string
+    runtimeVersion?: string,
+    signal?: AbortSignal
   ): Promise<NormalizedCellExecutionResult> {
+    const completeValues = completeInputValues(cell, inputs);
+    try {
+      assertValidInputValues(cell, completeValues);
+    } catch (error) {
+      return Promise.reject(toError(error));
+    }
+    if (signal?.aborted) return Promise.reject(new ExecutionCancellationError());
+
     const requestId = nextRequestId++;
-    const request = createWorkerRequest(requestId, cell, inputs, runtimeVersion);
+    const request = createWorkerRequest(requestId, cell, completeValues, runtimeVersion);
 
     return new Promise((resolve, reject) => {
       let worker: Worker | undefined;
@@ -57,7 +70,20 @@ export function createInteractiveCellRunner(dependencies: RuntimeClientDependenc
           failWorker(ownedWorker, new Error(`${cell.title} timed out after ${cell.timeoutMs}ms`));
         }, cell.timeoutMs);
 
-        pending.set(requestId, { resolve, reject, timeout, worker });
+        const abort = () => failWorker(ownedWorker, new ExecutionCancellationError());
+        signal?.addEventListener('abort', abort, { once: true });
+        pending.set(requestId, {
+          resolve,
+          reject,
+          timeout,
+          worker,
+          removeAbortListener: () => signal?.removeEventListener('abort', abort)
+        });
+
+        if (signal?.aborted) {
+          abort();
+          return;
+        }
 
         try {
           worker.postMessage(request);
@@ -92,6 +118,7 @@ export function createInteractiveCellRunner(dependencies: RuntimeClientDependenc
 
         pending.delete(event.data.requestId);
         dependencies.clearTimeout(request.timeout);
+        request.removeAbortListener();
 
         if (!event.data.ok) {
           request.reject(new Error(event.data.error));
@@ -144,6 +171,7 @@ export function createInteractiveCellRunner(dependencies: RuntimeClientDependenc
 
     for (const [requestId, request] of ownedRequests) {
       dependencies.clearTimeout(request.timeout);
+      request.removeAbortListener();
       pending.delete(requestId);
       request.reject(error);
     }
@@ -166,6 +194,10 @@ function createWorkerRequest(
     cellId: cell.id,
     ...(cell.language === 'haskell' ? { haskellFingerprintHash: runtimeHaskellFingerprintHash(runtimeVersion) } : {}),
     inputArgs: cell.language === 'haskell' ? cell.inputs.map((input) => inputArgument(input, inputs)) : undefined,
+    integerInputNames:
+      cell.language === 'python'
+        ? cell.inputs.filter((input) => input.type === 'integer' || input.integer).map((input) => input.name)
+        : undefined,
     inputs,
     source: cell.language === 'python' ? cell.source : undefined,
     packages: cell.language === 'python' ? cell.packages : undefined

--- a/packages/oxiquill/src/lib/doc-runtime/runtime-client.ts
+++ b/packages/oxiquill/src/lib/doc-runtime/runtime-client.ts
@@ -2,6 +2,7 @@ import type { CellLanguage, CellManifest, InputValues, RuntimeWorkerRequest, Run
 import { ExecutionCancellationError } from './execution-cancellation.js';
 import { assertValidInputValues, completeInputValues } from './interactive-input-validation.js';
 import { normalizeCellExecutionResult, type NormalizedCellExecutionResult } from './output-artifacts.js';
+import { boundedErrorMessage } from './output-limits.mjs';
 
 type PendingRequest = {
   reject: (reason: Error) => void;
@@ -121,7 +122,7 @@ export function createInteractiveCellRunner(dependencies: RuntimeClientDependenc
         request.removeAbortListener();
 
         if (!event.data.ok) {
-          request.reject(new Error(event.data.error));
+          request.reject(toError(event.data.error));
           return;
         }
 
@@ -155,6 +156,7 @@ export function createInteractiveCellRunner(dependencies: RuntimeClientDependenc
   }
 
   function failWorker(worker: Worker, error: Error): void {
+    const boundedError = toError(error);
     let ownsWorker = false;
 
     for (const [language, current] of workers) {
@@ -173,7 +175,7 @@ export function createInteractiveCellRunner(dependencies: RuntimeClientDependenc
       dependencies.clearTimeout(request.timeout);
       request.removeAbortListener();
       pending.delete(requestId);
-      request.reject(error);
+      request.reject(boundedError);
     }
   }
 
@@ -239,7 +241,7 @@ function isRuntimeWorkerResponse(value: unknown): value is RuntimeWorkerResponse
 }
 
 function toError(value: unknown): Error {
-  return value instanceof Error ? value : new Error(String(value));
+  return new Error(boundedErrorMessage(value));
 }
 
 function inputArgument(input: CellManifest['inputs'][number], inputs: InputValues): string {

--- a/packages/oxiquill/src/lib/doc-runtime/runtime-localization.ts
+++ b/packages/oxiquill/src/lib/doc-runtime/runtime-localization.ts
@@ -8,6 +8,7 @@ export type ChartSummaryDetails = {
   dataCount: number;
   seriesCount: number;
   seriesNames: string;
+  valueRange?: string;
   xRange?: string;
   yRange?: string;
 };
@@ -25,6 +26,7 @@ export type RuntimeLabels = {
   chartCaption: string;
   chartLoadError: (detail: string) => string;
   chartLoading: string;
+  chartRetry: string;
   chartSummary: (details: ChartSummaryDetails) => string;
   chartTitle: (kind: ChartKind) => string;
   clipboardUnavailable: string;
@@ -124,8 +126,9 @@ const runtimeLabels = {
     chartCaption: 'Chart data summary',
     chartLoadError: (detail) => `Chart renderer could not be loaded: ${detail}`,
     chartLoading: 'Loading chart renderer...',
-    chartSummary: ({ dataCount, seriesCount, seriesNames, xRange, yRange }) =>
-      `Series: ${seriesCount}${seriesNames ? ` (${seriesNames})` : ''}. Data items: ${dataCount}.${xRange ? ` X range: ${xRange}.` : ''}${yRange ? ` Y range: ${yRange}.` : ''}`,
+    chartRetry: 'Retry chart rendering',
+    chartSummary: ({ dataCount, seriesCount, seriesNames, valueRange, xRange, yRange }) =>
+      `Series: ${seriesCount}${seriesNames ? ` (${seriesNames})` : ''}. Data items: ${dataCount}.${xRange ? ` X range: ${xRange}.` : ''}${yRange ? ` Y range: ${yRange}.` : ''}${valueRange ? ` Heat value range: ${valueRange}.` : ''}`,
     chartTitle: (kind) => chartTitles.en[kind],
     clipboardUnavailable: 'Clipboard access is unavailable.',
     copyCsv: 'Copy visible rows as CSV',
@@ -180,8 +183,9 @@ const runtimeLabels = {
     chartCaption: 'グラフデータの概要',
     chartLoadError: (detail) => `グラフ表示を読み込めませんでした: ${detail}`,
     chartLoading: 'グラフ表示を読み込んでいます…',
-    chartSummary: ({ dataCount, seriesCount, seriesNames, xRange, yRange }) =>
-      `系列数: ${seriesCount}${seriesNames ? `（${seriesNames}）` : ''}。データ数: ${dataCount}。${xRange ? `X の範囲: ${xRange}。` : ''}${yRange ? `Y の範囲: ${yRange}。` : ''}`,
+    chartRetry: 'グラフ表示を再試行',
+    chartSummary: ({ dataCount, seriesCount, seriesNames, valueRange, xRange, yRange }) =>
+      `系列数: ${seriesCount}${seriesNames ? `（${seriesNames}）` : ''}。データ数: ${dataCount}。${xRange ? `X の範囲: ${xRange}。` : ''}${yRange ? `Y の範囲: ${yRange}。` : ''}${valueRange ? `ヒート値の範囲: ${valueRange}。` : ''}`,
     chartTitle: (kind) => chartTitles.ja[kind],
     clipboardUnavailable: 'クリップボードを利用できません。',
     copyCsv: '表示中の行を CSV としてコピー',

--- a/packages/oxiquill/src/lib/doc-runtime/rust-worker.ts
+++ b/packages/oxiquill/src/lib/doc-runtime/rust-worker.ts
@@ -1,5 +1,7 @@
 import init, { run_rust_cell } from 'virtual:oxiquill/rust-wasm';
+import { boundedErrorMessage } from './output-limits.mjs';
 import type { CellExecutionResult, RuntimeWorkerRequest, RuntimeWorkerResponse } from './types.js';
+import { boundWorkerResult } from './worker-output.js';
 
 type WorkerScope = {
   addEventListener(type: 'message', listener: (event: MessageEvent<RuntimeWorkerRequest>) => void): void;
@@ -16,14 +18,16 @@ worker.addEventListener('message', (event) => {
 async function handleRequest(request: RuntimeWorkerRequest): Promise<void> {
   try {
     await ensureWasm();
-    const result = JSON.parse(run_rust_cell(request.cellId, JSON.stringify(request.inputs))) as CellExecutionResult;
+    const result = boundWorkerResult(
+      JSON.parse(run_rust_cell(request.cellId, JSON.stringify(request.inputs))) as CellExecutionResult
+    );
 
     worker.postMessage({ requestId: request.requestId, ok: true, result });
   } catch (error) {
     worker.postMessage({
       requestId: request.requestId,
       ok: false,
-      error: error instanceof Error ? error.message : String(error)
+      error: boundedErrorMessage(error)
     });
   }
 }

--- a/packages/oxiquill/src/lib/doc-runtime/types.ts
+++ b/packages/oxiquill/src/lib/doc-runtime/types.ts
@@ -2,6 +2,8 @@ export type CellLanguage = 'rust' | 'python' | 'haskell';
 export type RunMode = 'button' | 'reactive' | 'autorun';
 export type InputType = 'range' | 'number' | 'integer' | 'text' | 'textarea' | 'checkbox' | 'select' | 'radio';
 
+export { PORTABLE_INTEGER_MAX, PORTABLE_INTEGER_MIN } from './portable-integer.mjs';
+
 export interface InputOption {
   label: string;
   value: string;
@@ -179,6 +181,7 @@ export interface RuntimeWorkerRequest {
   cellId: string;
   haskellFingerprintHash?: string;
   inputArgs?: readonly string[];
+  integerInputNames?: readonly string[];
   inputs: InputValues;
   source?: string;
   packages?: readonly string[];

--- a/packages/oxiquill/src/lib/doc-runtime/worker-output.ts
+++ b/packages/oxiquill/src/lib/doc-runtime/worker-output.ts
@@ -1,0 +1,71 @@
+import { outputArtifactLimits, utf8ByteLength } from './output-limits.mjs';
+import { normalizeCellExecutionResult, outputsToLegacyResult } from './output-artifacts.js';
+import type { ValidatedArtifactResult, ValidatedOutputArtifact } from './output-artifact-validation.js';
+import type { OutputArtifact, RawCellExecutionResult } from './types.js';
+
+type ProducerErrorArtifact = {
+  kind: '__oxiquill_error';
+  message: string;
+};
+
+type WorkerOutputCandidate = OutputArtifact | ProducerErrorArtifact;
+
+const responseLimitArtifact: ProducerErrorArtifact = {
+  kind: '__oxiquill_error',
+  message: `Worker response exceeded ${outputArtifactLimits.workerResponseBytes} bytes; later artifacts were omitted.`
+};
+
+export function boundWorkerResult(result: RawCellExecutionResult): RawCellExecutionResult {
+  const normalized = normalizeCellExecutionResult(result);
+  const candidates = capArtifactCount(normalized.outputResults.map(workerOutputCandidate));
+  const complete = workerResultFromCandidates(candidates);
+  if (workerResultByteLength(complete) <= outputArtifactLimits.workerResponseBytes) return complete;
+
+  let low = 0;
+  let high = Math.min(candidates.length, outputArtifactLimits.artifactsPerRun - 1);
+  while (low < high) {
+    const middle = Math.ceil((low + high) / 2);
+    const candidate = workerResultFromCandidates([...candidates.slice(0, middle), responseLimitArtifact]);
+    if (workerResultByteLength(candidate) <= outputArtifactLimits.workerResponseBytes) low = middle;
+    else high = middle - 1;
+  }
+
+  return workerResultFromCandidates([...candidates.slice(0, low), responseLimitArtifact]);
+}
+
+export function workerResultByteLength(result: RawCellExecutionResult): number {
+  return utf8ByteLength(JSON.stringify(result));
+}
+
+function capArtifactCount(candidates: readonly WorkerOutputCandidate[]): readonly WorkerOutputCandidate[] {
+  if (candidates.length <= outputArtifactLimits.artifactsPerRun) return candidates;
+  return [...candidates.slice(0, outputArtifactLimits.artifactsPerRun - 1), candidates.at(-1) ?? responseLimitArtifact];
+}
+
+function workerOutputCandidate(result: ValidatedArtifactResult): WorkerOutputCandidate {
+  return result.status === 'valid'
+    ? publicOutputArtifact(result.artifact)
+    : { kind: '__oxiquill_error', message: result.message };
+}
+
+function workerResultFromCandidates(candidates: readonly WorkerOutputCandidate[]): RawCellExecutionResult {
+  const outputs = candidates.filter((candidate): candidate is OutputArtifact => candidate.kind !== '__oxiquill_error');
+  return {
+    ...outputsToLegacyResult(outputs),
+    outputs: candidates
+  };
+}
+
+function publicOutputArtifact(artifact: ValidatedOutputArtifact): OutputArtifact {
+  if (artifact.kind === 'json') {
+    const output = { ...artifact };
+    Reflect.deleteProperty(output, 'formattedValue');
+    return output;
+  }
+  if (artifact.kind === 'image') {
+    const output = { ...artifact };
+    Reflect.deleteProperty(output, 'source');
+    return output;
+  }
+  return artifact;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -138,6 +138,9 @@ importers:
       shiki:
         specifier: 4.4.3
         version: 4.4.3
+      smol-toml:
+        specifier: 1.8.0
+        version: 1.8.0
       typescript:
         specifier: 6.0.3
         version: 6.0.3

--- a/tests/docs/check-documentation.mjs
+++ b/tests/docs/check-documentation.mjs
@@ -1,8 +1,9 @@
 import assert from 'node:assert/strict';
 import { access, readFile, readdir } from 'node:fs/promises';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import { checkMarkdownStructure, headingSlug } from './markdown-structure.mjs';
+import { loadDocumentedConsumerConfig } from './documented-config.mjs';
 
 const repositoryRoot = fileURLToPath(new URL('../..', import.meta.url));
 const contentRoot = path.join(repositoryRoot, 'examples/docs-site/content/docs');
@@ -24,12 +25,13 @@ const documentsPackageJsonRoot = await readFile(path.join(repositoryRoot, 'packa
 const documentsTemplatePackageJson = await readFile(path.join(repositoryRoot, 'templates/basic/package.json'), 'utf8');
 
 checkDocumentStructures();
+await loadDocumentedConsumerConfig(repositoryRoot);
 await checkLinks();
 await checkLocalizedRoutes();
 await checkSidebarRoutes();
 await checkPublicContracts();
 checkJsonExamples();
-checkPackageImports();
+await checkPackageImports();
 checkShellCommands();
 
 console.log(
@@ -211,7 +213,7 @@ function checkJsonExamples() {
   }
 }
 
-function checkPackageImports() {
+async function checkPackageImports() {
   const packageJson = JSON.parse(documentsPackageJson);
   const publicSpecifiers = new Set(
     Object.keys(packageJson.exports).map((key) =>
@@ -224,6 +226,38 @@ function checkPackageImports() {
       assert.ok(publicSpecifiers.has(match[1]), `${relative(filePath)} imports undocumented package path ${match[1]}.`);
     }
   }
+
+  const namespaces = new Map();
+  for (const [filePath, source] of documents) {
+    for (const match of source.matchAll(
+      /\b(?:import|export)\s+\{([^}]+)\}\s+from\s+['"](oxiquill(?:\/[^'"]+)?)['"]/gu
+    )) {
+      const [, bindings, specifier] = match;
+      let namespace = namespaces.get(specifier);
+      if (!namespace) {
+        namespace = await import(packageEntryUrl(packageJson, specifier));
+        namespaces.set(specifier, namespace);
+      }
+
+      for (const binding of bindings.split(',')) {
+        const exportName = binding.trim().split(/\s+as\s+/u, 1)[0];
+        assert.ok(exportName in namespace, `${relative(filePath)} imports missing ${specifier} export ${exportName}.`);
+      }
+    }
+  }
+}
+
+function packageEntryUrl(packageJson, specifier) {
+  const exportKey = specifier === packageJson.name ? '.' : `.${specifier.slice(packageJson.name.length)}`;
+  const target = packageImportTarget(packageJson.exports[exportKey]);
+  assert.ok(target, `Unable to resolve built package entry point ${specifier}.`);
+  return pathToFileURL(path.join(repositoryRoot, 'packages/oxiquill', target)).href;
+}
+
+function packageImportTarget(value) {
+  if (typeof value === 'string') return value;
+  if (!value || typeof value !== 'object') return undefined;
+  return packageImportTarget(value.import ?? value.default);
 }
 
 function checkShellCommands() {

--- a/tests/docs/documented-config.mjs
+++ b/tests/docs/documented-config.mjs
@@ -8,14 +8,28 @@ export async function loadDocumentedConsumerConfig(repositoryRoot) {
     path.join(contentRoot, 'guides/project-configuration.mdx'),
     path.join(contentRoot, 'ja/guides/project-configuration.mdx')
   ];
+  const sectionHeadings = ['Minimal Configuration', '最小構成'];
   const sources = await Promise.all(sourcePaths.map((sourcePath) => readFile(sourcePath, 'utf8')));
-  const configs = sources.map((source, index) => ({
-    astro: codeFenceContaining(source, 'js', 'defineOxiquillConfig', sourcePaths[index]),
-    content: codeFenceContaining(source, 'ts', 'createOxiquillCollections', sourcePaths[index])
-  }));
+  const configs = sources.map((source, index) => {
+    const section = sectionUnderHeading(source, sectionHeadings[index], sourcePaths[index]);
+    return {
+      astro: codeFenceContaining(section, 'js', 'defineOxiquillConfig', sourcePaths[index]),
+      content: codeFenceContaining(section, 'ts', 'createOxiquillCollections', sourcePaths[index])
+    };
+  });
 
   assert.deepEqual(configs[1], configs[0], 'English and Japanese minimal configuration snippets must stay identical.');
   return configs[0];
+}
+
+function sectionUnderHeading(source, heading, sourcePath) {
+  const marker = `## ${heading}\n`;
+  const markerIndex = source.indexOf(marker);
+  assert.notEqual(markerIndex, -1, `${sourcePath} must contain the ${heading} section.`);
+
+  const sectionStart = markerIndex + marker.length;
+  const sectionEnd = source.indexOf('\n## ', sectionStart);
+  return source.slice(sectionStart, sectionEnd < 0 ? undefined : sectionEnd);
 }
 
 function codeFenceContaining(source, language, token, sourcePath) {

--- a/tests/docs/documented-config.mjs
+++ b/tests/docs/documented-config.mjs
@@ -1,0 +1,28 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+
+export async function loadDocumentedConsumerConfig(repositoryRoot) {
+  const contentRoot = path.join(repositoryRoot, 'examples/docs-site/content/docs');
+  const sourcePaths = [
+    path.join(contentRoot, 'guides/project-configuration.mdx'),
+    path.join(contentRoot, 'ja/guides/project-configuration.mdx')
+  ];
+  const sources = await Promise.all(sourcePaths.map((sourcePath) => readFile(sourcePath, 'utf8')));
+  const configs = sources.map((source, index) => ({
+    astro: codeFenceContaining(source, 'js', 'defineOxiquillConfig', sourcePaths[index]),
+    content: codeFenceContaining(source, 'ts', 'createOxiquillCollections', sourcePaths[index])
+  }));
+
+  assert.deepEqual(configs[1], configs[0], 'English and Japanese minimal configuration snippets must stay identical.');
+  return configs[0];
+}
+
+function codeFenceContaining(source, language, token, sourcePath) {
+  const fences = Array.from(source.matchAll(new RegExp(`^\`\`\`${language}[^\\n]*\\n([\\s\\S]*?)^\`\`\``, 'gmu')))
+    .map((match) => match[1])
+    .filter((code) => code.includes(token));
+
+  assert.equal(fences.length, 1, `${sourcePath} must contain exactly one ${language} snippet using ${token}.`);
+  return fences[0];
+}

--- a/tests/docs/documented-config.mjs
+++ b/tests/docs/documented-config.mjs
@@ -13,7 +13,7 @@ export async function loadDocumentedConsumerConfig(repositoryRoot) {
   const configs = sources.map((source, index) => {
     const section = sectionUnderHeading(source, sectionHeadings[index], sourcePaths[index]);
     return {
-      astro: codeFenceContaining(section, 'js', 'defineOxiquillConfig', sourcePaths[index]),
+      astro: codeFenceContaining(section, 'js', "from 'oxiquill/astro'", sourcePaths[index]),
       content: codeFenceContaining(section, 'ts', 'createOxiquillCollections', sourcePaths[index])
     };
   });

--- a/tests/e2e/accessibility.spec.ts
+++ b/tests/e2e/accessibility.spec.ts
@@ -5,6 +5,25 @@ import type { Locator, Page } from '@playwright/test';
 const wcag22AATags = ['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa', 'wcag22a', 'wcag22aa'];
 
 test.describe('runtime accessibility', () => {
+  test('desktop table-of-contents control remains accessible when expanded and collapsed', async ({
+    browserName,
+    page
+  }) => {
+    await page.setViewportSize({ width: 1280, height: 900 });
+    await page.goto('/features/math/');
+
+    const toggle = page.getByRole('button', { name: 'Collapse table of contents' });
+    await toggle.focus();
+    await toggle.press('Space');
+
+    const expandedToggle = page.getByRole('button', { name: 'Expand table of contents' });
+    await expect(expandedToggle).toHaveAttribute('aria-controls', 'starlight__right-sidebar');
+    await expect(expandedToggle).toHaveAttribute('aria-expanded', 'false');
+    await expect(expandedToggle).toBeFocused();
+    await expect(page.locator('#starlight__right-sidebar')).toHaveAttribute('inert', '');
+    await expectNoWcag22AAViolations(page, browserName);
+  });
+
   test('interactive cells expose localized semantics and support keyboard-only execution', async ({
     browserName,
     page

--- a/tests/e2e/interactive.spec.ts
+++ b/tests/e2e/interactive.spec.ts
@@ -318,14 +318,8 @@ test('rich output examples render browser-visible artifacts', async ({ page }) =
   await expect(htmlOutput).toHaveAttribute('srcdoc', /Sandboxed HTML/);
 
   const privacyProbeResponses: string[] = [];
-  const privacyProbeFailures: string[] = [];
   page.on('response', (response) => {
     if (response.url().includes('__oxiquill_html_privacy_probe__')) privacyProbeResponses.push(response.url());
-  });
-  page.on('requestfailed', (request) => {
-    if (request.url().includes('__oxiquill_html_privacy_probe__')) {
-      privacyProbeFailures.push(request.failure()?.errorText ?? 'blocked');
-    }
   });
   await htmlOutput.evaluate((element) => {
     const iframe = element as HTMLIFrameElement;
@@ -347,7 +341,6 @@ test('rich output examples render browser-visible artifacts', async ({ page }) =
   await expect(htmlFrame.locator('body')).not.toHaveAttribute('data-script-executed', 'true');
   expect(await page.locator('html').getAttribute('data-html-artifact-parent-read')).toBeNull();
   expect(privacyProbeResponses).toEqual([]);
-  expect(privacyProbeFailures).toHaveLength(2);
 
   const python = page.getByTestId('cell-features__rich-output__python-rich-outputs');
   await hydrateCell(python);

--- a/tests/e2e/interactive.spec.ts
+++ b/tests/e2e/interactive.spec.ts
@@ -83,6 +83,131 @@ test('desktop sidebar preference does not affect the mobile menu', async ({ page
   expect(await page.evaluate(() => sessionStorage.getItem('oxiquill-sidebar-collapsed'))).toBe('true');
 });
 
+test('desktop table of contents collapses, releases its column, and persists independently', async ({ page }) => {
+  await page.setViewportSize({ width: 1280, height: 900 });
+  await page.goto('/features/math/');
+
+  const tableOfContents = page.locator('#starlight__right-sidebar');
+  const mainPane = page.locator('.two-column-content > .main-pane');
+  const contentContainer = page.locator('.content-panel .sl-container').first();
+  const toggle = page.locator('starlight-table-of-contents-toggle button');
+  const tableOfContentsLink = tableOfContents.getByRole('link').first();
+
+  await expect(toggle).toBeVisible();
+  await expect(toggle).toHaveAttribute('aria-controls', 'starlight__right-sidebar');
+  await expect(toggle).toHaveAttribute('aria-expanded', 'true');
+  await expect(toggle).toHaveAttribute('aria-label', 'Collapse table of contents');
+  await expect(tableOfContents).toBeVisible();
+  const expandedMainWidth = await elementWidth(mainPane);
+  const expandedContentWidth = await elementWidth(contentContainer);
+
+  await tableOfContentsLink.focus();
+  await toggle.evaluate((element) => (element as HTMLButtonElement).click());
+
+  await expect(toggle).toBeFocused();
+  await expect(page.locator('html')).toHaveAttribute('data-table-of-contents-collapsed', '');
+  await expect(page.locator('html')).not.toHaveAttribute('data-sidebar-collapsed', '');
+  await expect(toggle).toHaveAttribute('aria-expanded', 'false');
+  await expect(toggle).toHaveAttribute('aria-label', 'Expand table of contents');
+  await expect(tableOfContents).toHaveAttribute('aria-hidden', 'true');
+  await expect(tableOfContents).toHaveAttribute('inert', '');
+  await expect(tableOfContents).not.toBeVisible();
+  await expect.poll(() => elementWidth(mainPane)).toBeGreaterThan(expandedMainWidth + 100);
+  await expect.poll(() => elementWidth(contentContainer)).toBeGreaterThan(expandedContentWidth + 100);
+  expect(await horizontalOverflow(page)).toBeLessThan(1);
+  expect(await page.evaluate(() => sessionStorage.getItem('oxiquill-table-of-contents-collapsed'))).toBe('true');
+  expect(await page.evaluate(() => sessionStorage.getItem('oxiquill-sidebar-collapsed'))).toBeNull();
+
+  await page.goto('/features/diagrams/');
+
+  const persistedToggle = page.locator('starlight-table-of-contents-toggle button');
+  await expect(page.locator('html')).toHaveAttribute('data-table-of-contents-collapsed', '');
+  await expect(persistedToggle).toHaveAttribute('aria-expanded', 'false');
+  await expect(page.locator('#starlight__right-sidebar')).not.toBeVisible();
+
+  await persistedToggle.evaluate((element) => {
+    const toggleElement = element.closest('starlight-table-of-contents-toggle');
+    const parent = toggleElement?.parentElement;
+    if (toggleElement && parent) parent.append(toggleElement);
+  });
+  await persistedToggle.focus();
+  await persistedToggle.press('Enter');
+
+  await expect(persistedToggle).toBeFocused();
+  await expect(page.locator('html')).not.toHaveAttribute('data-table-of-contents-collapsed', '');
+  await expect(persistedToggle).toHaveAttribute('aria-expanded', 'true');
+  await expect(page.locator('#starlight__right-sidebar')).toBeVisible();
+  expect(await page.evaluate(() => sessionStorage.getItem('oxiquill-table-of-contents-collapsed'))).toBeNull();
+});
+
+test('desktop table-of-contents labels use the primary Japanese language subtag', async ({ page }) => {
+  await page.setViewportSize({ width: 1280, height: 900 });
+  await page.goto('/ja/features/math/');
+
+  await expect(page.locator('html')).toHaveAttribute('lang', 'ja-JP');
+  await expect(page.locator('starlight-table-of-contents-toggle button')).toHaveAttribute(
+    'aria-label',
+    '目次を折りたたむ'
+  );
+});
+
+test('desktop table-of-contents preference does not affect the mobile disclosure', async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 800 });
+  await page.goto('/features/math/');
+  await page.evaluate(() => sessionStorage.setItem('oxiquill-table-of-contents-collapsed', 'true'));
+  await page.reload();
+
+  const tableOfContents = page.locator('#starlight__right-sidebar');
+  const desktopToggle = page.locator('starlight-table-of-contents-toggle button');
+  const mobileDisclosure = page.locator('#starlight__mobile-toc summary');
+
+  await expect(page.locator('html')).not.toHaveAttribute('data-table-of-contents-collapsed', '');
+  await expect(desktopToggle).not.toBeVisible();
+  await expect(tableOfContents).not.toHaveAttribute('aria-hidden');
+  await expect(tableOfContents).not.toHaveAttribute('inert');
+  await expect(mobileDisclosure).toBeVisible();
+  await mobileDisclosure.press('Enter');
+  await expect(page.locator('#starlight__mobile-toc')).toHaveAttribute('open', '');
+  expect(await page.evaluate(() => sessionStorage.getItem('oxiquill-table-of-contents-collapsed'))).toBe('true');
+});
+
+test('table-of-contents toggle stays absent on disabled and splash pages', async ({ page }) => {
+  await page.setViewportSize({ width: 1280, height: 900 });
+  await page.goto('/features/math/');
+  await page.evaluate(() => sessionStorage.setItem('oxiquill-table-of-contents-collapsed', 'true'));
+
+  for (const path of ['/tests/no-table-of-contents/', '/tests/splash/']) {
+    await page.goto(path);
+    await expect(page.locator('html')).not.toHaveAttribute('data-has-toc', '');
+    await expect(page.locator('html')).not.toHaveAttribute('data-table-of-contents-collapsed', '');
+    await expect(page.locator('starlight-table-of-contents-toggle')).toHaveCount(0);
+    await expect(page.locator('#starlight__right-sidebar')).toHaveCount(0);
+  }
+});
+
+test('table-of-contents collapse uses logical positioning and does not constrain print output', async ({ page }) => {
+  await page.setViewportSize({ width: 1280, height: 900 });
+  await page.goto('/features/math/');
+
+  const toggle = page.locator('starlight-table-of-contents-toggle button');
+  const ltrPosition = await inlinePosition(toggle);
+  expect(ltrPosition.x).toBeGreaterThan(640);
+
+  await page.locator('html').evaluate((element) => {
+    (element as HTMLElement).dir = 'rtl';
+  });
+  const rtlPosition = await inlinePosition(toggle);
+  expect(rtlPosition.x).toBeLessThan(640);
+
+  await toggle.click();
+  await page.emulateMedia({ media: 'print' });
+
+  await expect(toggle).not.toBeVisible();
+  await expect(page.locator('#starlight__right-sidebar')).not.toBeVisible();
+  expect(await elementWidth(page.locator('.two-column-content > .main-pane'))).toBeGreaterThan(1200);
+  expect(await horizontalOverflow(page)).toBeLessThan(1);
+});
+
 test('static pages do not reference optional browser runtimes', async ({ page }) => {
   const requests = captureRequestPaths(page);
 
@@ -456,6 +581,17 @@ async function sidebarPadding(mainFrame: Locator): Promise<number> {
 
 async function elementWidth(locator: Locator): Promise<number> {
   return locator.evaluate((element) => element.getBoundingClientRect().width);
+}
+
+async function horizontalOverflow(page: Page): Promise<number> {
+  return page.evaluate(() => document.documentElement.scrollWidth - document.documentElement.clientWidth);
+}
+
+async function inlinePosition(locator: Locator): Promise<{ x: number; width: number }> {
+  return locator.evaluate((element) => {
+    const bounds = element.getBoundingClientRect();
+    return { width: bounds.width, x: bounds.x };
+  });
 }
 
 async function canvasStats(canvas: Locator): Promise<{

--- a/tests/e2e/interactive.spec.ts
+++ b/tests/e2e/interactive.spec.ts
@@ -281,6 +281,9 @@ test('interactive cells and math rendering are available', async ({ page }) => {
 test('rich output examples render browser-visible artifacts', async ({ page }) => {
   test.setTimeout(180_000);
   await page.goto('/features/rich-output/');
+  await page.evaluate(() => {
+    document.documentElement.dataset.theme = 'light';
+  });
 
   const rust = page.getByTestId('cell-features__rich-output__rust-rich-outputs');
   await hydrateCell(rust);
@@ -295,10 +298,56 @@ test('rich output examples render browser-visible artifacts', async ({ page }) =
 
   const rustChart = rust.getByTestId('doc-plot');
   await expect(rustChart.locator('canvas')).toHaveCount(1);
+  await expect(rustChart).toHaveAttribute('data-chart-theme', 'light');
   expect((await canvasStats(rustChart.locator('canvas'))).inkPixels).toBeGreaterThan(1_000);
+  await page.evaluate(() => {
+    document.documentElement.dataset.theme = 'dark';
+  });
+  await expect(rustChart).toHaveAttribute('data-chart-theme', 'dark');
+  await expect(rustChart.locator('canvas')).toHaveCount(1);
+  await page.evaluate(() => {
+    document.documentElement.dataset.theme = 'light';
+  });
+  await expect(rustChart).toHaveAttribute('data-chart-theme', 'light');
   await expect(rust.getByTestId('image-output')).toHaveAttribute('src', /data:image\/svg\+xml/);
-  await expect(rust.getByTestId('html-output')).toHaveAttribute('sandbox', '');
-  await expect(rust.getByTestId('html-output')).toHaveAttribute('srcdoc', /Sandboxed HTML/);
+  const htmlOutput = rust.getByTestId('html-output');
+  await expect(htmlOutput).toHaveAttribute('sandbox', '');
+  await expect(htmlOutput).toHaveAttribute('csp', /default-src 'none'/);
+  await expect(htmlOutput).toHaveAttribute('referrerpolicy', 'no-referrer');
+  await expect(htmlOutput).toHaveAttribute('srcdoc', /default-src 'none'/);
+  await expect(htmlOutput).toHaveAttribute('srcdoc', /Sandboxed HTML/);
+
+  const privacyProbeResponses: string[] = [];
+  const privacyProbeFailures: string[] = [];
+  page.on('response', (response) => {
+    if (response.url().includes('__oxiquill_html_privacy_probe__')) privacyProbeResponses.push(response.url());
+  });
+  page.on('requestfailed', (request) => {
+    if (request.url().includes('__oxiquill_html_privacy_probe__')) {
+      privacyProbeFailures.push(request.failure()?.errorText ?? 'blocked');
+    }
+  });
+  await htmlOutput.evaluate((element) => {
+    const iframe = element as HTMLIFrameElement;
+    iframe.srcdoc = (iframe.srcdoc ?? '').replace(
+      '</body>',
+      `<script>
+        document.body.dataset.scriptExecuted = 'true';
+        parent.document.documentElement.dataset.htmlArtifactParentRead = document.title;
+        fetch('/__oxiquill_html_privacy_probe__/script');
+      </script>
+      <img src="/__oxiquill_html_privacy_probe__/image" alt="">
+      <div style="background-image: url('/__oxiquill_html_privacy_probe__/style')">probe</div>
+      </body>`
+    );
+  });
+  const htmlFrame = htmlOutput.contentFrame();
+  await expect(htmlFrame.locator('body')).toBeVisible();
+  await page.waitForTimeout(500);
+  await expect(htmlFrame.locator('body')).not.toHaveAttribute('data-script-executed', 'true');
+  expect(await page.locator('html').getAttribute('data-html-artifact-parent-read')).toBeNull();
+  expect(privacyProbeResponses).toEqual([]);
+  expect(privacyProbeFailures).toHaveLength(2);
 
   const python = page.getByTestId('cell-features__rich-output__python-rich-outputs');
   await hydrateCell(python);
@@ -308,8 +357,44 @@ test('rich output examples render browser-visible artifacts', async ({ page }) =
   await expect(python.getByTestId('table-output').locator('caption')).toHaveText('Pandas table');
   await expect(python.getByTestId('value-output').filter({ hasText: '"status": "ok"' })).toBeVisible();
   await expect(python.getByTestId('html-output')).toHaveAttribute('sandbox', '');
+  await expect(python.getByTestId('html-output')).toHaveAttribute('referrerpolicy', 'no-referrer');
   await expect(python.getByTestId('html-output')).toHaveAttribute('srcdoc', /Sandboxed HTML/);
   await expect(python.getByTestId('image-output')).toHaveAttribute('src', /data:image\/svg\+xml/);
+});
+
+test('chart rendering recovers after a transient chunk load failure', async ({ browserName, page }) => {
+  test.skip(
+    browserName !== 'chromium',
+    'One real-browser recovery path is sufficient for the chunk failure regression.'
+  );
+  test.setTimeout(180_000);
+  let failedOnce = false;
+  await page.route('**/*', async (route) => {
+    const request = route.request();
+    const pathname = new URL(request.url()).pathname;
+    const referrer = request.headers()['referer'] ?? '';
+    if (
+      !failedOnce &&
+      pathname.includes('/ChartOutput.') &&
+      pathname.endsWith('.js') &&
+      referrer.includes('/InteractiveCell.')
+    ) {
+      failedOnce = true;
+      await route.abort('failed');
+      return;
+    }
+    await route.continue();
+  });
+
+  await page.goto('/features/rich-output/');
+  const rust = page.getByTestId('cell-features__rich-output__rust-rich-outputs');
+  await hydrateCell(rust);
+  await rust.getByRole('button', { name: 'Run' }).click();
+  await expect(rust.getByRole('alert')).toContainText('Chart renderer could not be loaded');
+  expect(failedOnce).toBe(true);
+
+  await rust.getByRole('button', { name: 'Retry chart rendering' }).click();
+  await expect(rust.getByTestId('doc-plot').locator('canvas')).toHaveCount(1);
 });
 
 test('theme note and Mermaid examples are available without author-side TSX imports', async ({ page }) => {

--- a/tests/e2e/interactive.spec.ts
+++ b/tests/e2e/interactive.spec.ts
@@ -36,13 +36,27 @@ test('desktop sidebar toggle collapses, expands, and persists across navigation'
   await expect(persistedToggle).toHaveAttribute('aria-label', 'Expand sidebar');
   await expect(page.locator('#starlight__sidebar')).not.toBeVisible();
 
+  await persistedToggle.evaluate((element) => {
+    const toggleElement = element.closest('starlight-sidebar-toggle');
+    const parent = toggleElement?.parentElement;
+    if (toggleElement && parent) parent.append(toggleElement);
+  });
   await persistedToggle.click();
+  await expect(page.locator('html')).not.toHaveAttribute('data-sidebar-collapsed', '');
 
   await expect(page.locator('html')).not.toHaveAttribute('data-sidebar-collapsed', '');
   await expect(persistedToggle).toHaveAttribute('aria-expanded', 'true');
   await expect(persistedToggle).toHaveAttribute('aria-label', 'Collapse sidebar');
   await expect(page.locator('#starlight__sidebar')).toBeVisible();
   expect(await page.evaluate(() => sessionStorage.getItem('oxiquill-sidebar-collapsed'))).toBeNull();
+});
+
+test('sidebar labels use the primary Japanese language subtag', async ({ page }) => {
+  await page.setViewportSize({ width: 1280, height: 900 });
+  await page.goto('/ja/features/math/');
+
+  await expect(page.locator('html')).toHaveAttribute('lang', 'ja-JP');
+  await expect(page.locator('starlight-sidebar-toggle button')).toHaveAttribute('aria-label', 'サイドバーを折りたたむ');
 });
 
 test('desktop sidebar preference does not affect the mobile menu', async ({ page }) => {

--- a/tests/package/consumer-smoke.mjs
+++ b/tests/package/consumer-smoke.mjs
@@ -176,9 +176,14 @@ try {
   await mkdir(projectRoot);
   await rename(path.join(consumerRoot, 'content'), path.join(projectRoot, 'content'));
   await rename(path.join(consumerRoot, 'crates'), path.join(projectRoot, 'helper crates'));
+  await mkdir(path.join(projectRoot, 'helper crates/packed-helper/src'), { recursive: true });
   await writeFile(
-    path.join(projectRoot, 'helper crates/doc-rust/Cargo.toml'),
-    ["package.name = 'doc-rust'", "package.version = '0.1.0'", "package.edition = '2024'", ''].join('\n')
+    path.join(projectRoot, 'helper crates/packed-helper/Cargo.toml'),
+    ["package.name = 'packed-helper'", "package.version = '0.1.0'", "package.edition = '2024'", ''].join('\n')
+  );
+  await writeFile(
+    path.join(projectRoot, 'helper crates/packed-helper/src/lib.rs'),
+    'pub fn message() -> &\'static str { "packed consumer" }\n'
   );
   await rename(path.join(consumerRoot, 'public'), path.join(projectRoot, 'static files'));
   await rename(path.join(consumerRoot, 'content.config.ts'), path.join(projectRoot, 'content.config.ts'));
@@ -211,8 +216,8 @@ try {
       '',
       '```rust',
       '//| id: package-rust',
-      '//| crates: []',
-      'println!("packed consumer");',
+      '//| crates: [packed-helper]',
+      'println!("{}", packed_helper::message());',
       '```',
       '',
       '```python',

--- a/tests/package/consumer-smoke.mjs
+++ b/tests/package/consumer-smoke.mjs
@@ -176,6 +176,10 @@ try {
   await mkdir(projectRoot);
   await rename(path.join(consumerRoot, 'content'), path.join(projectRoot, 'content'));
   await rename(path.join(consumerRoot, 'crates'), path.join(projectRoot, 'helper crates'));
+  await writeFile(
+    path.join(projectRoot, 'helper crates/doc-rust/Cargo.toml'),
+    ["package.name = 'doc-rust'", "package.version = '0.1.0'", "package.edition = '2024'", ''].join('\n')
+  );
   await rename(path.join(consumerRoot, 'public'), path.join(projectRoot, 'static files'));
   await rename(path.join(consumerRoot, 'content.config.ts'), path.join(projectRoot, 'content.config.ts'));
   const tsconfigPath = path.join(projectRoot, 'tsconfig.json');

--- a/tests/package/consumer-smoke.mjs
+++ b/tests/package/consumer-smoke.mjs
@@ -392,6 +392,17 @@ async function runInstalledBrowserSmoke({ consumerRoot, installedCliPath, projec
     });
     const page = await browser.newPage();
     await page.goto(`http://127.0.0.1:${port}/`);
+    const tableOfContentsToggle = page.locator('starlight-table-of-contents-toggle button');
+    await tableOfContentsToggle.waitFor({ state: 'visible' });
+    assert.equal(await tableOfContentsToggle.getAttribute('aria-expanded'), 'true');
+    await tableOfContentsToggle.click();
+    assert.equal(await tableOfContentsToggle.getAttribute('aria-expanded'), 'false');
+    assert.equal(await page.locator('#starlight__right-sidebar').getAttribute('inert'), '');
+    assert.equal(
+      await page.locator('html').getAttribute('data-table-of-contents-collapsed'),
+      '',
+      'packed consumer did not enable the configured desktop table-of-contents toggle'
+    );
     const manifest = JSON.parse(await readFile(path.join(projectRoot, 'state cache/generated runtime/cells.json')));
     const pythonCell = manifest.find((cell) => cell.id.endsWith('__package-python'));
     assert.deepEqual(pythonCell?.packages, supportedPythonPackages);
@@ -490,6 +501,7 @@ function packedAstroConfig({ offline }) {
     "const projectRoot = fileURLToPath(new URL('./site root/', import.meta.url));",
     '',
     'export default defineOxiquillConfig({',
+    '  desktopTableOfContentsToggle: true,',
     '  framework: { starlight },',
     '  root: projectRoot,',
     "  publicDir: 'static files',",

--- a/tests/package/consumer-smoke.mjs
+++ b/tests/package/consumer-smoke.mjs
@@ -7,6 +7,7 @@ import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { chromium } from '@playwright/test';
+import { loadDocumentedConsumerConfig } from '../docs/documented-config.mjs';
 
 const supportedPythonPackages = [
   'contourpy',
@@ -38,10 +39,12 @@ const packageRoot = path.join(repositoryRoot, 'packages/oxiquill');
 const registryMode = process.argv.includes('--registry');
 const temporaryRoot = await mkdtemp(path.join(tmpdir(), 'oxiquill-consumer-'));
 const consumerRoot = path.join(temporaryRoot, 'consumer');
+const documentedConfig = await loadDocumentedConsumerConfig(repositoryRoot);
 const packageApiSource = `
+import starlight from '@astrojs/starlight';
 import { defineOxiquillConfig as defineRootConfig, oxiquillIntegration } from 'oxiquill';
 import { defineOxiquillConfig } from 'oxiquill/astro';
-import type { OxiquillPathOptions, OxiquillPythonOptions } from 'oxiquill/astro';
+import type { OxiquillMarkdownConfig, OxiquillPathOptions, OxiquillPythonOptions } from 'oxiquill/astro';
 import { createOxiquillCollections } from 'oxiquill/content';
 import InteractiveCell from 'oxiquill/runtime/InteractiveCell';
 import MermaidDiagram from 'oxiquill/runtime/MermaidDiagram';
@@ -50,6 +53,20 @@ import type { CellManifest } from 'oxiquill/runtime/types';
 const cell = {} as CellManifest;
 const paths = { downloadCacheDir: new URL('./verified downloads/', import.meta.url) } satisfies OxiquillPathOptions;
 const python = { offline: true, packageMirror: new URL('https://packages.example/pyodide/') } satisfies OxiquillPythonOptions;
+const markdownConfigs: OxiquillMarkdownConfig[] = [
+  { syntaxHighlight: false },
+  { syntaxHighlight: 'prism' },
+  { syntaxHighlight: 'shiki' },
+  { syntaxHighlight: { type: 'shiki', excludeLangs: ['custom'] } }
+];
+markdownConfigs.forEach((markdown) => defineOxiquillConfig({ framework: { starlight }, markdown }));
+defineOxiquillConfig({
+  framework: { starlight },
+  markdown: {
+    // @ts-expect-error Oxiquill owns the Markdown processor so required transforms cannot be bypassed.
+    processor: { createRenderer: async () => ({ render: async () => ({}) }), name: 'custom', options: {} }
+  }
+});
 void [
   defineRootConfig,
   oxiquillIntegration,
@@ -90,6 +107,8 @@ try {
   await writeFile(packageJsonPath, `${JSON.stringify(packageJson, null, 2)}\n`);
 
   run(packageManager, ['install'], consumerRoot);
+  await writeFile(path.join(consumerRoot, 'astro.config.mjs'), documentedConfig.astro);
+  await writeFile(path.join(consumerRoot, 'content.config.ts'), documentedConfig.content);
   const installedManifest = JSON.parse(
     await readFile(path.join(consumerRoot, 'node_modules/oxiquill/package.json'), 'utf8')
   );

--- a/tests/package/consumer-smoke.mjs
+++ b/tests/package/consumer-smoke.mjs
@@ -113,6 +113,10 @@ try {
   }
 
   initializeConsumer(packageManager, packageSource, consumerRoot, temporaryRoot);
+  const starterConfig = {
+    astro: await readFile(path.join(consumerRoot, 'astro.config.mjs'), 'utf8'),
+    content: await readFile(path.join(consumerRoot, 'content.config.ts'), 'utf8')
+  };
   const packageJsonPath = path.join(consumerRoot, 'package.json');
   const packageJson = JSON.parse(await readFile(packageJsonPath, 'utf8'));
   assert.equal(packageJson.dependencies.oxiquill, `^${expectedVersion}`, 'starter Oxiquill version is stale');
@@ -174,6 +178,10 @@ try {
 
   const nodeOnlyEnvironment = createNodeOnlyEnvironment();
   run(process.execPath, [installedCliPath, 'check'], consumerRoot, false, nodeOnlyEnvironment);
+  await Promise.all([
+    writeFile(path.join(consumerRoot, 'astro.config.mjs'), starterConfig.astro),
+    writeFile(path.join(consumerRoot, 'content.config.ts'), starterConfig.content)
+  ]);
   const initialBuild = run(process.execPath, [installedCliPath, 'build'], consumerRoot, true, nodeOnlyEnvironment);
   assertNo404Warning(initialBuild);
   run(packageManager, ['run', 'preview', '--', '--background', '--host', '127.0.0.1', '--port', '4321'], consumerRoot);

--- a/tests/package/consumer-smoke.mjs
+++ b/tests/package/consumer-smoke.mjs
@@ -44,8 +44,16 @@ const packageApiSource = `
 import starlight from '@astrojs/starlight';
 import { defineOxiquillConfig as defineRootConfig, oxiquillIntegration } from 'oxiquill';
 import { defineOxiquillConfig } from 'oxiquill/astro';
-import type { OxiquillMarkdownConfig, OxiquillPathOptions, OxiquillPythonOptions } from 'oxiquill/astro';
+import type {
+  OxiquillConfig,
+  OxiquillFrameworkOptions,
+  OxiquillIntegrationOptions,
+  OxiquillMarkdownConfig,
+  OxiquillPathOptions,
+  OxiquillPythonOptions
+} from 'oxiquill/astro';
 import { createOxiquillCollections } from 'oxiquill/content';
+import type { OxiquillCollections, OxiquillContentDependencies } from 'oxiquill/content';
 import InteractiveCell from 'oxiquill/runtime/InteractiveCell';
 import MermaidDiagram from 'oxiquill/runtime/MermaidDiagram';
 import type { CellManifest } from 'oxiquill/runtime/types';
@@ -53,6 +61,14 @@ import type { CellManifest } from 'oxiquill/runtime/types';
 const cell = {} as CellManifest;
 const paths = { downloadCacheDir: new URL('./verified downloads/', import.meta.url) } satisfies OxiquillPathOptions;
 const python = { offline: true, packageMirror: new URL('https://packages.example/pyodide/') } satisfies OxiquillPythonOptions;
+const publicTypes = {} as [
+  OxiquillConfig,
+  OxiquillFrameworkOptions,
+  OxiquillIntegrationOptions,
+  OxiquillPathOptions,
+  OxiquillCollections<(...args: never[]) => unknown>,
+  OxiquillContentDependencies<(...args: never[]) => unknown, (...args: never[]) => unknown, (...args: never[]) => unknown>
+];
 const markdownConfigs: OxiquillMarkdownConfig[] = [
   { syntaxHighlight: false },
   { syntaxHighlight: 'prism' },
@@ -76,7 +92,8 @@ void [
   MermaidDiagram,
   cell,
   paths,
-  python
+  python,
+  publicTypes
 ];
 `;
 

--- a/tests/package/consumer-smoke.mjs
+++ b/tests/package/consumer-smoke.mjs
@@ -76,6 +76,7 @@ const markdownConfigs: OxiquillMarkdownConfig[] = [
   { syntaxHighlight: { type: 'shiki', excludeLangs: ['custom'] } }
 ];
 markdownConfigs.forEach((markdown) => defineOxiquillConfig({ framework: { starlight }, markdown }));
+defineOxiquillConfig({ desktopTableOfContentsToggle: false, framework: { starlight } });
 defineOxiquillConfig({
   framework: { starlight },
   markdown: {

--- a/tests/package/consumer-smoke.mjs
+++ b/tests/package/consumer-smoke.mjs
@@ -116,6 +116,7 @@ try {
   const packageJsonPath = path.join(consumerRoot, 'package.json');
   const packageJson = JSON.parse(await readFile(packageJsonPath, 'utf8'));
   assert.equal(packageJson.dependencies.oxiquill, `^${expectedVersion}`, 'starter Oxiquill version is stale');
+  assert.equal(packageJson.dependencies.preact, undefined, 'starter must not declare Preact directly');
   packageJson.dependencies.oxiquill = registryMode
     ? expectedVersion
     : `file:${path.relative(consumerRoot, packageSource).split(path.sep).join('/')}`;
@@ -162,6 +163,14 @@ try {
     ['--input-type=module', '--eval', "await import('oxiquill'); await import('oxiquill/astro');"],
     consumerRoot
   );
+
+  if (packageManager === 'pnpm') {
+    await appendFile(
+      path.join(consumerRoot, 'content/docs/index.mdx'),
+      ['', '```mermaid', 'graph TD', '  core --> linalg', '```', ''].join('\n')
+    );
+    await runInstalledDevSmoke({ consumerRoot });
+  }
 
   const nodeOnlyEnvironment = createNodeOnlyEnvironment();
   run(process.execPath, [installedCliPath, 'check'], consumerRoot, false, nodeOnlyEnvironment);
@@ -405,6 +414,42 @@ async function runInstalledBrowserSmoke({ consumerRoot, installedCliPath, projec
   }
 }
 
+async function runInstalledDevSmoke({ consumerRoot }) {
+  const port = 4_386;
+
+  try {
+    run(
+      packageManager,
+      ['run', 'dev', '--', '--background', '--host', '127.0.0.1', '--port', String(port)],
+      consumerRoot
+    );
+    const response = await waitForHttpResponse(`http://127.0.0.1:${port}/`, 60_000);
+    const html = await response.text();
+
+    assert.equal(response.status, 200, `packed development server returned ${response.status}`);
+    assert.ok(html.includes('data-testid="mermaid-diagram"'), 'packed development response omitted Mermaid SSR markup');
+    assert.ok(
+      !/Cannot read properties of undefined|__H/u.test(html),
+      'packed development response contained a Preact hook error'
+    );
+  } finally {
+    stopAstroDev(packageManager, consumerRoot);
+  }
+}
+
+async function waitForHttpResponse(url, timeoutMs) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      return await fetch(url);
+    } catch {
+      // The development server is still starting.
+    }
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  }
+  throw new Error(`Timed out waiting for packed development server at ${url}.`);
+}
+
 async function waitForHttp(url, timeoutMs, server, output, readServerError) {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
@@ -472,6 +517,11 @@ function initializeConsumer(packageManager, packageSource, target, cwd) {
 function stopAstroPreview(packageManager, cwd) {
   const args =
     packageManager === 'npm' ? ['exec', '--', 'astro', 'preview', 'stop'] : ['exec', 'astro', 'preview', 'stop'];
+  run(packageManager, args, cwd);
+}
+
+function stopAstroDev(packageManager, cwd) {
+  const args = packageManager === 'npm' ? ['exec', '--', 'astro', 'dev', 'stop'] : ['exec', 'astro', 'dev', 'stop'];
   run(packageManager, args, cwd);
 }
 

--- a/tests/package/package-contents.mjs
+++ b/tests/package/package-contents.mjs
@@ -130,6 +130,7 @@ async function expectedPackageFiles() {
   );
   const copiedFiles = [
     'dist/components/starlight/PageFrame.astro',
+    'dist/components/starlight/TwoColumnContent.astro',
     'dist/env.d.ts',
     'dist/styles/custom.css',
     'dist/styles/katex.css',

--- a/tests/unit/astro-config.test.mjs
+++ b/tests/unit/astro-config.test.mjs
@@ -299,6 +299,54 @@ describe('defineOxiquillConfig', () => {
     );
   });
 
+  it('enables the desktop table-of-contents toggle by default and preserves component overrides', () => {
+    const starlight = vi.fn(() => ({ hooks: {}, name: 'custom-starlight' }));
+
+    defineOxiquillConfig({
+      framework: { starlight },
+      starlight: {
+        components: {
+          PageFrame: './CustomPageFrame.astro',
+          TableOfContents: './CustomTableOfContents.astro'
+        }
+      }
+    });
+
+    expect(starlight).toHaveBeenCalledWith(
+      expect.objectContaining({
+        components: {
+          PageFrame: './CustomPageFrame.astro',
+          TableOfContents: './CustomTableOfContents.astro',
+          TwoColumnContent: 'oxiquill/components/starlight/TwoColumnContent'
+        }
+      })
+    );
+  });
+
+  it('allows consumers to disable or replace the desktop table-of-contents toggle', () => {
+    const disabledStarlight = vi.fn(() => ({ hooks: {}, name: 'disabled-starlight' }));
+    defineOxiquillConfig({ desktopTableOfContentsToggle: false, framework: { starlight: disabledStarlight } });
+    expect(disabledStarlight).toHaveBeenCalledWith(
+      expect.objectContaining({
+        components: { PageFrame: 'oxiquill/components/starlight/PageFrame' }
+      })
+    );
+
+    const overriddenStarlight = vi.fn(() => ({ hooks: {}, name: 'overridden-starlight' }));
+    defineOxiquillConfig({
+      framework: { starlight: overriddenStarlight },
+      starlight: { components: { TwoColumnContent: './CustomTwoColumnContent.astro' } }
+    });
+    expect(overriddenStarlight).toHaveBeenCalledWith(
+      expect.objectContaining({
+        components: {
+          PageFrame: 'oxiquill/components/starlight/PageFrame',
+          TwoColumnContent: './CustomTwoColumnContent.astro'
+        }
+      })
+    );
+  });
+
   it('keeps explicit integration factory overrides for tests and advanced consumers', () => {
     const preact = vi.fn(() => ({ hooks: {}, name: 'custom-preact' }));
     const starlight = vi.fn(() => ({ hooks: {}, name: 'custom-starlight' }));

--- a/tests/unit/astro-config.test.mjs
+++ b/tests/unit/astro-config.test.mjs
@@ -19,7 +19,8 @@ vi.mock('@astrojs/starlight', () => ({
   default: () => ({ hooks: {}, name: '@astrojs/starlight' })
 }));
 
-const { defineOxiquillConfig: definePackageConfig } = await import('../../packages/oxiquill/src/astro/index.ts');
+const { defineOxiquillConfig: definePackageConfig, oxiquillIntegration } =
+  await import('../../packages/oxiquill/src/astro/index.ts');
 const { readOxiquillMetadata } = await import('../../packages/oxiquill/src/config/metadata.mjs');
 const { canonicalPath } = await import('../../packages/oxiquill/src/config/paths.mjs');
 const linkedConsumerRoot = new URL('../fixtures/linked-consumer/', import.meta.url);
@@ -179,10 +180,14 @@ describe('defineOxiquillConfig', () => {
     const remarkPlugins = update.markdown.processor.options.remarkPlugins;
     const rehypePlugins = update.markdown.processor.options.rehypePlugins;
 
-    expect(remarkPlugins).toHaveLength(5);
-    expect(remarkPlugins.at(-1)).toBe(remarkPlugin);
-    expect(rehypePlugins).toHaveLength(2);
-    expect(rehypePlugins.at(-1)).toBe(rehypePlugin);
+    expect(remarkPlugins.map(pluginName)).toEqual([
+      'remarkMath',
+      'remarkPublicAssetBase',
+      'remarkInteractiveCells',
+      'remarkMermaidDiagrams',
+      'remarkPlugin'
+    ]);
+    expect(rehypePlugins.map(pluginName)).toEqual(['rehypeKatex', 'rehypePlugin']);
     expect(update.markdown).not.toHaveProperty('remarkPlugins');
     expect(update.markdown).not.toHaveProperty('rehypePlugins');
   });
@@ -251,12 +256,12 @@ describe('defineOxiquillConfig', () => {
 
   it('rejects a custom Markdown processor before configuration setup', () => {
     const markdown = { processor: { createRenderer: vi.fn(), name: 'custom', options: {} } };
-
-    expect(() => defineOxiquillConfig({ markdown, sidebar: [], title: 'Docs' })).toThrow(
-      new TypeError(
-        'Oxiquill does not support markdown.processor because it owns the Markdown processor pipeline required for its transforms.'
-      )
+    const expectedError = new TypeError(
+      'Oxiquill does not support markdown.processor because it owns the Markdown processor pipeline required for its transforms.'
     );
+
+    expect(() => defineOxiquillConfig({ markdown, sidebar: [], title: 'Docs' })).toThrow(expectedError);
+    expect(() => oxiquillIntegration({ markdown })).toThrow(expectedError);
   });
 
   it('installs package-owned main and worker bundle reporters', () => {
@@ -472,3 +477,7 @@ describe('defineOxiquillConfig', () => {
     expect(resolved['astro/runtime/server/index.js']).toEqual(expect.any(String));
   });
 });
+
+function pluginName(plugin) {
+  return (Array.isArray(plugin) ? plugin[0] : plugin).name;
+}

--- a/tests/unit/astro-config.test.mjs
+++ b/tests/unit/astro-config.test.mjs
@@ -33,6 +33,12 @@ const preactExportSpecifiers = [
   'preact/debug',
   'preact/devtools'
 ];
+const preactRendererExportSpecifiers = [
+  'preact-render-to-string',
+  'preact-render-to-string/jsx',
+  'preact-render-to-string/stream',
+  'preact-render-to-string/stream-node'
+];
 
 function defineOxiquillConfig(options) {
   return definePackageConfig({
@@ -336,7 +342,7 @@ describe('defineOxiquillConfig', () => {
     expect(normalizedAllow.some((entry) => entry.includes('node_modules/.pnpm/aria-query'))).toBe(true);
   });
 
-  it('aliases Preact when the workspace does not expose a direct install', () => {
+  it('aliases the Preact runtime when the workspace does not expose a direct install', () => {
     const config = defineOxiquillConfig({
       sidebar: [],
       title: 'Docs'
@@ -349,6 +355,13 @@ describe('defineOxiquillConfig', () => {
 
       expect(replacement, id).toEqual(expect.any(String));
       expect(replacement.replaceAll('\\', '/'), id).toContain('/node_modules/preact/');
+    }
+
+    for (const id of preactRendererExportSpecifiers) {
+      const replacement = aliasReplacementFor(update.vite.resolve.alias, id);
+
+      expect(replacement, id).toEqual(expect.any(String));
+      expect(replacement.replaceAll('\\', '/'), id).toContain('/node_modules/preact-render-to-string/');
     }
   });
 
@@ -371,7 +384,7 @@ describe('defineOxiquillConfig', () => {
     expect(resolve).not.toHaveBeenCalled();
   });
 
-  it('bundles compiled Oxiquill while sharing the Preact SSR runtime', () => {
+  it('bundles the complete Preact SSR runtime with compiled Oxiquill', () => {
     const config = defineOxiquillConfig({
       sidebar: [],
       title: 'Docs'
@@ -379,9 +392,12 @@ describe('defineOxiquillConfig', () => {
 
     const update = runConfigSetup(config, linkedConsumerRoot);
 
-    expect(update.vite.ssr.noExternal).toEqual(expect.arrayContaining(['@astrojs/preact', 'oxiquill']));
-    expect(update.vite.ssr.noExternal).not.toEqual(expect.arrayContaining(['preact', 'preact-render-to-string']));
-    expect(update.vite.resolve.dedupe).toEqual(expect.arrayContaining(['@preact/signals', 'preact']));
+    expect(update.vite.ssr.noExternal).toEqual(
+      expect.arrayContaining(['@astrojs/preact', 'oxiquill', 'preact', 'preact-render-to-string'])
+    );
+    expect(update.vite.resolve.dedupe).toEqual(
+      expect.arrayContaining(['@preact/signals', 'preact', 'preact-render-to-string'])
+    );
   });
 
   it('merges consumer Vite SSR and dedupe settings with Oxiquill defaults', () => {
@@ -404,10 +420,17 @@ describe('defineOxiquillConfig', () => {
 
     expect(update.vite.ssr.external).toEqual(['external-runtime']);
     expect(update.vite.ssr.noExternal).toEqual(
-      expect.arrayContaining(['consumer-package', consumerNoExternal, '@astrojs/preact', 'oxiquill'])
+      expect.arrayContaining([
+        'consumer-package',
+        consumerNoExternal,
+        '@astrojs/preact',
+        'oxiquill',
+        'preact',
+        'preact-render-to-string'
+      ])
     );
     expect(update.vite.resolve.dedupe).toEqual(
-      expect.arrayContaining(['consumer-runtime', '@preact/signals', 'preact'])
+      expect.arrayContaining(['consumer-runtime', '@preact/signals', 'preact', 'preact-render-to-string'])
     );
   });
 
@@ -423,7 +446,9 @@ describe('defineOxiquillConfig', () => {
 
       const update = runConfigSetup(config, linkedConsumerRoot);
 
-      expect(update.vite.ssr.noExternal).toEqual(expect.arrayContaining([noExternal, '@astrojs/preact', 'oxiquill']));
+      expect(update.vite.ssr.noExternal).toEqual(
+        expect.arrayContaining([noExternal, '@astrojs/preact', 'oxiquill', 'preact', 'preact-render-to-string'])
+      );
     }
   });
 
@@ -450,6 +475,7 @@ describe('defineOxiquillConfig', () => {
     const update = runConfigSetup(config, linkedConsumerRoot);
     const resolved = await resolveWithVite(update, [
       ...preactExportSpecifiers,
+      ...preactRendererExportSpecifiers,
       '@preact/signals',
       '@bjorn3/browser_wasi_shim',
       'aria-query',
@@ -463,6 +489,10 @@ describe('defineOxiquillConfig', () => {
     ]);
 
     for (const id of preactExportSpecifiers) {
+      expect(resolved[id], id).toEqual(expect.any(String));
+    }
+
+    for (const id of preactRendererExportSpecifiers) {
       expect(resolved[id], id).toEqual(expect.any(String));
     }
 

--- a/tests/unit/astro-config.test.mjs
+++ b/tests/unit/astro-config.test.mjs
@@ -176,25 +176,87 @@ describe('defineOxiquillConfig', () => {
       title: 'Docs'
     });
     const update = runConfigSetup(config);
+    const remarkPlugins = update.markdown.processor.options.remarkPlugins;
+    const rehypePlugins = update.markdown.processor.options.rehypePlugins;
 
-    expect(update.markdown.processor.options.remarkPlugins.at(-1)).toBe(remarkPlugin);
-    expect(update.markdown.processor.options.rehypePlugins.at(-1)).toBe(rehypePlugin);
+    expect(remarkPlugins).toHaveLength(5);
+    expect(remarkPlugins.at(-1)).toBe(remarkPlugin);
+    expect(rehypePlugins).toHaveLength(2);
+    expect(rehypePlugins.at(-1)).toBe(rehypePlugin);
     expect(update.markdown).not.toHaveProperty('remarkPlugins');
     expect(update.markdown).not.toHaveProperty('rehypePlugins');
   });
 
-  it('preserves explicit Astro rendering and Markdown processor options', () => {
-    const processor = { render: vi.fn() };
+  it.each([
+    ['disabled highlighting', false],
+    ['Prism highlighting', 'prism'],
+    ['Shiki shorthand highlighting', 'shiki']
+  ])('preserves %s', (_label, syntaxHighlight) => {
+    const config = defineOxiquillConfig({
+      markdown: { syntaxHighlight },
+      sidebar: [],
+      title: 'Docs'
+    });
+    const update = runConfigSetup(config);
+
+    expect(update.markdown.syntaxHighlight).toBe(syntaxHighlight);
+  });
+
+  it('merges required languages into Shiki object exclusions without dropping consumer fields', () => {
+    const config = defineOxiquillConfig({
+      markdown: {
+        syntaxHighlight: { excludeLangs: ['custom', 'math'], type: 'shiki' }
+      },
+      sidebar: [],
+      title: 'Docs'
+    });
+    const update = runConfigSetup(config);
+
+    expect(update.markdown.syntaxHighlight).toEqual({
+      excludeLangs: ['custom', 'math', 'mermaid'],
+      type: 'shiki'
+    });
+  });
+
+  it('uses Shiki with Oxiquill exclusions when syntax highlighting is not configured', () => {
+    const update = runConfigSetup(defineOxiquillConfig({ sidebar: [], title: 'Docs' }));
+
+    expect(update.markdown.syntaxHighlight).toEqual({
+      excludeLangs: ['math', 'mermaid'],
+      type: 'shiki'
+    });
+  });
+
+  it('preserves supported Astro rendering and Markdown fields', () => {
+    const image = { domains: ['images.example.com'] };
+    const remarkRehype = { footnoteLabel: 'Notes' };
+    const shikiConfig = { theme: 'github-light' };
+    const smartypants = { dashes: 'oldschool' };
     const config = defineOxiquillConfig({
       compressHTML: 'jsx',
-      markdown: { processor },
+      markdown: { gfm: false, image, remarkRehype, shikiConfig, smartypants },
       sidebar: [],
       title: 'Docs'
     });
     const update = runConfigSetup(config);
 
     expect(config.compressHTML).toBe('jsx');
-    expect(update.markdown.processor).toBe(processor);
+    expect(update.markdown).toMatchObject({ image, shikiConfig });
+    expect(update.markdown.processor.options).toMatchObject({
+      gfm: false,
+      remarkRehype,
+      smartypants
+    });
+  });
+
+  it('rejects a custom Markdown processor before configuration setup', () => {
+    const markdown = { processor: { createRenderer: vi.fn(), name: 'custom', options: {} } };
+
+    expect(() => defineOxiquillConfig({ markdown, sidebar: [], title: 'Docs' })).toThrow(
+      new TypeError(
+        'Oxiquill does not support markdown.processor because it owns the Markdown processor pipeline required for its transforms.'
+      )
+    );
   });
 
   it('installs package-owned main and worker bundle reporters', () => {

--- a/tests/unit/clean.test.mjs
+++ b/tests/unit/clean.test.mjs
@@ -1,60 +1,192 @@
 // @vitest-environment node
 
+import { existsSync } from 'node:fs';
+import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
 import path from 'node:path';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { createOxiquillPaths } from '../../packages/oxiquill/src/config/paths.mjs';
 import { cleanOxiquillWorkspace } from '../../packages/oxiquill/src/generator/clean.mjs';
+import {
+  CLEANUP_OWNERSHIP_MARKER,
+  maintainCleanupOwnership,
+  prepareCleanupOwnership
+} from '../../packages/oxiquill/src/generator/cleanup-ownership.mjs';
+
+const temporaryDirectories = [];
+
+afterEach(async () => {
+  await Promise.all(temporaryDirectories.splice(0).map((directory) => rm(directory, { force: true, recursive: true })));
+});
 
 describe('Oxiquill cleanup', () => {
-  it('removes only exact resolved Oxiquill and Astro output paths', async () => {
-    const root = path.resolve('/repo');
+  it('removes safe default output and preserves authored, repository, dependency, and download-cache files', async () => {
+    const root = await temporaryDirectory();
+    const paths = createOxiquillPaths({ workspaceRoot: root });
+    const preservedFiles = [
+      path.join(paths.docsDir, 'guide.mdx'),
+      path.join(paths.cratesDir, 'helper/Cargo.toml'),
+      path.join(paths.publicDir, 'media/photo.txt'),
+      path.join(root, '.git/HEAD'),
+      path.join(root, 'node_modules/package/index.js'),
+      path.join(paths.downloadCacheDir, 'verified.whl')
+    ];
+    const removedFiles = [
+      path.join(paths.cacheDir, 'generated/cells.json'),
+      path.join(paths.outDir, 'index.html'),
+      path.join(paths.publicAssetsDir, 'rust-wasm/runtime.wasm')
+    ];
+
+    await Promise.all([...preservedFiles, ...removedFiles].map((filePath) => writeSentinel(filePath)));
+    await cleanOxiquillWorkspace({ paths });
+
+    preservedFiles.forEach((filePath) => expect(existsSync(filePath), filePath).toBe(true));
+    [paths.cacheDir, paths.outDir, paths.publicAssetsDir].forEach((directory) =>
+      expect(existsSync(directory), directory).toBe(false)
+    );
+  });
+
+  it('cleans custom roots only after the lifecycle establishes explicit ownership', async () => {
+    const root = await temporaryDirectory();
     const paths = createOxiquillPaths({
       cacheDir: 'custom-cache',
       outDir: 'custom-output',
       publicAssetsDir: 'custom-assets',
       workspaceRoot: root
     });
-    const fileSystem = { rm: vi.fn(async () => undefined) };
 
-    await cleanOxiquillWorkspace({ fileSystem, paths });
+    const ownership = await prepareCleanupOwnership({ paths });
+    expect(ownership).toHaveLength(3);
+    for (const targetPath of [paths.cacheDir, paths.outDir, paths.publicAssetsDir]) {
+      expect(JSON.parse(await readFile(path.join(targetPath, CLEANUP_OWNERSHIP_MARKER), 'utf8'))).toMatchObject({
+        owner: 'oxiquill',
+        schemaVersion: 1
+      });
+      await writeSentinel(path.join(targetPath, 'generated.txt'));
+    }
 
-    expect(fileSystem.rm.mock.calls).toEqual(
-      expect.arrayContaining([
-        [path.join(root, 'custom-cache'), { force: true, recursive: true }],
-        [path.join(root, 'custom-output'), { force: true, recursive: true }],
-        [path.join(root, 'public/custom-assets'), { force: true, recursive: true }]
-      ])
+    await cleanOxiquillWorkspace({ paths });
+
+    [paths.cacheDir, paths.outDir, paths.publicAssetsDir].forEach((directory) =>
+      expect(existsSync(directory), directory).toBe(false)
     );
-    expect(fileSystem.rm).toHaveBeenCalledTimes(3);
-    expect(fileSystem.rm).not.toHaveBeenCalledWith(paths.downloadCacheDir, expect.anything());
   });
 
-  it('validates every target before deleting anything', async () => {
-    const root = path.resolve('/repo');
-    const paths = {
-      ...createOxiquillPaths({ workspaceRoot: root }),
-      cacheDir: root
-    };
-    const fileSystem = { rm: vi.fn(async () => undefined) };
+  it('does not infer ownership from a pre-existing custom directory', async () => {
+    const root = await temporaryDirectory();
+    const paths = createOxiquillPaths({ cacheDir: 'custom-cache', workspaceRoot: root });
+    const sentinel = path.join(paths.cacheDir, 'authored.txt');
+    await writeSentinel(sentinel);
 
-    await expect(cleanOxiquillWorkspace({ fileSystem, paths })).rejects.toThrow(
-      'cacheDir must resolve to a directory inside'
+    await expect(cleanOxiquillWorkspace({ paths })).rejects.toThrow(
+      `Unsafe cleanup root cacheDir at ${paths.cacheDir}: the custom cleanup target has no ${CLEANUP_OWNERSHIP_MARKER}`
     );
+    expect(existsSync(sentinel)).toBe(true);
+  });
+
+  it('restores ownership after a build tool empties a verified custom output root', async () => {
+    const root = await temporaryDirectory();
+    const paths = createOxiquillPaths({ outDir: 'custom-output', workspaceRoot: root });
+    const ownership = await prepareCleanupOwnership({ paths });
+    const outOwnership = ownership.filter(({ root: ownedRoot }) => ownedRoot.property === 'outDir');
+
+    await rm(paths.outDir, { force: true, recursive: true });
+    await writeSentinel(path.join(paths.outDir, 'index.html'));
+    await maintainCleanupOwnership({ ownership: outOwnership });
+    await cleanOxiquillWorkspace({ paths });
+
+    expect(existsSync(paths.outDir)).toBe(false);
+  });
+
+  it('validates every target before deleting any otherwise valid target', async () => {
+    const root = await temporaryDirectory();
+    const paths = createOxiquillPaths({ cacheDir: 'custom-cache', workspaceRoot: root });
+    const sentinels = [
+      path.join(paths.cacheDir, 'authored.txt'),
+      path.join(paths.outDir, 'generated.html'),
+      path.join(paths.publicAssetsDir, 'generated.js')
+    ];
+    await Promise.all(sentinels.map((filePath) => writeSentinel(filePath)));
+    const fileSystem = { rm: vi.fn(rm) };
+
+    await expect(cleanOxiquillWorkspace({ fileSystem, paths })).rejects.toThrow('custom cleanup target has no');
+
     expect(fileSystem.rm).not.toHaveBeenCalled();
-    await expect(cleanOxiquillWorkspace()).rejects.toThrow('requires resolved project paths');
+    sentinels.forEach((filePath) => expect(existsSync(filePath), filePath).toBe(true));
   });
 
-  it('rejects a download cache nested below a cleaned directory before deleting anything', async () => {
-    const root = path.resolve('/repo');
+  it.each(['.git', 'node_modules'])(
+    'rejects a generated root containing discovered protected state: %s',
+    async (protectedName) => {
+      const root = await temporaryDirectory();
+      const paths = createOxiquillPaths({ workspaceRoot: root });
+      const protectedSentinel = path.join(paths.outDir, 'nested', protectedName, 'sentinel');
+      const otherSentinel = path.join(paths.cacheDir, 'generated.txt');
+      await Promise.all([writeSentinel(protectedSentinel), writeSentinel(otherSentinel)]);
+      const fileSystem = { rm: vi.fn(rm) };
+
+      await expect(cleanOxiquillWorkspace({ fileSystem, paths })).rejects.toThrow(protectedName);
+
+      expect(fileSystem.rm).not.toHaveBeenCalled();
+      expect(existsSync(protectedSentinel)).toBe(true);
+      expect(existsSync(otherSentinel)).toBe(true);
+    }
+  );
+
+  it('canonicalizes a symlinked cleanup ancestor and rejects authored content', async () => {
+    const root = await temporaryDirectory();
+    const docsDir = path.join(root, 'content/docs');
+    const linked = path.join(root, 'linked');
+    const sentinel = path.join(docsDir, 'guide.mdx');
+    await writeSentinel(sentinel);
+    await symlink(path.join(root, 'content'), linked, process.platform === 'win32' ? 'junction' : 'dir');
+    const paths = createOxiquillPaths({ cacheDir: path.join(linked, 'docs'), workspaceRoot: root });
+
+    await expect(cleanOxiquillWorkspace({ paths })).rejects.toThrow(
+      `cacheDir at ${docsDir}: it is equal to docsDir (authored documentation input)`
+    );
+    expect(existsSync(sentinel)).toBe(true);
+  });
+
+  it('canonicalizes a symlinked ancestor and rejects an external cleanup target', async () => {
+    const root = await temporaryDirectory();
+    const external = await temporaryDirectory();
+    const linked = path.join(root, 'linked');
+    const sentinel = path.join(external, 'generated/sentinel');
+    await writeSentinel(sentinel);
+    await symlink(external, linked, process.platform === 'win32' ? 'junction' : 'dir');
+    const paths = createOxiquillPaths({ outDir: path.join(linked, 'generated'), workspaceRoot: root });
+
+    await expect(cleanOxiquillWorkspace({ paths })).rejects.toThrow(
+      `Unsafe path outDir at ${path.join(external, 'generated')}`
+    );
+    expect(existsSync(sentinel)).toBe(true);
+  });
+
+  it('rejects malformed calls and persistent caches below cleanup roots without mutating files', async () => {
+    const root = await temporaryDirectory();
     const paths = {
       ...createOxiquillPaths({ workspaceRoot: root }),
       downloadCacheDir: path.join(root, '.oxiquill/downloads')
     };
-    const fileSystem = { rm: vi.fn(async () => undefined) };
+    const sentinel = path.join(paths.outDir, 'index.html');
+    await writeSentinel(sentinel);
 
-    await expect(cleanOxiquillWorkspace({ fileSystem, paths })).rejects.toThrow(
-      'paths.downloadCacheDir must resolve outside directories removed by oxiquill clean'
+    await expect(cleanOxiquillWorkspace({ paths })).rejects.toThrow(
+      'cacheDir at ' + path.join(root, '.oxiquill') + ': it is an ancestor of paths.downloadCacheDir'
     );
-    expect(fileSystem.rm).not.toHaveBeenCalled();
+    expect(existsSync(sentinel)).toBe(true);
+    await expect(cleanOxiquillWorkspace()).rejects.toThrow('requires resolved project paths');
   });
 });
+
+async function temporaryDirectory() {
+  const directory = await mkdtemp(path.join(tmpdir(), 'oxiquill-clean-'));
+  temporaryDirectories.push(directory);
+  return directory;
+}
+
+async function writeSentinel(filePath) {
+  await mkdir(path.dirname(filePath), { recursive: true });
+  await writeFile(filePath, 'sentinel\n');
+}

--- a/tests/unit/clean.test.mjs
+++ b/tests/unit/clean.test.mjs
@@ -84,6 +84,31 @@ describe('Oxiquill cleanup', () => {
     expect(existsSync(sentinel)).toBe(true);
   });
 
+  it('rejects a public asset root nested below an authored public subtree', async () => {
+    const root = await temporaryDirectory();
+    const paths = createOxiquillPaths({ publicAssetsDir: 'media/generated', workspaceRoot: root });
+    const sentinel = path.join(paths.publicDir, 'media/photo.txt');
+    await writeSentinel(sentinel);
+
+    await expect(prepareCleanupOwnership({ paths })).rejects.toThrow(
+      `paths.publicAssetsDir at ${paths.publicAssetsDir}: it is a descendant of authored public subtree`
+    );
+    expect(existsSync(sentinel)).toBe(true);
+    expect(existsSync(paths.publicAssetsDir)).toBe(false);
+  });
+
+  it('supports a nested custom public asset root when its ancestors contain only generated output', async () => {
+    const root = await temporaryDirectory();
+    const paths = createOxiquillPaths({ publicAssetsDir: 'generated/runtime', workspaceRoot: root });
+
+    await prepareCleanupOwnership({ paths });
+    await prepareCleanupOwnership({ paths });
+    await writeSentinel(path.join(paths.publicAssetsDir, 'runtime.js'));
+    await cleanOxiquillWorkspace({ paths });
+
+    expect(existsSync(paths.publicAssetsDir)).toBe(false);
+  });
+
   it('restores ownership after a build tool empties a verified custom output root', async () => {
     const root = await temporaryDirectory();
     const paths = createOxiquillPaths({ outDir: 'custom-output', workspaceRoot: root });

--- a/tests/unit/clean.test.mjs
+++ b/tests/unit/clean.test.mjs
@@ -5,7 +5,7 @@ import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from 'node:fs/promis
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { createOxiquillPaths } from '../../packages/oxiquill/src/config/paths.mjs';
+import { canonicalPath, createOxiquillPaths } from '../../packages/oxiquill/src/config/paths.mjs';
 import { cleanOxiquillWorkspace } from '../../packages/oxiquill/src/generator/clean.mjs';
 import {
   CLEANUP_OWNERSHIP_MARKER,
@@ -206,7 +206,7 @@ describe('Oxiquill cleanup', () => {
 });
 
 async function temporaryDirectory() {
-  const directory = await mkdtemp(path.join(tmpdir(), 'oxiquill-clean-'));
+  const directory = canonicalPath(await mkdtemp(path.join(tmpdir(), 'oxiquill-clean-')));
   temporaryDirectories.push(directory);
   return directory;
 }

--- a/tests/unit/cli.test.mjs
+++ b/tests/unit/cli.test.mjs
@@ -455,6 +455,39 @@ describe('oxiquill CLI', () => {
     });
   });
 
+  it('preflights outDir ownership before starting an Oxiquill build', async () => {
+    const runCommand = vi.fn(async () => undefined);
+
+    await runCli('build', [], {
+      cwd: repoRoot,
+      runCommand,
+      selectNode: () => 'node'
+    });
+
+    expect(cliMocks.prepareCleanupOwnership).toHaveBeenCalledWith({
+      configFile: undefined,
+      fields: ['cacheDir', 'outDir', 'publicAssetsDir'],
+      paths: expect.objectContaining({ workspaceRoot: repoRoot })
+    });
+    expect(runCommand).toHaveBeenCalled();
+  });
+
+  it('does not start generation or Astro when build output ownership is invalid', async () => {
+    const runCommand = vi.fn(async () => undefined);
+    cliMocks.prepareCleanupOwnership.mockRejectedValueOnce(new Error('unowned outDir'));
+
+    await expect(
+      runCli('build', [], {
+        cwd: repoRoot,
+        runCommand,
+        selectNode: () => 'node'
+      })
+    ).rejects.toThrow('unowned outDir');
+
+    expect(cliMocks.createDocRuntimeContext).not.toHaveBeenCalled();
+    expect(runCommand).not.toHaveBeenCalled();
+  });
+
   it('generates manifests without Wasm unless a valid mode is requested', async () => {
     const log = vi.spyOn(console, 'log').mockImplementation(() => {});
 

--- a/tests/unit/cli.test.mjs
+++ b/tests/unit/cli.test.mjs
@@ -15,6 +15,7 @@ const cliMocks = vi.hoisted(() => ({
   createDocRuntimeContext: vi.fn(),
   loadProjectConfig: vi.fn(),
   markRuntimeReady: vi.fn(),
+  prepareCleanupOwnership: vi.fn(),
   runHelperCargo: vi.fn(),
   syncDocRuntime: vi.fn(),
   syncLicenseArtifacts: vi.fn(),
@@ -32,6 +33,9 @@ vi.mock('../../packages/oxiquill/src/generator/doc-runtime-service.mjs', () => (
 }));
 vi.mock('../../packages/oxiquill/src/generator/clean.mjs', () => ({
   cleanOxiquillWorkspace: cliMocks.cleanOxiquillWorkspace
+}));
+vi.mock('../../packages/oxiquill/src/generator/cleanup-ownership.mjs', () => ({
+  prepareCleanupOwnership: cliMocks.prepareCleanupOwnership
 }));
 vi.mock('../../packages/oxiquill/src/generator/run-helper-cargo.mjs', () => ({
   runHelperCargo: cliMocks.runHelperCargo
@@ -72,6 +76,7 @@ beforeEach(() => {
     haskellFingerprint: 'haskell-fingerprint',
     rustCellCount: 1
   });
+  cliMocks.prepareCleanupOwnership.mockResolvedValue([]);
   cliMocks.buildHaskellWasm.mockResolvedValue({ ok: true });
   cliMocks.testGeneratedHaskellCells.mockResolvedValue({ cellCount: 1 });
   cliMocks.watchDocRuntime.mockResolvedValue({ close: vi.fn(async () => undefined) });
@@ -445,6 +450,7 @@ describe('oxiquill CLI', () => {
     await runCli('clean', [], { cwd: repoRoot });
 
     expect(cliMocks.cleanOxiquillWorkspace).toHaveBeenCalledWith({
+      configFile: undefined,
       paths: expect.objectContaining({ workspaceRoot: repoRoot })
     });
   });
@@ -453,6 +459,11 @@ describe('oxiquill CLI', () => {
     const log = vi.spyOn(console, 'log').mockImplementation(() => {});
 
     await runCli('docgen', [], { cwd: repoRoot });
+    expect(cliMocks.prepareCleanupOwnership).toHaveBeenCalledWith({
+      configFile: undefined,
+      fields: ['cacheDir', 'publicAssetsDir'],
+      paths: expect.objectContaining({ workspaceRoot: repoRoot })
+    });
     expect(cliMocks.syncDocRuntime).toHaveBeenCalledTimes(1);
     expect(cliMocks.buildRustWasm).not.toHaveBeenCalled();
     expect(cliMocks.syncDocRuntime).toHaveBeenLastCalledWith(

--- a/tests/unit/cli.test.mjs
+++ b/tests/unit/cli.test.mjs
@@ -456,13 +456,18 @@ describe('oxiquill CLI', () => {
   });
 
   it('preflights outDir ownership before starting an Oxiquill build', async () => {
-    const runCommand = vi.fn(async () => undefined);
-
-    await runCli('build', [], {
-      cwd: repoRoot,
-      runCommand,
-      selectNode: () => 'node'
+    const stopBeforeAstro = new Error('stop before Astro');
+    const runCommand = vi.fn(async () => {
+      throw stopBeforeAstro;
     });
+
+    await expect(
+      runCli('build', [], {
+        cwd: repoRoot,
+        runCommand,
+        selectNode: () => 'node'
+      })
+    ).rejects.toBe(stopBeforeAstro);
 
     expect(cliMocks.prepareCleanupOwnership).toHaveBeenCalledWith({
       configFile: undefined,
@@ -470,6 +475,9 @@ describe('oxiquill CLI', () => {
       paths: expect.objectContaining({ workspaceRoot: repoRoot })
     });
     expect(runCommand).toHaveBeenCalled();
+    expect(cliMocks.prepareCleanupOwnership.mock.invocationCallOrder[0]).toBeLessThan(
+      runCommand.mock.invocationCallOrder[0]
+    );
   });
 
   it('does not start generation or Astro when build output ownership is invalid', async () => {

--- a/tests/unit/components.test.tsx
+++ b/tests/unit/components.test.tsx
@@ -1192,6 +1192,7 @@ describe('OutputRenderer', () => {
 
     const htmlOutputs = screen.getAllByTestId('html-output');
     expect(htmlOutputs[0]).toHaveAttribute('sandbox', '');
+    expect(htmlOutputs[0]).toHaveAttribute('csp', htmlArtifactContentSecurityPolicy);
     expect(htmlOutputs[0]).toHaveAttribute('referrerpolicy', 'no-referrer');
     expect(htmlOutputs[0].getAttribute('srcdoc')).toContain('<strong>safe</strong>');
     expect(htmlOutputs[0].getAttribute('srcdoc')).toContain(htmlArtifactContentSecurityPolicy);

--- a/tests/unit/components.test.tsx
+++ b/tests/unit/components.test.tsx
@@ -238,7 +238,8 @@ describe('InteractiveCell', () => {
         count: 4,
         label: 'next'
       }),
-      'v1'
+      'v1',
+      expect.anything()
     );
   });
 
@@ -345,6 +346,58 @@ describe('InteractiveCell', () => {
     expect(input).toHaveAttribute('aria-invalid', 'true');
     expect(input).toHaveAttribute('aria-errormessage', 'doc-input-cell-one-count-validation');
     expect(screen.getByRole('alert')).toHaveTextContent('1 以上の値を入力してください。');
+    expect(screen.getByRole('button', { name: '実行' })).toBeDisabled();
+  });
+
+  it('preserves invalid numeric edits and never commits or runs them', async () => {
+    mocks.runInteractiveCell.mockResolvedValue({ stdout: 'ok', plots: [] });
+    setManifestCells([
+      makeCell({
+        inputs: [{ name: 'count', type: 'number', label: 'count', value: 1, min: -2, max: 2, step: 0.5, options: [] }]
+      })
+    ]);
+
+    render(<InteractiveCell cellId="cell-one" />);
+    const input = screen.getByRole('spinbutton', { name: 'count' });
+    const runButton = screen.getByRole('button', { name: 'Run' });
+
+    for (const invalidValue of ['', '-', '1e309', '-2.5', '2.5', '1.25']) {
+      fireEvent.input(input, { target: { value: invalidValue } });
+      expect(input).toHaveValue(invalidValue);
+      expect(runButton).toBeDisabled();
+      fireEvent.click(runButton);
+    }
+    expect(mocks.runInteractiveCell).not.toHaveBeenCalled();
+
+    fireEvent.input(input, { target: { value: '-1.5' } });
+    expect(runButton).toBeEnabled();
+    fireEvent.click(runButton);
+    await waitFor(() => expect(mocks.runInteractiveCell).toHaveBeenCalledOnce());
+    expect(mocks.runInteractiveCell).toHaveBeenCalledWith(expect.anything(), { count: -1.5 }, 'v1', expect.anything());
+  });
+
+  it('formats range labels from fractional and exponential steps', () => {
+    setManifestCells([
+      makeCell({
+        inputs: [
+          { name: 'fine', type: 'range', label: 'fine', value: 1.2, min: 0, max: 2, step: 0.001, options: [] },
+          {
+            name: 'tiny',
+            type: 'range',
+            label: 'tiny',
+            value: 0.0000003,
+            min: 0,
+            max: 0.000001,
+            step: 1e-7,
+            options: []
+          }
+        ]
+      })
+    ]);
+
+    render(<InteractiveCell cellId="cell-one" />);
+    expect(screen.getByTestId('fine-value')).toHaveTextContent('1.200');
+    expect(screen.getByTestId('tiny-value')).toHaveTextContent('0.0000003');
   });
 
   it('shows running and error states', async () => {
@@ -459,15 +512,41 @@ describe('InteractiveCell', () => {
     expect(mocks.runInteractiveCell).toHaveBeenLastCalledWith(
       expect.objectContaining({ id: 'cell-one' }),
       expect.objectContaining({ ratio: 2.5 }),
-      'v1'
+      'v1',
+      expect.anything()
     );
   });
 
-  it('runs at most one active reactive request and one final replacement', async () => {
+  it('blocks invalid reactive edits and schedules the latest values once validity returns', async () => {
+    mocks.runInteractiveCell.mockResolvedValue({ stdout: 'auto', plots: [] });
+    setManifestCells([
+      makeCell({
+        run: 'reactive',
+        inputs: [{ name: 'count', type: 'number', label: 'count', value: 1, min: 0, max: 4, step: 0.5, options: [] }]
+      })
+    ]);
+
+    render(<InteractiveCell cellId="cell-one" />);
+    await waitFor(() => expect(mocks.runInteractiveCell).toHaveBeenCalledOnce());
+    const input = screen.getByRole('spinbutton', { name: 'count' });
+
+    fireEvent.input(input, { target: { value: '' } });
+    await new Promise((resolve) => globalThis.setTimeout(resolve, 200));
+    expect(mocks.runInteractiveCell).toHaveBeenCalledOnce();
+
+    fireEvent.input(input, { target: { value: '2' } });
+    fireEvent.input(input, { target: { value: '3' } });
+    await waitFor(() => expect(mocks.runInteractiveCell).toHaveBeenCalledTimes(2));
+    expect(mocks.runInteractiveCell).toHaveBeenLastCalledWith(expect.anything(), { count: 3 }, 'v1', expect.anything());
+  });
+
+  it('cancels an active reactive request and runs only the final replacement', async () => {
     const pending: Array<ReturnType<typeof createDeferredResult>> = [];
-    mocks.runInteractiveCell.mockImplementation(() => {
+    const signals: AbortSignal[] = [];
+    mocks.runInteractiveCell.mockImplementation((_cell, _values, _version, signal: AbortSignal) => {
       const deferred = createDeferredResult();
       pending.push(deferred);
+      signals.push(signal);
       return deferred.promise;
     });
     setManifestCells([
@@ -485,22 +564,15 @@ describe('InteractiveCell', () => {
     }
     await new Promise((resolve) => globalThis.setTimeout(resolve, 200));
 
-    expect(pending).toHaveLength(1);
+    expect(pending).toHaveLength(2);
+    expect(signals[0].aborted).toBe(true);
     expect(screen.getByText('Running cell...')).toBeVisible();
-
-    await act(async () => {
-      pending[0].resolve({
-        stdout: 'obsolete result',
-        stderr: '',
-        value: null,
-        plots: [],
-        outputs: [{ kind: 'text', stream: 'stdout', content: 'obsolete result' }]
-      });
-      await pending[0].promise;
-    });
-
-    await waitFor(() => expect(pending).toHaveLength(2));
-    expect(mocks.runInteractiveCell).toHaveBeenLastCalledWith(expect.anything(), { label: 'newer input 9' }, 'v1');
+    expect(mocks.runInteractiveCell).toHaveBeenLastCalledWith(
+      expect.anything(),
+      { label: 'newer input 9' },
+      'v1',
+      expect.anything()
+    );
     expect(screen.queryByText('obsolete result')).not.toBeInTheDocument();
 
     await act(async () => {
@@ -514,7 +586,7 @@ describe('InteractiveCell', () => {
       await pending[1].promise;
     });
 
-    expect(screen.getByTestId('run-output')).toHaveTextContent('newer result');
+    await waitFor(() => expect(screen.getByTestId('run-output')).toHaveTextContent('newer result'));
   });
 
   it('ignores stale async errors from superseded reactive runs', async () => {
@@ -556,15 +628,19 @@ describe('InteractiveCell', () => {
       await pending[1].promise;
     });
 
-    expect(screen.getByTestId('run-output')).toHaveTextContent('newer result');
+    await waitFor(() => expect(screen.getByTestId('run-output')).toHaveTextContent('newer result'));
   });
 
   it('drops debounced and active callbacks when a reactive cell unmounts', async () => {
     const active = createDeferredResult();
     const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
     const unhandledRejection = vi.fn();
+    let signal: AbortSignal | undefined;
     window.addEventListener('unhandledrejection', unhandledRejection);
-    mocks.runInteractiveCell.mockReturnValue(active.promise);
+    mocks.runInteractiveCell.mockImplementation((_cell, _values, _version, activeSignal: AbortSignal) => {
+      signal = activeSignal;
+      return active.promise;
+    });
     setManifestCells([
       makeCell({
         run: 'reactive',
@@ -576,6 +652,8 @@ describe('InteractiveCell', () => {
     await waitFor(() => expect(mocks.runInteractiveCell).toHaveBeenCalledOnce());
     fireEvent.input(screen.getByLabelText('label'), { target: { value: 'discarded' } });
     rendered.unmount();
+
+    expect(signal?.aborted).toBe(true);
 
     active.reject(new Error('failure after unmount'));
     await active.promise.catch(() => undefined);
@@ -1325,6 +1403,82 @@ describe('TableOutput', () => {
     expect(screen.getByText('Rows 0-0 of 0')).toBeVisible();
     expect(screen.getByTestId('table-prev')).toBeDisabled();
     expect(screen.getByTestId('table-next')).toBeDisabled();
+  });
+
+  it('resets page, sort, and copy state at a new execution result boundary', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(globalThis.navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText }
+    });
+    const firstResult = {};
+    const secondResult = {};
+    const rows = Array.from({ length: 30 }, (_, index) => [30 - index, `row ${index + 1}`]);
+    const { rerender } = render(
+      <TableOutput
+        resultIdentity={firstResult}
+        table={{
+          kind: 'table',
+          columns: [
+            { key: 'score', label: 'Score' },
+            { key: 'label', label: 'Label' }
+          ],
+          rows
+        }}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Score' }));
+    fireEvent.click(screen.getByTestId('table-next'));
+    fireEvent.click(screen.getByTestId('table-next'));
+    fireEvent.click(screen.getByTestId('table-copy-csv'));
+    await waitFor(() => expect(screen.getByTestId('table-copy-status')).toBeVisible());
+
+    rerender(
+      <TableOutput
+        resultIdentity={secondResult}
+        table={{
+          kind: 'table',
+          columns: [{ key: 'replacement', label: 'Replacement' }],
+          rows: [['a'], ['b'], ['c']]
+        }}
+      />
+    );
+
+    expect(screen.getByText('Rows 1-3 of 3')).toBeVisible();
+    expect(screen.getByRole('columnheader', { name: 'Replacement' })).toHaveAttribute('aria-sort', 'none');
+    expect(screen.queryByTestId('table-copy-status')).not.toBeInTheDocument();
+  });
+
+  it('stores a clamped page and clears removed-column sort for an unchanged result identity', () => {
+    const resultIdentity = {};
+    const columns = [{ key: 'score', label: 'Score' }];
+    const largeRows = Array.from({ length: 30 }, (_, index) => [index]);
+    const { rerender } = render(
+      <TableOutput resultIdentity={resultIdentity} table={{ kind: 'table', columns, rows: largeRows }} />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Score' }));
+    fireEvent.click(screen.getByTestId('table-next'));
+    fireEvent.click(screen.getByTestId('table-next'));
+    expect(screen.getByText('Rows 21-30 of 30')).toBeVisible();
+
+    rerender(
+      <TableOutput
+        resultIdentity={resultIdentity}
+        table={{ kind: 'table', columns: [{ key: 'other', label: 'Other' }], rows: [[1], [2], [3]] }}
+      />
+    );
+    expect(screen.getByText('Rows 1-3 of 3')).toBeVisible();
+    expect(screen.getByRole('columnheader', { name: 'Other' })).toHaveAttribute('aria-sort', 'none');
+
+    rerender(
+      <TableOutput
+        resultIdentity={resultIdentity}
+        table={{ kind: 'table', columns: [{ key: 'other', label: 'Other' }], rows: largeRows }}
+      />
+    );
+    expect(screen.getByText('Rows 1-10 of 30')).toBeVisible();
   });
 
   it('sorts and formats table values without mutating rows', () => {

--- a/tests/unit/components.test.tsx
+++ b/tests/unit/components.test.tsx
@@ -51,6 +51,8 @@ const {
 } = await import('../../packages/oxiquill/src/components/doc-runtime/MermaidDiagram');
 const {
   default: OutputRenderer,
+  htmlArtifactContentSecurityPolicy,
+  htmlArtifactSrcdoc,
   imageArtifactSource,
   LazyChartOutput
 } = await import('../../packages/oxiquill/src/components/doc-runtime/OutputRenderer');
@@ -1190,7 +1192,9 @@ describe('OutputRenderer', () => {
 
     const htmlOutputs = screen.getAllByTestId('html-output');
     expect(htmlOutputs[0]).toHaveAttribute('sandbox', '');
-    expect(htmlOutputs[0]).toHaveAttribute('srcdoc', '<strong>safe</strong>');
+    expect(htmlOutputs[0]).toHaveAttribute('referrerpolicy', 'no-referrer');
+    expect(htmlOutputs[0].getAttribute('srcdoc')).toContain('<strong>safe</strong>');
+    expect(htmlOutputs[0].getAttribute('srcdoc')).toContain(htmlArtifactContentSecurityPolicy);
     expect(htmlOutputs[0]).toHaveAttribute('title', 'HTML preview');
     expect(htmlOutputs[1]).toHaveAttribute('title', 'HTML output');
     expect(screen.getByTestId('image-output')).toHaveAttribute('src', `data:image/png;base64,${pngBase64}`);
@@ -1247,6 +1251,15 @@ describe('OutputRenderer', () => {
         })
       )
     ).toBe(`data:image/png;base64,${pngBase64}`);
+  });
+
+  it('places the restrictive HTML policy before author markup', () => {
+    const srcdoc = htmlArtifactSrcdoc('<script>parent.document.body.dataset.compromised = "true"</script>');
+    expect(srcdoc.indexOf('Content-Security-Policy')).toBeLessThan(srcdoc.indexOf('<script>'));
+    expect(srcdoc).toContain("default-src 'none'");
+    expect(srcdoc).toContain('img-src data: blob:');
+    expect(srcdoc).toContain("form-action 'none'");
+    expect(srcdoc).toContain('<meta name="referrer" content="no-referrer">');
   });
 
   it('isolates renderer failures and resets the boundary for replacement output', async () => {
@@ -1651,6 +1664,26 @@ describe('TableOutput', () => {
     expect(tableToCsv([{ key: 'a', label: 'A' }], [[1, 2]], labelsForLanguage('ja'))).toEqual({
       ok: false,
       error: '1 行目のセルは 2 個ですが、1 個である必要があります。'
+    });
+  });
+
+  it('escapes spreadsheet formula prefixes in string headers and cells without changing negative numbers', () => {
+    expect(
+      tableToCsv(
+        [
+          { key: 'formula', label: '=Formula' },
+          { key: 'number', label: 'Number' }
+        ],
+        [
+          ['=SUM(A1:A2)', -42],
+          ['  +1', '-42'],
+          ['\t@command', true],
+          ['\r-control', null]
+        ]
+      )
+    ).toEqual({
+      ok: true,
+      csv: ["'=Formula,Number", "'=SUM(A1:A2),-42", "'  +1,'-42", "'\t@command,true", '"\'\r-control",'].join('\n')
     });
   });
 });

--- a/tests/unit/components.test.tsx
+++ b/tests/unit/components.test.tsx
@@ -376,6 +376,24 @@ describe('InteractiveCell', () => {
     expect(mocks.runInteractiveCell).toHaveBeenCalledWith(expect.anything(), { count: -1.5 }, 'v1', expect.anything());
   });
 
+  it('supports keyboard stepping for numeric spinbuttons and clamps at their bounds', () => {
+    setManifestCells([
+      makeCell({
+        inputs: [{ name: 'count', type: 'integer', label: 'count', value: 1, min: 0, max: 2, step: 1, options: [] }]
+      })
+    ]);
+
+    render(<InteractiveCell cellId="cell-one" />);
+    const input = screen.getByRole('spinbutton', { name: 'count' });
+    fireEvent.keyDown(input, { key: 'ArrowUp' });
+    expect(input).toHaveValue('2');
+    expect(input).toHaveAttribute('aria-valuenow', '2');
+    fireEvent.keyDown(input, { key: 'ArrowUp' });
+    expect(input).toHaveValue('2');
+    fireEvent.keyDown(input, { key: 'ArrowDown' });
+    expect(input).toHaveValue('1');
+  });
+
   it('formats range labels from fractional and exponential steps', () => {
     setManifestCells([
       makeCell({

--- a/tests/unit/components.test.tsx
+++ b/tests/unit/components.test.tsx
@@ -940,6 +940,21 @@ describe('lazy chart renderer', () => {
 
     expect(screen.queryByTestId('doc-plot')).not.toBeInTheDocument();
   });
+
+  it('retries a transient chart-module load failure', async () => {
+    const load = vi
+      .fn<() => Promise<typeof chartOutputModule>>()
+      .mockRejectedValueOnce(new Error('temporary chart failure'))
+      .mockResolvedValue(chartOutputModule);
+
+    render(<LazyChartOutput spec={spec} load={load} />);
+    await waitFor(() => expect(screen.getByRole('alert')).toHaveTextContent('temporary chart failure'));
+
+    fireEvent.click(screen.getByRole('button', { name: 'Retry chart rendering' }));
+
+    await waitFor(() => expect(screen.getByTestId('doc-plot')).toBeVisible());
+    expect(load).toHaveBeenCalledTimes(2);
+  });
 });
 
 describe('ChartOutput options', () => {
@@ -1036,7 +1051,7 @@ describe('ChartOutput options', () => {
       xAxis: { type: 'category', data: ['x'] },
       yAxis: { type: 'category', data: ['y'] },
       dataZoom: undefined,
-      visualMap: expect.objectContaining({ calculable: true }),
+      visualMap: expect.objectContaining({ calculable: true, min: 5, max: 5 }),
       series: [{ type: 'heatmap', data: [['x', 'y', 5]] }]
     });
 
@@ -1057,6 +1072,24 @@ describe('ChartOutput options', () => {
       })
     ).toMatchObject({
       legend: { top: 4 }
+    });
+
+    expect(
+      chartSpecToEChartsOptions({
+        kind: 'heatmap',
+        data: [
+          [0, 0, -8],
+          [1, 0, -2]
+        ]
+      })
+    ).toMatchObject({ visualMap: { min: -8, max: -2 } });
+    expect(chartSpecToEChartsOptions({ kind: 'heatmap', data: [] })).toMatchObject({
+      visualMap: { min: 0, max: 1 }
+    });
+    expect(chartSpecToEChartsOptions({ kind: 'line', series: [] }, 'dark')).toMatchObject({
+      textStyle: { color: '#f3f4f6' },
+      xAxis: { axisLabel: { color: '#d1d5db' } },
+      yAxis: { axisLabel: { color: '#d1d5db' } }
     });
   });
 
@@ -1084,6 +1117,56 @@ describe('ChartOutput options', () => {
     expect(chartDataSummary({ kind: 'bar', categories: [], series: [] }, labelsForLanguage('en'))).toBe(
       'The chart contains no data.'
     );
+    expect(
+      chartDataSummary(
+        {
+          kind: 'heatmap',
+          data: [
+            [-2, 10, -8],
+            [4, 20, 6]
+          ]
+        },
+        labelsForLanguage('en')
+      )
+    ).toBe('Series: 1. Data items: 2. X range: -2–4. Y range: 10–20. Heat value range: -8–6.');
+    expect(
+      chartDataSummary(
+        {
+          kind: 'heatmap',
+          xCategories: ['x'],
+          yCategories: ['y'],
+          data: [['x', 'y', 3]]
+        },
+        labelsForLanguage('ja')
+      )
+    ).toBe('系列数: 1。データ数: 1。ヒート値の範囲: 3。');
+
+    const exactLimit = Array.from({ length: 100_000 }, (_, index) => [index, -index] as const);
+    expect(chartDataSummary({ kind: 'line', series: [{ points: exactLimit }] }, labelsForLanguage('en'))).toContain(
+      'Data items: 100000. X range: 0–99,999. Y range: -99,999–0.'
+    );
+  });
+
+  it('recreates charts with legible options when the Starlight theme changes', async () => {
+    const ChartOutput = chartOutputModule.default;
+    render(
+      <ChartOutput
+        artifact={{ kind: 'chart', spec: { kind: 'line', title: 'Theme chart', series: [] } }}
+        idPrefix="theme-chart"
+        labels={labelsForLanguage('en')}
+      />
+    );
+
+    await waitFor(() => expect(mocks.echartsInit).toHaveBeenCalledTimes(1));
+    expect(screen.getByTestId('doc-plot')).toHaveAttribute('data-chart-theme', 'light');
+    expect(mocks.echartsInit.mock.calls[0]?.[1]).toMatchObject({ textStyle: { color: '#111827' } });
+
+    document.documentElement.dataset.theme = 'dark';
+
+    await waitFor(() => expect(mocks.echartsInit).toHaveBeenCalledTimes(2));
+    expect(screen.getByTestId('doc-plot')).toHaveAttribute('data-chart-theme', 'dark');
+    expect(mocks.echartsInit.mock.calls[1]?.[1]).toMatchObject({ textStyle: { color: '#f3f4f6' } });
+    expect(mocks.chart.dispose).toHaveBeenCalled();
   });
 });
 

--- a/tests/unit/doc-runtime-core.test.mjs
+++ b/tests/unit/doc-runtime-core.test.mjs
@@ -559,6 +559,12 @@ describe('doc runtime core', () => {
     );
     expect(generateRustLib([])).toContain('let _: Value = serde_json::from_str(inputs_json)');
     expect(generateRustLib([])).toContain('unknown Rust cell');
+    const plainRustLib = generateRustLib([{ id: 'plain', source: 'println!("ok");', inputs: [] }]);
+    expect(plainRustLib).not.toContain('fn bound_output_artifact');
+    expect(plainRustLib).not.toContain('fn push(&mut self, artifact: OutputArtifact)');
+    expect(plainRustLib).not.toContain('OutputArtifact::Json(json)');
+    expect(plainRustLib).not.toContain('OutputArtifact::Html(html)');
+    expect(plainRustLib).not.toContain('OutputArtifact::Image(image)');
     expect(generateRustLib([rustCell])).toContain('enum OutputArtifact');
     expect(generateRustLib([rustCell])).toContain('outputs: Vec<OutputArtifact>');
     expect(generateRustLib([preludeCell])).toContain('Json(JsonArtifact)');

--- a/tests/unit/doc-runtime-core.test.mjs
+++ b/tests/unit/doc-runtime-core.test.mjs
@@ -225,6 +225,21 @@ describe('doc runtime core', () => {
       'inputs.count.value'
     ],
     [
+      'integer default below portable domain',
+      '//| id: bad\n//| inputs:\n//|   count: { type: integer, value: -2147483649 }',
+      'inputs.count.value'
+    ],
+    [
+      'integer maximum above portable domain',
+      '//| id: bad\n//| inputs:\n//|   count: { type: integer, value: 1, max: 2147483648 }',
+      'inputs.count.max'
+    ],
+    [
+      'integer step above portable domain',
+      '//| id: bad\n//| inputs:\n//|   count: { type: integer, value: 1, step: 2147483648 }',
+      'inputs.count.step'
+    ],
+    [
       'empty options',
       '//| id: bad\n//| inputs:\n//|   mode: { type: select, value: a, options: [] }',
       'inputs.mode.options'
@@ -450,8 +465,8 @@ describe('doc runtime core', () => {
     expect(rustFunctionName('cell-id')).toBe('run_cell_id');
     expect(rustFunctionName('page__cell')).toBe('run_page_cell');
     expect(rustReaderName({ type: 'checkbox' })).toBe('read_bool');
-    expect(rustReaderName({ type: 'integer' })).toBe('read_u32');
-    expect(rustReaderName({ type: 'text', integer: true })).toBe('read_u32');
+    expect(rustReaderName({ type: 'integer' })).toBe('read_i32');
+    expect(rustReaderName({ type: 'text', integer: true })).toBe('read_i32');
     expect(rustReaderName({ type: 'range' })).toBe('read_f64');
     expect(rustReaderName({ type: 'number' })).toBe('read_f64');
     expect(rustReaderName({ type: 'text' })).toBe('read_string');
@@ -520,6 +535,9 @@ describe('doc runtime core', () => {
       inputs: []
     };
     expect(generateRustReaders([rustCell])).toContain('fn read_f64');
+    expect(generateRustReaders([rustCell])).toContain('fn read_i32');
+    expect(generateRustReaders([rustCell])).toContain('.and_then(Value::as_i64)');
+    expect(generateHaskellMain([rustCell])).toContain('value >= -2147483648 && value <= 2147483647');
     expect(generateRustFunction(rustCell)).toContain('macro_rules! println');
     expect(generateRustFunction(rustCell)).toContain('macro_rules! emit_line_plot');
     expect(generateRustFunction(rustCell)).not.toContain('macro_rules! emit_json');

--- a/tests/unit/doc-runtime-core.test.mjs
+++ b/tests/unit/doc-runtime-core.test.mjs
@@ -427,7 +427,7 @@ describe('doc runtime core', () => {
       'doc-rust'
     );
     expect(() => packageNameFromCargoToml('[dependencies]\nserde = "1"\n', '/repo/crates/bad/Cargo.toml')).toThrow(
-      'missing [package] name'
+      'missing a [package] table'
     );
     expect(() =>
       helperCratesFromManifests(
@@ -437,7 +437,7 @@ describe('doc runtime core', () => {
         ],
         { rustCellsDir: '/repo/.oxiquill/rust-cells' }
       )
-    ).toThrow('Duplicate helper crate');
+    ).toThrow('use duplicate package name');
   });
 
   it('generates manifest files and Rust support code', () => {

--- a/tests/unit/doc-runtime-core.test.mjs
+++ b/tests/unit/doc-runtime-core.test.mjs
@@ -555,7 +555,7 @@ describe('doc runtime core', () => {
     expect(generateRustFunction(chartCell)).toContain('macro_rules! emit_heatmap');
     expect(generateRustFunction(rustCell)).toContain('Ok(finish_cell_output');
     expect(generateRustFunction({ id: 'plain', source: 'let value = 1;', inputs: [] })).toContain(
-      'let __stdout = std::cell::RefCell::new(String::new());'
+      'let __stdout = std::cell::RefCell::new(BoundedText::new());'
     );
     expect(generateRustLib([])).toContain('let _: Value = serde_json::from_str(inputs_json)');
     expect(generateRustLib([])).toContain('unknown Rust cell');
@@ -564,8 +564,9 @@ describe('doc runtime core', () => {
     expect(generateRustLib([preludeCell])).toContain('Json(JsonArtifact)');
     expect(generateRustLib([preludeCell])).toContain('Html(HtmlArtifact)');
     expect(generateRustLib([preludeCell])).toContain('Image(ImageArtifact)');
-    expect(generateRustLib([preludeCell])).not.toContain('fn ensure_output_size');
-    expect(generateRustLib([tableCell])).toContain('row_count > 10_000');
+    expect(generateRustLib([preludeCell])).toContain('struct OutputCollector');
+    expect(generateRustLib([preludeCell])).toContain('fn serialize_cell_output');
+    expect(generateRustLib([tableCell])).toContain('row_count > 10000');
     expect(generateRustLib([preludeCell])).toContain('fn json_artifact');
     expect(generateRustLib([preludeCell])).toContain('fn html_artifact');
     expect(generateRustLib([preludeCell])).toContain('fn image_artifact');
@@ -577,7 +578,9 @@ describe('doc runtime core', () => {
     expect(generateRustLib([chartCell])).toContain('fn bar_chart_spec');
     expect(generateRustLib([chartCell])).toContain('fn histogram_chart_spec');
     expect(generateRustLib([chartCell])).toContain('fn heatmap_chart_spec');
+    expect(generateRustLib([chartCell])).toContain('fn ensure_chart_data_limit');
     expect(generateRustLib([rustCell])).toContain('generated_plot_cell_runs');
+    expect(generateRustLib([rustCell])).toContain('generated_output_limits_are_enforced');
 
     const haskellCell = {
       id: 'haskell-cell',

--- a/tests/unit/doc-runtime-service.test.mjs
+++ b/tests/unit/doc-runtime-service.test.mjs
@@ -92,6 +92,31 @@ function createMemoryFileSystem(initialFiles = {}) {
     mkdir: async (directory) => {
       directories.add(memoryPath(directory));
     },
+    link: async (sourcePath, targetPath) => {
+      const normalizedSource = memoryPath(sourcePath);
+      const normalizedTarget = memoryPath(targetPath);
+      if (files.has(normalizedTarget)) {
+        const error = new Error(`exists ${targetPath}`);
+        error.code = 'EEXIST';
+        throw error;
+      }
+      ensureParents(normalizedTarget);
+      files.set(normalizedTarget, Buffer.from(files.get(normalizedSource)));
+    },
+    open: async (filePath) => {
+      const normalizedPath = memoryPath(filePath);
+      ensureParents(normalizedPath);
+      files.set(normalizedPath, Buffer.alloc(0));
+      return {
+        close: async () => {},
+        write: async (buffer, offset, length) => {
+          const bytes = Buffer.from(buffer).subarray(offset, offset + length);
+          files.set(normalizedPath, Buffer.concat([files.get(normalizedPath), bytes]));
+          writes.push(normalizedPath);
+          return { bytesWritten: bytes.length };
+        }
+      };
+    },
     readFile: async (filePath, encoding) => {
       const content = files.get(memoryPath(filePath));
       if (!content) {
@@ -712,6 +737,7 @@ describe('doc runtime service', () => {
     globalThis.fetch = async (url) => {
       requestedUrls.push(String(url));
       return {
+        body: ReadableStream.from([Buffer.from('root bytes')]),
         ok: true,
         arrayBuffer: async () => Buffer.from('root bytes')
       };

--- a/tests/unit/haskell-worker.test.ts
+++ b/tests/unit/haskell-worker.test.ts
@@ -4,6 +4,7 @@ import {
   createHaskellCellResult,
   createHaskellModuleLoader,
   createHaskellWorkerRequestHandler,
+  createOutputCapture,
   fetchHaskellModule,
   fetchHaskellRuntimeStatus,
   parseHaskellRuntimeStatus,
@@ -104,6 +105,34 @@ describe('haskell worker helpers', () => {
     await expect(loadModule('hash-two')).rejects.toThrow('generated runtime is stale');
     expect(fetchStatus).toHaveBeenCalledTimes(2);
     expect(fetchModule).toHaveBeenCalledOnce();
+  });
+
+  it('bounds WASI bytes while callbacks run and flushes a split UTF-8 sequence safely', () => {
+    const exact = createOutputCapture(6);
+    exact.file.fd_write(new TextEncoder().encode('日本'));
+    expect(exact.take()).toEqual({ value: '日本', truncated: false });
+
+    const oversized = createOutputCapture(6);
+    oversized.file.fd_write(new TextEncoder().encode('日本語'));
+    expect(oversized.take()).toEqual({ value: '日本', truncated: true });
+
+    const splitSequence = createOutputCapture(4);
+    splitSequence.file.fd_write(new TextEncoder().encode('日本'));
+    expect(splitSequence.take()).toEqual({ value: '…', truncated: true });
+  });
+
+  it('marks bounded Haskell stream artifacts as truncated', () => {
+    expect(
+      createHaskellCellResult({
+        stdout: 'bounded stdout',
+        stdoutTruncated: true,
+        stderr: 'bounded stderr',
+        stderrTruncated: true
+      }).outputs
+    ).toEqual([
+      { kind: 'text', stream: 'stdout', content: 'bounded stdout', truncated: true },
+      { kind: 'text', stream: 'stderr', content: 'bounded stderr', truncated: true }
+    ]);
   });
 
   it('parses and validates generated Haskell runtime status', () => {

--- a/tests/unit/helper-crates.test.mjs
+++ b/tests/unit/helper-crates.test.mjs
@@ -37,7 +37,7 @@ describe('helper crate manifests', () => {
     ];
 
     expect(() => helperCratesFromManifests(manifests, { rustCellsDir: '/repo/.oxiquill/rust-cells' })).toThrow(
-      'Helper crate manifests /repo/crates/z/Cargo.toml and /repo/crates/a/Cargo.toml use duplicate package name "same".'
+      'Helper crate manifests /repo/crates/a/Cargo.toml and /repo/crates/z/Cargo.toml use duplicate package name "same".'
     );
 
     const crates = helperCratesFromManifests(

--- a/tests/unit/helper-crates.test.mjs
+++ b/tests/unit/helper-crates.test.mjs
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import {
+  helperCratesFromManifests,
+  packageNameFromCargoToml
+} from '../../packages/oxiquill/src/generator/doc-runtime-core.mjs';
+
+const manifestPath = '/repo/crates/helper/Cargo.toml';
+
+describe('helper crate manifests', () => {
+  it.each([
+    ['standard table', '[package]\nname = "standard-crate"\n', 'standard-crate'],
+    ['comments and whitespace', '  # package metadata\n[ package ]\n name = "spaced_crate" # name\n', 'spaced_crate'],
+    ['literal string', "[package]\nname = 'literal-crate'\n", 'literal-crate'],
+    ['dotted key', "package.name = 'dotted-crate'\n", 'dotted-crate'],
+    ['Unicode alphanumeric characters', '[package]\nname = "補助-crate٢"\n', '補助-crate٢']
+  ])('parses a Cargo manifest using %s syntax', (_label, source, expected) => {
+    expect(packageNameFromCargoToml(source, manifestPath)).toBe(expected);
+  });
+
+  it.each([
+    ['malformed TOML', '[package\nname = "broken"\n', 'contains malformed TOML'],
+    ['missing package table', '[dependencies]\nserde = "1"\n', 'is missing a [package] table'],
+    ['missing name', '[package]\nversion = "1.0.0"\n', 'is missing package.name'],
+    ['non-string name', '[package]\nname = 42\n', 'has a non-string package.name'],
+    ['empty name', '[package]\nname = ""\n', 'has invalid package.name ""'],
+    ['invalid name', '[package]\nname = "invalid name"\n', 'has invalid package.name "invalid name"']
+  ])('reports a path-qualified diagnostic for %s', (_label, source, message) => {
+    expect(() => packageNameFromCargoToml(source, manifestPath)).toThrow(
+      `Helper crate manifest ${manifestPath} ${message}`
+    );
+  });
+
+  it('sorts crates and reports both paths for duplicate effective names', () => {
+    const manifests = [
+      { content: 'package.name = "same"\n', manifestPath: '/repo/crates/z/Cargo.toml' },
+      { content: '[package]\nname = "same"\n', manifestPath: '/repo/crates/a/Cargo.toml' }
+    ];
+
+    expect(() => helperCratesFromManifests(manifests, { rustCellsDir: '/repo/.oxiquill/rust-cells' })).toThrow(
+      'Helper crate manifests /repo/crates/z/Cargo.toml and /repo/crates/a/Cargo.toml use duplicate package name "same".'
+    );
+
+    const crates = helperCratesFromManifests(
+      [
+        { content: '[package]\nname = "z-crate"\n', manifestPath: '/repo/crates/z/Cargo.toml' },
+        { content: 'package.name = "a-crate"\n', manifestPath: '/repo/crates/a/Cargo.toml' }
+      ],
+      { rustCellsDir: '/repo/.oxiquill/rust-cells' }
+    );
+    expect(Array.from(crates.keys())).toEqual(['a-crate', 'z-crate']);
+  });
+});

--- a/tests/unit/interactive-cell-model.test.ts
+++ b/tests/unit/interactive-cell-model.test.ts
@@ -7,6 +7,7 @@ import {
   labelsForLanguage,
   localeFromLanguage,
   parseNumericInput,
+  stepNumericInputValue,
   shouldShowInputControls,
   shouldShowRunButton
 } from '../../packages/oxiquill/src/lib/doc-runtime/interactive-cell-model';
@@ -126,5 +127,13 @@ describe('interactive cell model', () => {
     expect(parseNumericInput(integerInput, '-2147483649')).toEqual({ valid: false, validation: 'integer' });
     expect(parseNumericInput(integerInput, '2147483648')).toEqual({ valid: false, validation: 'integer' });
     expect(parseNumericInput(integerInput, '9007199254740992')).toEqual({ valid: false, validation: 'integer' });
+  });
+
+  it('steps numeric spinbuttons without floating-point artifacts and clamps their range', () => {
+    const numberInput: InputSpec = { ...textInput, type: 'number', value: 0.2, min: 0, max: 0.3, step: 0.1 };
+
+    expect(stepNumericInputValue(numberInput, 0.2, 1)).toBe(0.3);
+    expect(stepNumericInputValue(numberInput, 0.3, 1)).toBe(0.3);
+    expect(stepNumericInputValue(numberInput, 0, -1)).toBe(0);
   });
 });

--- a/tests/unit/interactive-cell-model.test.ts
+++ b/tests/unit/interactive-cell-model.test.ts
@@ -6,6 +6,7 @@ import {
   initialValues,
   labelsForLanguage,
   localeFromLanguage,
+  parseNumericInput,
   shouldShowInputControls,
   shouldShowRunButton
 } from '../../packages/oxiquill/src/lib/doc-runtime/interactive-cell-model';
@@ -31,6 +32,10 @@ describe('interactive cell model', () => {
     expect(formatInputValue(2.345)).toBe('2.35');
     expect(formatInputValue(true)).toBe('true');
     expect(formatInputValue('raw')).toBe('raw');
+    expect(formatInputValue(1.2, 0.001)).toBe('1.200');
+    expect(formatInputValue(0.0000003, 1e-7)).toBe('0.0000003');
+    expect(formatInputValue(0.0075, 2.5e-3)).toBe('0.0075');
+    expect(formatInputValue(0.30000000000000004, 0.1)).toBe('0.3');
   });
 
   it('describes run controls and idle output messages', () => {
@@ -91,5 +96,35 @@ describe('interactive cell model', () => {
     expect(coerceInputValue({ ...textInput, type: 'number' }, '12')).toBe(12);
     expect(coerceInputValue({ ...textInput, type: 'integer' }, '12')).toBe(12);
     expect(coerceInputValue(textInput, '12')).toBe('12');
+    expect(coerceInputValue({ ...textInput, type: 'number' }, '')).toBe('');
+  });
+
+  it('parses only complete finite numeric values that satisfy every constraint', () => {
+    const numberInput: InputSpec = {
+      ...textInput,
+      type: 'number',
+      value: 1,
+      min: -2,
+      max: 2,
+      step: 0.5
+    };
+
+    expect(parseNumericInput(numberInput, '')).toEqual({ valid: false, validation: 'required' });
+    expect(parseNumericInput(numberInput, '-')).toEqual({ valid: false, validation: 'number' });
+    expect(parseNumericInput(numberInput, '1e309')).toEqual({ valid: false, validation: 'number' });
+    expect(parseNumericInput(numberInput, '-2.5')).toEqual({ valid: false, validation: 'rangeUnderflow' });
+    expect(parseNumericInput(numberInput, '2.5')).toEqual({ valid: false, validation: 'rangeOverflow' });
+    expect(parseNumericInput(numberInput, '1.25')).toEqual({ valid: false, validation: 'stepMismatch' });
+    expect(parseNumericInput(numberInput, '-1.5')).toEqual({ valid: true, value: -1.5 });
+  });
+
+  it('enforces the portable signed 32-bit integer domain', () => {
+    const integerInput: InputSpec = { ...textInput, type: 'integer', value: 0 };
+
+    expect(parseNumericInput(integerInput, '-2147483648')).toEqual({ valid: true, value: -2147483648 });
+    expect(parseNumericInput(integerInput, '2147483647')).toEqual({ valid: true, value: 2147483647 });
+    expect(parseNumericInput(integerInput, '-2147483649')).toEqual({ valid: false, validation: 'integer' });
+    expect(parseNumericInput(integerInput, '2147483648')).toEqual({ valid: false, validation: 'integer' });
+    expect(parseNumericInput(integerInput, '9007199254740992')).toEqual({ valid: false, validation: 'integer' });
   });
 });

--- a/tests/unit/interactive-cell-scheduler.test.ts
+++ b/tests/unit/interactive-cell-scheduler.test.ts
@@ -27,14 +27,16 @@ afterEach(() => {
 });
 
 describe('interactive cell request scheduler', () => {
-  it('keeps one active request and only the newest delayed replacement', async () => {
+  it('actively cancels obsolete work and starts only the newest delayed replacement', async () => {
     vi.useFakeTimers();
     const executions: number[] = [];
     const pending: Array<ReturnType<typeof createDeferred<string>>> = [];
+    const signals: AbortSignal[] = [];
     const onResult = vi.fn();
     const scheduler = createLatestRequestScheduler<number, string>({
-      execute: (request) => {
+      execute: (request, signal) => {
         executions.push(request);
+        signals.push(signal);
         const deferred = createDeferred<string>();
         pending.push(deferred);
         return deferred.promise;
@@ -52,12 +54,8 @@ describe('interactive cell request scheduler', () => {
     }
     await vi.advanceTimersByTimeAsync(150);
 
-    expect(executions).toEqual([0]);
-
-    pending[0].resolve('obsolete');
-    await flushMicrotasks();
-
     expect(executions).toEqual([0, 10]);
+    expect(signals[0].aborted).toBe(true);
     expect(onResult).not.toHaveBeenCalled();
 
     pending[1].resolve('latest');
@@ -65,6 +63,10 @@ describe('interactive cell request scheduler', () => {
 
     expect(onResult).toHaveBeenCalledOnce();
     expect(onResult).toHaveBeenCalledWith('latest');
+
+    pending[0].resolve('obsolete');
+    await flushMicrotasks();
+    expect(onResult).toHaveBeenCalledOnce();
   });
 
   it('suppresses stale failures and continues with the ready replacement', async () => {
@@ -121,6 +123,20 @@ describe('interactive cell request scheduler', () => {
     expect(execute).toHaveBeenCalledOnce();
     expect(onError).not.toHaveBeenCalled();
     expect(onResult).not.toHaveBeenCalled();
+  });
+
+  it('reports external cancellation separately from execution failures', async () => {
+    const onCancelled = vi.fn();
+    const scheduler = createLatestRequestScheduler<string, string>({
+      execute: async () => Promise.reject(new DOMException('cancelled', 'AbortError')),
+      onCancelled,
+      onError: vi.fn(),
+      onResult: vi.fn(),
+      onScheduled: vi.fn()
+    });
+
+    scheduler.schedule('request');
+    await vi.waitFor(() => expect(onCancelled).toHaveBeenCalledOnce());
   });
 
   it('shares successful and failed executions by key', async () => {

--- a/tests/unit/mocks/external-runtime.ts
+++ b/tests/unit/mocks/external-runtime.ts
@@ -6,7 +6,11 @@ export const chart = {
   setOption: vi.fn()
 };
 
-export const echartsInit = vi.fn(() => chart);
+export const echartsInit = vi.fn((element?: HTMLElement, theme?: unknown) => {
+  void element;
+  void theme;
+  return chart;
+});
 export const echartsUse = vi.fn();
 export const mermaidInitialize = vi.fn();
 export const mermaidRender = vi.fn();

--- a/tests/unit/output-artifact-validation.test.ts
+++ b/tests/unit/output-artifact-validation.test.ts
@@ -247,12 +247,25 @@ describe('output artifact validation', () => {
   });
 
   it.each([
-    { kind: 'line', series: [{ name: 'line', points: [[0, 1]] }] },
-    { kind: 'scatter', series: [{ points: [['x', 1]] }] },
-    { kind: 'area', series: [{ points: [[0, 'y']] }] },
-    { kind: 'bar', categories: ['a'], series: [{ name: 'bar', values: [1] }] },
-    { kind: 'histogram', bins: [[0, 1, 2]] },
-    { kind: 'heatmap', xCategories: ['x'], yCategories: ['y'], data: [['x', 'y', 3]] }
+    { kind: 'line', xType: 'value', yType: 'log', series: [{ name: 'line', points: [[0, 1]] }] },
+    { kind: 'scatter', xType: 'category', yType: 'log', series: [{ points: [['x', 1]] }] },
+    { kind: 'area', xType: 'value', yType: 'category', series: [{ points: [[0, 'y']] }] },
+    {
+      kind: 'bar',
+      xType: 'category',
+      yType: 'log',
+      categories: ['a'],
+      series: [{ name: 'bar', values: [1] }]
+    },
+    { kind: 'histogram', xType: 'category', yType: 'log', bins: [[0, 1, 2]] },
+    {
+      kind: 'heatmap',
+      xType: 'category',
+      yType: 'category',
+      xCategories: ['x'],
+      yCategories: ['y'],
+      data: [['x', 'y', 3]]
+    }
   ])('validates the $kind chart variant', (spec) => {
     expect(
       validArtifact({
@@ -261,8 +274,6 @@ describe('output artifact validation', () => {
           title: 'Chart',
           xLabel: 'x',
           yLabel: 'y',
-          xType: 'value',
-          yType: 'log',
           legend: true,
           tooltip: false,
           dataZoom: true,
@@ -270,6 +281,96 @@ describe('output artifact validation', () => {
         }
       })
     ).toMatchObject({ kind: 'chart', spec: { kind: spec.kind } });
+  });
+
+  it('validates coordinates against the effective value, log, time, and category axes', () => {
+    expect(
+      validationError({
+        kind: 'chart',
+        spec: { kind: 'line', series: [{ points: [['implicit category', 1]] }] }
+      })
+    ).toContain('finite number');
+    expect(
+      validationError({
+        kind: 'chart',
+        spec: { kind: 'line', xType: 'log', series: [{ points: [[0, 1]] }] }
+      })
+    ).toContain('strictly positive');
+    expect(
+      validArtifact({
+        kind: 'chart',
+        spec: {
+          kind: 'line',
+          xType: 'time',
+          series: [
+            {
+              points: [
+                ['2026-08-30T12:34:56Z', 1],
+                [1_788_092_096_000, 2]
+              ]
+            }
+          ]
+        }
+      })
+    ).toMatchObject({ kind: 'chart' });
+    expect(
+      validationError({
+        kind: 'chart',
+        spec: { kind: 'line', xType: 'time', series: [{ points: [['2026-02-30T00:00:00Z', 1]] }] }
+      })
+    ).toContain('ISO-8601');
+    expect(
+      validationError({
+        kind: 'chart',
+        spec: {
+          kind: 'heatmap',
+          xCategories: ['known'],
+          yCategories: ['row'],
+          data: [['unknown', 'row', 1]]
+        }
+      })
+    ).toContain('declared categories');
+    expect(
+      validArtifact({
+        kind: 'chart',
+        spec: {
+          kind: 'heatmap',
+          xCategories: ['first', 'second'],
+          yCategories: ['row'],
+          data: [[1, 0, 1]]
+        }
+      })
+    ).toMatchObject({ kind: 'chart' });
+  });
+
+  it('accepts empty and equal chart domains while rejecting invalid histogram bins and axis overrides', () => {
+    expect(validArtifact({ kind: 'chart', spec: { kind: 'line', series: [] } })).toMatchObject({ kind: 'chart' });
+    expect(
+      validArtifact({
+        kind: 'chart',
+        spec: {
+          kind: 'line',
+          series: [
+            {
+              points: [
+                [2, 3],
+                [2, 3]
+              ]
+            }
+          ]
+        }
+      })
+    ).toMatchObject({ kind: 'chart' });
+    expect(validationError({ kind: 'chart', spec: { kind: 'histogram', bins: [[1, 1, 2]] } })).toContain('smaller');
+    expect(
+      validationError({ kind: 'chart', spec: { kind: 'bar', xType: 'value', categories: [], series: [] } })
+    ).toContain('always category');
+    expect(
+      validationError({
+        kind: 'chart',
+        spec: { kind: 'heatmap', xType: 'log', xCategories: [], data: [] }
+      })
+    ).toContain('always category');
   });
 
   it('rejects malformed and excessive chart data', () => {

--- a/tests/unit/output-artifact-validation.test.ts
+++ b/tests/unit/output-artifact-validation.test.ts
@@ -579,4 +579,21 @@ describe('output artifact validation', () => {
     expect(siblings[0]).toMatchObject({ status: 'error' });
     expect(siblings[1]).toMatchObject({ status: 'valid', artifact: { content: 'still usable' } });
   });
+
+  it('bounds discriminator values and cumulative validation diagnostics', () => {
+    const invalidKind = 'unsupported-'.repeat(outputArtifactLimits.bytesPerDiagnostic);
+    const results = validateOutputArtifacts([
+      ...Array.from({ length: outputArtifactLimits.artifactsPerRun - 1 }, () => ({ kind: invalidKind })),
+      { kind: 'text', stream: 'stdout', content: 'valid sibling' }
+    ]);
+    const diagnosticBytes = results.reduce(
+      (total, result) => total + (result.status === 'error' ? new TextEncoder().encode(result.message).byteLength : 0),
+      0
+    );
+
+    expect(diagnosticBytes).toBeLessThanOrEqual(outputArtifactLimits.diagnosticBytesPerRun);
+    expect(results[0]).toMatchObject({ status: 'error' });
+    if (results[0]?.status === 'error') expect(results[0].message).not.toContain(invalidKind);
+    expect(results.at(-1)).toMatchObject({ status: 'valid', artifact: { content: 'valid sibling' } });
+  });
 });

--- a/tests/unit/output-artifacts.test.ts
+++ b/tests/unit/output-artifacts.test.ts
@@ -135,13 +135,13 @@ describe('output artifact normalization', () => {
       )
     ).toEqual({
       stdout: '',
-      stderr: 'explicit',
+      stderr: 'from outputs',
       plots: [],
       outputs: [{ kind: 'text', stream: 'stderr', content: 'from outputs' }]
     });
   });
 
-  it('keeps explicit legacy aliases when outputs are already present', () => {
+  it('replaces explicit legacy aliases with equivalents derived from bounded outputs', () => {
     expect(
       publicResult(
         normalizeCellExecutionResult({
@@ -152,9 +152,9 @@ describe('output artifact normalization', () => {
         })
       )
     ).toEqual({
-      stdout: 'alias',
-      value: null,
-      plots: [{ kind: 'line', x_label: 'old-x', y_label: 'old-y', points: [[0, 0]] }],
+      stdout: '',
+      value: { from: 'outputs' },
+      plots: [],
       outputs: [{ kind: 'json', value: { from: 'outputs' } }]
     });
   });

--- a/tests/unit/output-limits.test.ts
+++ b/tests/unit/output-limits.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import {
+  boundedErrorMessage,
+  createBoundedTextAccumulator,
+  outputArtifactLimits,
+  truncateUtf8,
+  utf8ByteLength
+} from '../../packages/oxiquill/src/lib/doc-runtime/output-limits.mjs';
+import { boundWorkerResult, workerResultByteLength } from '../../packages/oxiquill/src/lib/doc-runtime/worker-output';
+
+describe('producer output limits', () => {
+  it('retains exact UTF-8 stream limits and marks over-limit output without retaining later chunks', () => {
+    const exact = createBoundedTextAccumulator(8, '\n');
+    exact.append('abc');
+    exact.append('defg');
+    expect(exact.take()).toEqual({ value: 'abc\ndefg', truncated: false });
+
+    const oversized = createBoundedTextAccumulator(8, '\n');
+    oversized.append('abc');
+    oversized.append('defgh');
+    oversized.append('discarded');
+    expect(oversized.take()).toEqual({ value: 'abc\nd…', truncated: true });
+    expect(utf8ByteLength(oversized.take().value)).toBe(8);
+
+    expect(truncateUtf8('日本語', 6)).toEqual({ value: '日…', byteLength: 6, truncated: true });
+  });
+
+  it('bounds worker errors by UTF-8 bytes', () => {
+    const exact = 'x'.repeat(outputArtifactLimits.bytesPerError);
+    expect(boundedErrorMessage(new Error(exact))).toBe(exact);
+
+    const oversized = boundedErrorMessage('界'.repeat(outputArtifactLimits.bytesPerError));
+    expect(utf8ByteLength(oversized)).toBeLessThanOrEqual(outputArtifactLimits.bytesPerError);
+    expect(oversized.endsWith('…')).toBe(true);
+  });
+
+  it('normalizes aliases from bounded outputs and caps complete worker responses', () => {
+    const rawAlias = 'x'.repeat(outputArtifactLimits.workerResponseBytes + 1);
+    const boundedAlias = boundWorkerResult({
+      stdout: rawAlias,
+      outputs: [{ kind: 'text', stream: 'stdout', content: 'bounded' }]
+    });
+    expect(boundedAlias.stdout).toBe('bounded');
+    expect(boundedAlias.outputs).toEqual([{ kind: 'text', stream: 'stdout', content: 'bounded' }]);
+
+    const oneMiB = 'x'.repeat(outputArtifactLimits.bytesPerTextJsonOrHtml);
+    const boundedResponse = boundWorkerResult({
+      outputs: Array.from({ length: 20 }, () => ({ kind: 'text', stream: 'display', content: oneMiB }))
+    });
+    expect(workerResultByteLength(boundedResponse)).toBeLessThanOrEqual(outputArtifactLimits.workerResponseBytes);
+    expect(boundedResponse.outputs?.at(-1)).toMatchObject({ kind: '__oxiquill_error' });
+  });
+
+  it('keeps valid siblings while replacing invalid producer artifacts with bounded diagnostics', () => {
+    const result = boundWorkerResult({
+      outputs: [
+        { kind: 'x'.repeat(outputArtifactLimits.bytesPerDiagnostic * 2) },
+        { kind: 'text', stream: 'stdout', content: 'still usable' }
+      ]
+    });
+    expect(result.outputs?.[0]).toMatchObject({ kind: '__oxiquill_error' });
+    expect(utf8ByteLength(String((result.outputs?.[0] as { message?: string }).message))).toBeLessThanOrEqual(
+      outputArtifactLimits.bytesPerDiagnostic
+    );
+    expect(result.outputs?.[1]).toMatchObject({ kind: 'text', content: 'still usable' });
+    expect(result.stdout).toBe('still usable');
+  });
+});

--- a/tests/unit/project-config.test.mjs
+++ b/tests/unit/project-config.test.mjs
@@ -147,17 +147,109 @@ describe('Oxiquill project configuration', () => {
     expect(() => resolveProject({ root, paths: { docsDir: new URL('https://example.com/docs') } })).toThrow(
       'docsDir must be a path string or file URL'
     );
-    expect(() => resolveProject({ root, astro: { cacheDir: '.' } })).toThrow(
-      'cacheDir must resolve to a directory inside'
-    );
+    expect(() => resolveProject({ root, astro: { cacheDir: '.' } })).toThrow('Unsafe path cacheDir');
     expect(() => resolveProject({ root, paths: { publicAssetsDir: '..' } })).toThrow(
-      'paths.publicAssetsDir must resolve to a directory inside'
+      'Unsafe path paths.publicAssetsDir'
     );
     expect(() => resolveProject({ root, paths: { downloadCacheDir: '../shared-cache' } })).toThrow(
-      'paths.downloadCacheDir must resolve to a directory inside'
+      'Unsafe path paths.downloadCacheDir'
     );
     expect(() => resolveProject({ root, paths: { downloadCacheDir: '.oxiquill/downloads' } })).toThrow(
-      'paths.downloadCacheDir must resolve outside directories removed by oxiquill clean'
+      'cacheDir at ' + path.join(root, '.oxiquill') + ': it is an ancestor of paths.downloadCacheDir'
+    );
+  });
+
+  it.each([
+    {
+      conflict: 'docsDir (authored documentation input)',
+      name: 'cacheDir containing docsDir',
+      options: { astro: { cacheDir: 'content' } },
+      relationship: 'an ancestor of'
+    },
+    {
+      conflict: 'cratesDir (authored helper-crate input)',
+      name: 'outDir equal to cratesDir',
+      options: { astro: { outDir: 'crates' } },
+      relationship: 'equal to'
+    },
+    {
+      conflict: 'paths.publicDir (authored public asset root)',
+      name: 'outDir equal to publicDir',
+      options: { astro: { outDir: 'public' } },
+      relationship: 'equal to'
+    },
+    {
+      conflict: '.git (Git repository metadata)',
+      name: 'cacheDir equal to Git metadata',
+      options: { astro: { cacheDir: '.git' } },
+      relationship: 'equal to'
+    },
+    {
+      conflict: 'node_modules (installed package dependencies)',
+      name: 'outDir equal to installed dependencies',
+      options: { astro: { outDir: 'node_modules' } },
+      relationship: 'equal to'
+    },
+    {
+      conflict: 'docsDir (authored documentation input)',
+      name: 'outDir nested below docsDir',
+      options: { astro: { outDir: 'content/docs/generated' } },
+      relationship: 'a descendant of'
+    },
+    {
+      conflict: 'paths.frameworkRoot (Oxiquill framework input)',
+      name: 'outDir containing frameworkRoot',
+      options: { astro: { outDir: 'packages' }, paths: { frameworkRoot: 'packages/oxiquill' } },
+      relationship: 'an ancestor of'
+    },
+    {
+      conflict: 'paths.downloadCacheDir (persistent verified download cache)',
+      name: 'outDir containing the persistent cache',
+      options: { astro: { outDir: '.cache' } },
+      relationship: 'an ancestor of'
+    }
+  ])('rejects $name', ({ conflict, options, relationship }) => {
+    const root = path.resolve('/repo');
+    expect(() => resolveProject({ root, ...options })).toThrow(
+      expect.objectContaining({
+        message: expect.stringContaining(`${relationship} ${conflict}`)
+      })
+    );
+  });
+
+  it('rejects equal and nested cleanup roots with absolute diagnostics', () => {
+    const root = path.resolve('/repo');
+    expect(() => resolveProject({ astro: { cacheDir: 'dist', outDir: 'dist' }, root })).toThrow(
+      `cacheDir at ${path.join(root, 'dist')}: it is equal to outDir`
+    );
+    expect(() => resolveProject({ astro: { cacheDir: 'build', outDir: 'build/site' }, root })).toThrow(
+      `cacheDir at ${path.join(root, 'build')}: it is an ancestor of outDir`
+    );
+  });
+
+  it('rejects equality and nesting between generated subdirectory roles', () => {
+    const root = path.resolve('/repo');
+    expect(() => resolveProject({ paths: { generatedDir: 'rust-cells' }, root })).toThrow(
+      'paths.generatedDir at ' + path.join(root, '.oxiquill/rust-cells') + ': it is equal to paths.rustCellsDir'
+    );
+    expect(() =>
+      resolveProject({ paths: { licensesPublicDir: 'runtime', rustWasmPublicDir: 'runtime/rust' }, root })
+    ).toThrow('paths.licensesPublicDir at ' + path.join(root, 'public/oxiquill/runtime'));
+  });
+
+  it('keeps the intentional publicAssetsDir child relationship but rejects equality with publicDir', () => {
+    const root = path.resolve('/repo');
+    expect(() => resolveProject({ root })).not.toThrow();
+    expect(() => resolveProject({ paths: { publicAssetsDir: '.' }, root })).toThrow(
+      `Unsafe path paths.publicAssetsDir at ${path.join(root, 'public')}`
+    );
+  });
+
+  it('protects the selected Astro config from ancestor cleanup roots', () => {
+    const root = path.resolve('/repo');
+    const configFile = path.join(root, 'config/astro.custom.mjs');
+    expect(() => resolveProject({ astro: { outDir: 'config' }, configFile, root })).toThrow(
+      `outDir at ${path.join(root, 'config')}: it is an ancestor of configFile (selected Astro configuration) at ${configFile}`
     );
   });
 
@@ -229,10 +321,11 @@ describe('Oxiquill project configuration', () => {
   });
 });
 
-function resolveProject({ astro = {}, paths = {}, python = {}, root }) {
+function resolveProject({ astro = {}, configFile, paths = {}, python = {}, root }) {
   return resolveOxiquillProjectConfig({
     astroConfig: { root, ...astro },
     astroExplicitFields: ['root', ...Object.keys(astro)],
+    configFile,
     cwd: root,
     integrationMetadata: createOxiquillIntegrationMetadata({ paths, python })
   });

--- a/tests/unit/project-config.test.mjs
+++ b/tests/unit/project-config.test.mjs
@@ -81,6 +81,21 @@ describe('Oxiquill project configuration', () => {
     expect(normalizePath('C:\\workspace\\public\\oxiquill assets')).toBe('C:/workspace/public/oxiquill assets');
   });
 
+  it.runIf(process.platform === 'win32')('treats Windows path casing aliases as the same resolved path', async () => {
+    const root = await temporaryDirectory();
+    expect(() =>
+      resolveProject({
+        astro: { cacheDir: 'STATE', outDir: 'OUTPUT' },
+        paths: { cacheDir: 'state' },
+        root
+      })
+    ).not.toThrow();
+    expect(() => resolveProject({ astro: { cacheDir: 'OUTPUT', outDir: 'output' }, root })).toThrow(
+      'it is equal to outDir'
+    );
+    expect(() => resolveProject({ astro: { outDir: '.GIT' }, root })).toThrow('Git repository metadata');
+  });
+
   it('accepts equivalent explicit paths and reports conflicting fields', () => {
     const root = path.resolve('/repo');
     expect(() =>

--- a/tests/unit/pyodide-assets.test.mjs
+++ b/tests/unit/pyodide-assets.test.mjs
@@ -1,6 +1,6 @@
 // @vitest-environment node
 
-import { mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { mkdtemp, mkdir, readFile, readdir, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
@@ -10,11 +10,13 @@ import {
   fetchPyodidePackage,
   hashBytes,
   PYODIDE_DOWNLOAD_ATTEMPTS,
+  PYODIDE_DOWNLOAD_CONCURRENCY,
   PYODIDE_REQUEST_TIMEOUT_MS,
   requiredPyodideFiles,
   resolvePyodideRuntimeInputs
 } from '../../packages/oxiquill/src/generator/doc-runtime-service.mjs';
 import { cleanOxiquillWorkspace } from '../../packages/oxiquill/src/generator/clean.mjs';
+import { defaultFileSystem } from '../../packages/oxiquill/src/generator/doc-runtime/file-system.mjs';
 
 const fixtureVersion = 'test-release';
 const temporaryDirectories = [];
@@ -78,29 +80,334 @@ describe('Pyodide assets', () => {
 
     await cleanOxiquillWorkspace({ paths });
     expect(await readFile(path.join(cacheDirectory, 'root.whl'))).toEqual(fixture.wheels['root.whl']);
+    await rm(paths.pyodidePublicDir, { force: true, recursive: true });
+    const offlineFetch = vi.fn();
     await expect(
       copyPyodideAssets({
         ...options,
-        fetchImplementation: vi.fn(),
+        fetchImplementation: offlineFetch,
         pythonOptions: { offline: true }
       })
     ).resolves.toBe(true);
+    expect(offlineFetch).not.toHaveBeenCalled();
 
     await writeFile(path.join(cacheDirectory, 'root.whl'), 'corrupt');
     await rm(paths.pyodidePublicDir, { force: true, recursive: true });
+    const corruptOfflineFetch = vi.fn();
     await expect(
       copyPyodideAssets({
         ...options,
-        fetchImplementation: vi.fn(),
+        fetchImplementation: corruptOfflineFetch,
         pythonOptions: { offline: true }
       })
     ).rejects.toThrow(
       `Offline Pyodide cache miss for "root.whl" at "${path.join(cacheDirectory, 'root.whl')}"; expected sha256 ${hashBytes(fixture.wheels['root.whl'])}.`
     );
+    expect(corruptOfflineFetch).not.toHaveBeenCalled();
 
     await expect(copyPyodideAssets(options)).resolves.toBe(true);
     expect(fetchImplementation).toHaveBeenCalledTimes(3);
     expect(await readFile(path.join(cacheDirectory, 'root.whl'))).toEqual(fixture.wheels['root.whl']);
+  });
+
+  it('streams chunks to disk while incrementally verifying the checksum', async () => {
+    const fixture = await createInstalledPyodide();
+    const paths = createDocRuntimePaths(fixture.workspaceRoot);
+    const runtimeInputs = await resolvePyodideRuntimeInputs({
+      requestedPackages: ['dependency'],
+      resolvePackageJson: fixture.resolvePackageJson
+    });
+    const chunks = [Buffer.from('dependency '), Buffer.from('wheel')];
+    const writeSizes = [];
+    const fileSystem = {
+      ...defaultFileSystem,
+      open: async (...arguments_) => {
+        const fileHandle = await defaultFileSystem.open(...arguments_);
+        return {
+          close: () => fileHandle.close(),
+          write: async (buffer, offset, length) => {
+            writeSizes.push(length);
+            return fileHandle.write(buffer, offset, length);
+          }
+        };
+      }
+    };
+    const arrayBuffer = vi.fn(() => {
+      throw new Error('arrayBuffer must not be used while staging assets');
+    });
+
+    await expect(
+      copyPyodideAssets({
+        fetchImplementation: async () => ({
+          arrayBuffer,
+          body: ReadableStream.from(chunks),
+          ok: true,
+          status: 200,
+          statusText: 'ok'
+        }),
+        fileSystem,
+        paths,
+        requestedPackages: ['dependency'],
+        runtimeInputs
+      })
+    ).resolves.toBe(true);
+
+    expect(writeSizes).toEqual(chunks.map((chunk) => chunk.length));
+    expect(arrayBuffer).not.toHaveBeenCalled();
+    expect(await readFile(path.join(paths.pyodidePublicDir, 'dependency.whl'))).toEqual(Buffer.concat(chunks));
+  });
+
+  it('never exceeds the shared download concurrency limit', async () => {
+    const fixture = await createInstalledPyodide({ packageCount: PYODIDE_DOWNLOAD_CONCURRENCY * 2 + 1 });
+    const paths = createDocRuntimePaths(fixture.workspaceRoot);
+    const packageNames = Object.keys(fixture.wheels).map((fileName) => path.basename(fileName, '.whl'));
+    const runtimeInputs = await resolvePyodideRuntimeInputs({
+      requestedPackages: packageNames,
+      resolvePackageJson: fixture.resolvePackageJson
+    });
+    let active = 0;
+    let maximumActive = 0;
+    let releaseFirstBatch;
+    const firstBatch = new Promise((resolve) => {
+      releaseFirstBatch = resolve;
+    });
+
+    await copyPyodideAssets({
+      fetchImplementation: async (url) => {
+        active += 1;
+        maximumActive = Math.max(maximumActive, active);
+        if (active === PYODIDE_DOWNLOAD_CONCURRENCY) releaseFirstBatch();
+        const content = fixture.wheels[path.basename(new URL(url).pathname)];
+        return {
+          body: {
+            async *[Symbol.asyncIterator]() {
+              try {
+                await firstBatch;
+                yield content;
+              } finally {
+                active -= 1;
+              }
+            }
+          },
+          ok: true,
+          status: 200,
+          statusText: 'ok'
+        };
+      },
+      paths,
+      requestedPackages: packageNames,
+      runtimeInputs
+    });
+
+    expect(maximumActive).toBe(PYODIDE_DOWNLOAD_CONCURRENCY);
+    expect(active).toBe(0);
+  });
+
+  it('retries a mid-stream failure from a clean temporary file', async () => {
+    const fixture = await createInstalledPyodide();
+    const paths = createDocRuntimePaths(fixture.workspaceRoot);
+    const runtimeInputs = await resolvePyodideRuntimeInputs({
+      requestedPackages: ['dependency'],
+      resolvePackageJson: fixture.resolvePackageJson
+    });
+    const fetchImplementation = vi
+      .fn()
+      .mockResolvedValueOnce(streamFailureResponse(Buffer.from('partial')))
+      .mockResolvedValueOnce(response(fixture.wheels['dependency.whl']));
+
+    await expect(
+      copyPyodideAssets({
+        fetchImplementation,
+        paths,
+        requestedPackages: ['dependency'],
+        runtimeInputs,
+        sleep: async () => {}
+      })
+    ).resolves.toBe(true);
+
+    expect(fetchImplementation).toHaveBeenCalledTimes(2);
+    expect(await readFile(path.join(paths.pyodidePublicDir, 'dependency.whl'))).toEqual(
+      fixture.wheels['dependency.whl']
+    );
+    await expectNoTemporaryCacheFiles(paths, runtimeInputs);
+  });
+
+  it('cleans partial files after a terminal mid-stream failure', async () => {
+    const fixture = await createInstalledPyodide();
+    const paths = createDocRuntimePaths(fixture.workspaceRoot);
+    const runtimeInputs = await resolvePyodideRuntimeInputs({
+      requestedPackages: ['dependency'],
+      resolvePackageJson: fixture.resolvePackageJson
+    });
+    const fetchImplementation = vi.fn(async () => streamFailureResponse(Buffer.from('partial')));
+
+    await expect(
+      copyPyodideAssets({
+        fetchImplementation,
+        paths,
+        requestedPackages: ['dependency'],
+        runtimeInputs,
+        sleep: async () => {}
+      })
+    ).rejects.toThrow('stream interrupted');
+
+    expect(fetchImplementation).toHaveBeenCalledTimes(PYODIDE_DOWNLOAD_ATTEMPTS);
+    await expectNoTemporaryCacheFiles(paths, runtimeInputs);
+    await expect(readFile(path.join(paths.pyodidePublicDir, 'dependency.whl'))).rejects.toMatchObject({
+      code: 'ENOENT'
+    });
+  });
+
+  it('aborts active streams and removes every partial file before rejecting', async () => {
+    const fixture = await createInstalledPyodide();
+    const paths = createDocRuntimePaths(fixture.workspaceRoot);
+    const runtimeInputs = await resolvePyodideRuntimeInputs({
+      requestedPackages: ['dependency'],
+      resolvePackageJson: fixture.resolvePackageJson
+    });
+    const controller = new AbortController();
+    let streamStarted;
+    const started = new Promise((resolve) => {
+      streamStarted = resolve;
+    });
+    const fetchImplementation = vi.fn(async (_url, { signal }) => ({
+      body: {
+        async *[Symbol.asyncIterator]() {
+          yield Buffer.from('partial');
+          streamStarted();
+          await new Promise((_resolve, reject) => {
+            signal.addEventListener('abort', () => reject(signal.reason ?? new Error('request aborted')), {
+              once: true
+            });
+          });
+        }
+      },
+      ok: true,
+      status: 200,
+      statusText: 'ok'
+    }));
+    const operation = copyPyodideAssets({
+      fetchImplementation,
+      paths,
+      requestedPackages: ['dependency'],
+      runtimeInputs,
+      signal: controller.signal,
+      sleep: async () => {}
+    });
+
+    await started;
+    controller.abort(new Error('generation cancelled'));
+    await expect(operation).rejects.toThrow('generation cancelled');
+
+    expect(fetchImplementation).toHaveBeenCalledOnce();
+    await expectNoTemporaryCacheFiles(paths, runtimeInputs);
+  });
+
+  it('publishes one verified cache entry when concurrent writers target the same asset', async () => {
+    const fixture = await createInstalledPyodide();
+    const paths = createDocRuntimePaths(fixture.workspaceRoot);
+    let runtimeInputs = await resolvePyodideRuntimeInputs({
+      requestedPackages: ['dependency'],
+      resolvePackageJson: fixture.resolvePackageJson
+    });
+    runtimeInputs = { ...runtimeInputs, coreAssets: [] };
+    let fetches = 0;
+    let releaseWriters;
+    const writersReady = new Promise((resolve) => {
+      releaseWriters = resolve;
+    });
+    let publicationConflicts = 0;
+    const fileSystem = {
+      ...defaultFileSystem,
+      link: async (...arguments_) => {
+        try {
+          await defaultFileSystem.link(...arguments_);
+        } catch (error) {
+          if (error?.code === 'EEXIST') publicationConflicts += 1;
+          throw error;
+        }
+      }
+    };
+    const fetchPackage = async () => {
+      fetches += 1;
+      if (fetches === 2) releaseWriters();
+      return {
+        body: {
+          async *[Symbol.asyncIterator]() {
+            await writersReady;
+            yield fixture.wheels['dependency.whl'];
+          }
+        }
+      };
+    };
+    const options = {
+      fetchPackage,
+      fileSystem,
+      paths,
+      requestedPackages: ['dependency'],
+      runtimeInputs
+    };
+
+    const results = await Promise.all([copyPyodideAssets(options), copyPyodideAssets(options)]);
+
+    expect(results).toEqual([expect.any(Boolean), expect.any(Boolean)]);
+    expect(results).toContain(true);
+    const cachePath = path.join(
+      paths.downloadCacheDir,
+      'pyodide',
+      fixtureVersion,
+      runtimeInputs.lockSha256,
+      'dependency.whl'
+    );
+    expect(await readFile(cachePath)).toEqual(fixture.wheels['dependency.whl']);
+    expect(publicationConflicts).toBeGreaterThanOrEqual(1);
+    await expectNoTemporaryCacheFiles(paths, runtimeInputs);
+  });
+
+  it('copies assets in deterministic order after out-of-order downloads', async () => {
+    const fixture = await createInstalledPyodide({ packageCount: 3 });
+    const paths = createDocRuntimePaths(fixture.workspaceRoot);
+    const packageNames = Object.keys(fixture.wheels).map((fileName) => path.basename(fileName, '.whl'));
+    let runtimeInputs = await resolvePyodideRuntimeInputs({
+      requestedPackages: packageNames,
+      resolvePackageJson: fixture.resolvePackageJson
+    });
+    runtimeInputs = { ...runtimeInputs, coreAssets: [] };
+    const completed = [];
+    const copied = [];
+    const delays = new Map(packageNames.map((name, index) => [name, (packageNames.length - index) * 5]));
+    const fileSystem = {
+      ...defaultFileSystem,
+      copyFile: async (sourcePath, targetPath) => {
+        if (targetPath.startsWith(paths.pyodidePublicDir)) copied.push(path.basename(targetPath, '.whl'));
+        return defaultFileSystem.copyFile(sourcePath, targetPath);
+      }
+    };
+    const fetchImplementation = vi.fn(async (url) => {
+      const fileName = path.basename(new URL(url).pathname);
+      const packageName = path.basename(fileName, '.whl');
+      return {
+        body: {
+          async *[Symbol.asyncIterator]() {
+            await new Promise((resolve) => setTimeout(resolve, delays.get(packageName)));
+            completed.push(packageName);
+            yield fixture.wheels[fileName];
+          }
+        },
+        ok: true,
+        status: 200,
+        statusText: 'ok'
+      };
+    });
+    const options = { fetchImplementation, fileSystem, paths, requestedPackages: packageNames, runtimeInputs };
+
+    await expect(copyPyodideAssets(options)).resolves.toBe(true);
+    expect(completed).not.toEqual(packageNames);
+    expect(copied).toEqual(packageNames);
+
+    copied.length = 0;
+    await expect(copyPyodideAssets({ ...options, fetchImplementation: vi.fn() })).resolves.toBe(false);
+    expect(copied).toEqual([]);
   });
 
   it('rejects a hash mismatch without publishing or caching the invalid wheel', async () => {
@@ -201,22 +508,36 @@ describe('Pyodide assets', () => {
   });
 });
 
-async function createInstalledPyodide() {
+async function createInstalledPyodide({ packageCount } = {}) {
   const workspaceRoot = await mkdtemp(path.join(tmpdir(), 'oxiquill-pyodide-'));
   temporaryDirectories.push(workspaceRoot);
   const packageDirectory = path.join(workspaceRoot, 'installed', 'pyodide');
   await mkdir(packageDirectory, { recursive: true });
 
-  const wheels = {
-    'dependency.whl': Buffer.from('dependency wheel'),
-    'root.whl': Buffer.from('root wheel')
-  };
+  const wheels = packageCount
+    ? Object.fromEntries(
+        Array.from({ length: packageCount }, (_value, index) => [
+          `package-${index}.whl`,
+          Buffer.from(`package ${index} wheel`)
+        ])
+      )
+    : {
+        'dependency.whl': Buffer.from('dependency wheel'),
+        'root.whl': Buffer.from('root wheel')
+      };
   const lockFile = {
     info: { version: fixtureVersion },
-    packages: {
-      dependency: packageEntry('dependency', 'dependency.whl', wheels['dependency.whl']),
-      root: packageEntry('root', 'root.whl', wheels['root.whl'], ['dependency'])
-    }
+    packages: packageCount
+      ? Object.fromEntries(
+          Object.entries(wheels).map(([fileName, content]) => {
+            const name = path.basename(fileName, '.whl');
+            return [name, packageEntry(name, fileName, content)];
+          })
+        )
+      : {
+          dependency: packageEntry('dependency', 'dependency.whl', wheels['dependency.whl']),
+          root: packageEntry('root', 'root.whl', wheels['root.whl'], ['dependency'])
+        }
   };
   await Promise.all([
     writeFile(path.join(packageDirectory, 'package.json'), JSON.stringify({ version: fixtureVersion })),
@@ -248,9 +569,33 @@ function packageEntry(name, fileName, content, depends = []) {
 
 function response(content, status = 200, statusText = 'ok') {
   return {
+    body: content === undefined ? undefined : ReadableStream.from([content]),
     arrayBuffer: async () => content,
     ok: status >= 200 && status < 300,
     status,
     statusText
   };
+}
+
+function streamFailureResponse(partialContent) {
+  return {
+    body: {
+      async *[Symbol.asyncIterator]() {
+        yield partialContent;
+        throw new Error('stream interrupted');
+      }
+    },
+    ok: true,
+    status: 200,
+    statusText: 'ok'
+  };
+}
+
+async function expectNoTemporaryCacheFiles(paths, runtimeInputs) {
+  const cacheDirectory = path.join(paths.downloadCacheDir, 'pyodide', fixtureVersion, runtimeInputs.lockSha256);
+  const entries = await readdir(cacheDirectory).catch((error) => {
+    if (error?.code === 'ENOENT') return [];
+    throw error;
+  });
+  expect(entries.filter((entry) => entry.includes('.tmp-') || entry.includes('.corrupt-'))).toEqual([]);
 }

--- a/tests/unit/pyodide-assets.test.mjs
+++ b/tests/unit/pyodide-assets.test.mjs
@@ -303,6 +303,30 @@ describe('Pyodide assets', () => {
     await expectNoTemporaryCacheFiles(paths, runtimeInputs);
   });
 
+  it('does not start work when the operation is already aborted', async () => {
+    const fixture = await createInstalledPyodide();
+    const paths = createDocRuntimePaths(fixture.workspaceRoot);
+    let runtimeInputs = await resolvePyodideRuntimeInputs({
+      requestedPackages: ['dependency'],
+      resolvePackageJson: fixture.resolvePackageJson
+    });
+    runtimeInputs = { ...runtimeInputs, coreAssets: [] };
+    const controller = new AbortController();
+    controller.abort('cancelled');
+    const fetchImplementation = vi.fn();
+
+    await expect(
+      copyPyodideAssets({
+        fetchImplementation,
+        paths,
+        requestedPackages: ['dependency'],
+        runtimeInputs,
+        signal: controller.signal
+      })
+    ).rejects.toThrow('operation aborted');
+    expect(fetchImplementation).not.toHaveBeenCalled();
+  });
+
   it('publishes one verified cache entry when concurrent writers target the same asset', async () => {
     const fixture = await createInstalledPyodide();
     const paths = createDocRuntimePaths(fixture.workspaceRoot);
@@ -488,6 +512,26 @@ describe('Pyodide assets', () => {
       })
     ).rejects.toThrow('after 1 attempt(s): 404 not found');
     expect(permanentFetch).toHaveBeenCalledOnce();
+
+    await expect(
+      fetchPyodidePackage('legacy-response.whl', {
+        fetchImplementation: async () => ({
+          arrayBuffer: async () => Buffer.from('legacy response'),
+          ok: true
+        }),
+        packageBaseUrl: 'https://packages.example/'
+      })
+    ).resolves.toEqual(Buffer.from('legacy response'));
+
+    await expect(
+      fetchPyodidePackage('mixed-chunks.whl', {
+        fetchImplementation: async () => ({
+          body: ReadableStream.from(['mixed ', Uint8Array.from(Buffer.from('chunks')).buffer]),
+          ok: true
+        }),
+        packageBaseUrl: 'https://packages.example/'
+      })
+    ).resolves.toEqual(Buffer.from('mixed chunks'));
 
     const hangingFetch = vi.fn(
       async (_url, { signal }) =>

--- a/tests/unit/pyodide-assets.test.mjs
+++ b/tests/unit/pyodide-assets.test.mjs
@@ -206,10 +206,11 @@ describe('Pyodide assets', () => {
   it('retries a mid-stream failure from a clean temporary file', async () => {
     const fixture = await createInstalledPyodide();
     const paths = createDocRuntimePaths(fixture.workspaceRoot);
-    const runtimeInputs = await resolvePyodideRuntimeInputs({
+    let runtimeInputs = await resolvePyodideRuntimeInputs({
       requestedPackages: ['dependency'],
       resolvePackageJson: fixture.resolvePackageJson
     });
+    runtimeInputs = { ...runtimeInputs, coreAssets: [] };
     const fetchImplementation = vi
       .fn()
       .mockResolvedValueOnce(streamFailureResponse(Buffer.from('partial')))
@@ -221,7 +222,12 @@ describe('Pyodide assets', () => {
         paths,
         requestedPackages: ['dependency'],
         runtimeInputs,
-        sleep: async () => {}
+        sleep: async () => {
+          const cacheDirectory = path.join(paths.downloadCacheDir, 'pyodide', fixtureVersion, runtimeInputs.lockSha256);
+          expect((await readdir(cacheDirectory)).filter((entry) => entry.startsWith('dependency.whl.tmp-'))).toEqual(
+            []
+          );
+        }
       })
     ).resolves.toBe(true);
 

--- a/tests/unit/python-worker.test.ts
+++ b/tests/unit/python-worker.test.ts
@@ -10,6 +10,10 @@ import {
   resolvePyodideUrls
 } from '../../packages/oxiquill/src/lib/doc-runtime/python-worker';
 import { toOutputArtifacts } from '../../packages/oxiquill/src/lib/doc-runtime/python-cell-result';
+import {
+  createBoundedTextAccumulator,
+  outputArtifactLimits
+} from '../../packages/oxiquill/src/lib/doc-runtime/output-limits.mjs';
 import type { RuntimeWorkerRequest, RuntimeWorkerResponse } from '../../packages/oxiquill/src/lib/doc-runtime/types';
 
 function createDeferred() {
@@ -253,6 +257,39 @@ describe('python rich display support', () => {
     expect(pythonDisplaySupportCode).toContain('def display_table');
     expect(pythonDisplaySupportCode).toContain('_repr_html_');
     expect(pythonDisplaySupportCode).toContain('_repr_png_');
+    expect(pythonDisplaySupportCode).toContain(`__oxiquill_artifact_limit = ${outputArtifactLimits.artifactsPerRun}`);
+    expect(pythonDisplaySupportCode).toContain(
+      `__oxiquill_output_byte_limit = ${outputArtifactLimits.validatedBytesPerRun}`
+    );
+    expect(pythonDisplaySupportCode).toContain('def __oxiquill_append_output');
+  });
+
+  it('retains exact Python callback output and truncates over-limit stdout and stderr', () => {
+    const stdout = createBoundedTextAccumulator(outputArtifactLimits.bytesPerStream, '\n');
+    stdout.append('x'.repeat(outputArtifactLimits.bytesPerStream));
+    expect(stdout.take()).toEqual({ value: 'x'.repeat(outputArtifactLimits.bytesPerStream), truncated: false });
+
+    const stderr = createBoundedTextAccumulator(outputArtifactLimits.bytesPerStream, '\n');
+    stderr.append('x'.repeat(outputArtifactLimits.bytesPerStream + 1));
+    const bounded = stderr.take();
+    expect(new TextEncoder().encode(bounded.value).byteLength).toBeLessThanOrEqual(outputArtifactLimits.bytesPerStream);
+    expect(bounded.truncated).toBe(true);
+  });
+
+  it('marks bounded Python stream artifacts as truncated', () => {
+    const result = createPythonCellResult({
+      stdout: 'bounded stdout',
+      stdoutTruncated: true,
+      stderr: 'bounded stderr',
+      stderrTruncated: true,
+      value: null,
+      plots: [],
+      displayOutputs: []
+    });
+    expect(result.outputs).toEqual([
+      { kind: 'text', stream: 'stdout', content: 'bounded stdout', truncated: true },
+      { kind: 'text', stream: 'stderr', content: 'bounded stderr', truncated: true }
+    ]);
   });
 
   it('configures matplotlib and captures figures as image artifacts', () => {

--- a/tests/unit/python-worker.test.ts
+++ b/tests/unit/python-worker.test.ts
@@ -5,6 +5,7 @@ import {
   createPythonWorkerRequestHandler,
   createSerialRequestQueue,
   importPyodideModule,
+  pythonIntegerConversionCode,
   pythonDisplaySupportCode,
   resolvePyodideUrls
 } from '../../packages/oxiquill/src/lib/doc-runtime/python-worker';
@@ -81,6 +82,13 @@ describe('python worker request queue', () => {
     await flushMicrotasks();
 
     expect(events).toEqual(['start:first', 'start:second', 'finish:second']);
+  });
+});
+
+describe('python input conversion', () => {
+  it('converts validated integer bindings to Python ints without interpolating arbitrary names', () => {
+    expect(pythonIntegerConversionCode('negative_offset')).toBe('negative_offset = int(negative_offset)');
+    expect(() => pythonIntegerConversionCode('value; import os')).toThrow('Invalid integer input name');
   });
 });
 

--- a/tests/unit/repository-license.test.mjs
+++ b/tests/unit/repository-license.test.mjs
@@ -1,0 +1,50 @@
+// @vitest-environment node
+
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const repositoryRoot = fileURLToPath(new URL('../..', import.meta.url));
+const packageRoot = path.join(repositoryRoot, 'packages/oxiquill');
+
+describe('repository license contract', () => {
+  it('declares the same dual-license choice in root and package metadata', async () => {
+    const rootPackage = await readJson(path.join(repositoryRoot, 'package.json'));
+    const publishedPackage = await readJson(path.join(packageRoot, 'package.json'));
+
+    expect(rootPackage.license).toBe('MIT OR Apache-2.0');
+    expect(publishedPackage.license).toBe('MIT OR Apache-2.0');
+  });
+
+  it('links both complete license texts from the canonical entry point', async () => {
+    const canonicalLicense = await readFile(path.join(repositoryRoot, 'LICENSE'), 'utf8');
+    const mitLicense = await readFile(path.join(repositoryRoot, 'LICENSE-MIT'), 'utf8');
+    const apacheLicense = await readFile(path.join(repositoryRoot, 'LICENSE-APACHE'), 'utf8');
+
+    expect(canonicalLicense).toContain('[MIT License](LICENSE-MIT)');
+    expect(canonicalLicense).toContain('[Apache License, Version 2.0](LICENSE-APACHE)');
+    expect(canonicalLicense).toContain('SPDX-License-Identifier: MIT OR Apache-2.0');
+    expect(mitLicense).toContain('MIT License');
+    expect(apacheLicense).toContain('Apache License\n                           Version 2.0');
+    await expect(readFile(path.join(packageRoot, 'LICENSE-MIT'), 'utf8')).resolves.toBe(mitLicense);
+    await expect(readFile(path.join(packageRoot, 'LICENSE-APACHE'), 'utf8')).resolves.toBe(apacheLicense);
+  });
+
+  it('ships both license texts and keeps public and contribution prose consistent', async () => {
+    const publishedPackage = await readJson(path.join(packageRoot, 'package.json'));
+    const rootReadme = await readFile(path.join(repositoryRoot, 'README.md'), 'utf8');
+    const packageReadme = await readFile(path.join(packageRoot, 'README.md'), 'utf8');
+    const contributing = await readFile(path.join(repositoryRoot, 'CONTRIBUTING.md'), 'utf8');
+
+    expect(publishedPackage.files).toEqual(expect.arrayContaining(['LICENSE-MIT', 'LICENSE-APACHE']));
+    expect(rootReadme).toContain('[MIT License](./LICENSE-MIT)');
+    expect(rootReadme).toContain('[Apache License, Version 2.0](./LICENSE-APACHE)');
+    expect(packageReadme).toContain('your choice of the MIT License or the Apache License, Version 2.0');
+    expect(contributing).toContain('licensed under both the MIT License and the Apache License, Version 2.0');
+  });
+});
+
+async function readJson(filePath) {
+  return JSON.parse(await readFile(filePath, 'utf8'));
+}

--- a/tests/unit/runtime-client.test.ts
+++ b/tests/unit/runtime-client.test.ts
@@ -6,6 +6,7 @@ import {
   runInteractiveCell
 } from '../../packages/oxiquill/src/lib/doc-runtime/runtime-client';
 import { normalizeCellExecutionResult } from '../../packages/oxiquill/src/lib/doc-runtime/output-artifacts';
+import { outputArtifactLimits, utf8ByteLength } from '../../packages/oxiquill/src/lib/doc-runtime/output-limits.mjs';
 import type {
   CellExecutionResult,
   CellLanguage,
@@ -309,6 +310,32 @@ describe('runtime client', () => {
     expect(workers).toHaveLength(1);
     workers[0].emitMessage({ requestId: 2, ok: true, result });
     await expect(next).resolves.toEqual(normalizedResult);
+  });
+
+  it('bounds oversized worker errors and malformed artifact diagnostics', async () => {
+    const { runner, workers } = makeRunner();
+    const failed = runner.runInteractiveCell(makeCell('python'), {});
+    workers[0].emitMessage({
+      requestId: 1,
+      ok: false,
+      error: 'x'.repeat(outputArtifactLimits.bytesPerError + 1)
+    });
+    const workerError = await failed.catch((error: unknown) => error);
+    expect(workerError).toBeInstanceOf(Error);
+    expect(utf8ByteLength((workerError as Error).message)).toBeLessThanOrEqual(outputArtifactLimits.bytesPerError);
+
+    const malformed = runner.runInteractiveCell(makeCell('python'), {});
+    workers[0].emitMessage({
+      requestId: 2,
+      ok: true,
+      result: { outputs: [{ kind: 'x'.repeat(outputArtifactLimits.bytesPerDiagnostic * 2) }] }
+    });
+    const normalized = await malformed;
+    expect(normalized.outputResults[0]).toMatchObject({ status: 'error' });
+    const diagnostic = normalized.outputResults[0];
+    if (diagnostic?.status === 'error') {
+      expect(utf8ByteLength(diagnostic.message)).toBeLessThanOrEqual(outputArtifactLimits.bytesPerDiagnostic);
+    }
   });
 
   it('rejects every request owned by a timed-out worker and creates a clean replacement', async () => {

--- a/tests/unit/runtime-client.test.ts
+++ b/tests/unit/runtime-client.test.ts
@@ -147,7 +147,12 @@ describe('runtime client', () => {
 
   it('sends Python source and resolves successful worker responses', async () => {
     const { runner, workers } = makeRunner();
-    const promise = runner.runInteractiveCell(makeCell('python'), { scale: 2 });
+    const promise = runner.runInteractiveCell(
+      makeCell('python', {
+        inputs: [{ name: 'scale', type: 'number', label: 'scale', value: 1, options: [] }]
+      }),
+      { scale: 2 }
+    );
 
     expect(workers).toHaveLength(1);
     expect(workers[0].messages[0]).toMatchObject({
@@ -163,6 +168,39 @@ describe('runtime client', () => {
 
     await expect(promise).resolves.toEqual(normalizedResult);
   });
+
+  it('marks portable integer inputs for Python int conversion and accepts negative values', async () => {
+    const { runner, workers } = makeRunner();
+    const promise = runner.runInteractiveCell(
+      makeCell('python', {
+        inputs: [{ name: 'offset', type: 'integer', label: 'offset', value: 0, options: [] }]
+      }),
+      { offset: -2147483648 }
+    );
+
+    expect(workers[0].messages[0]).toMatchObject({
+      inputs: { offset: -2147483648 },
+      integerInputNames: ['offset']
+    });
+    workers[0].emitMessage({ requestId: 1, ok: true, result });
+    await expect(promise).resolves.toEqual(normalizedResult);
+  });
+
+  it.each([-2147483649, 2147483648, Number.MAX_SAFE_INTEGER + 1])(
+    'rejects integer values outside the portable domain before creating a worker: %s',
+    async (value) => {
+      const { runner, workers } = makeRunner();
+      const promise = runner.runInteractiveCell(
+        makeCell('rust', {
+          inputs: [{ name: 'count', type: 'integer', label: 'count', value: 0, options: [] }]
+        }),
+        { count: value }
+      );
+
+      await expect(promise).rejects.toThrow('invalid committed numeric value');
+      expect(workers).toEqual([]);
+    }
+  );
 
   it('normalizes legacy worker responses before resolving', async () => {
     const { runner, workers } = makeRunner();
@@ -307,6 +345,35 @@ describe('runtime client', () => {
 
     await expect(reset).rejects.toThrow('rust worker was reset');
     expect(workers[1].terminated).toBe(true);
+  });
+
+  it('cancels active worker requests, clears their timers, and recovers with a replacement worker', async () => {
+    const workers: FakeWorker[] = [];
+    const clearTimer = vi.fn(clearTimeout);
+    const runner = createInteractiveCellRunner({
+      clearTimeout: clearTimer,
+      createWorker: () => {
+        const worker = new FakeWorker();
+        workers.push(worker);
+        return worker as unknown as Worker;
+      },
+      setTimeout
+    });
+    const controller = new AbortController();
+    const cancelled = runner.runInteractiveCell(makeCell('rust'), {}, undefined, controller.signal);
+    const companion = runner.runInteractiveCell(makeCell('rust', { id: 'rust-companion' }), {});
+
+    controller.abort();
+
+    await expect(cancelled).rejects.toMatchObject({ name: 'AbortError' });
+    await expect(companion).rejects.toMatchObject({ name: 'AbortError' });
+    expect(workers[0].terminated).toBe(true);
+    expect(clearTimer).toHaveBeenCalledTimes(2);
+
+    const recovered = runner.runInteractiveCell(makeCell('rust'), {});
+    expect(workers).toHaveLength(2);
+    workers[1].emitMessage({ requestId: 3, ok: true, result });
+    await expect(recovered).resolves.toEqual(normalizedResult);
   });
 
   it('rejects only requests owned by a failed worker and replaces that worker', async () => {

--- a/tests/unit/rust-worker.test.ts
+++ b/tests/unit/rust-worker.test.ts
@@ -1,5 +1,6 @@
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { RuntimeWorkerRequest, RuntimeWorkerResponse } from '../../packages/oxiquill/src/lib/doc-runtime/types';
+import { outputArtifactLimits, utf8ByteLength } from '../../packages/oxiquill/src/lib/doc-runtime/output-limits.mjs';
 import { initializeRustWasm, run_rust_cell } from './mocks/virtual-runtime';
 
 type MessageListener = (event: MessageEvent<RuntimeWorkerRequest>) => void;
@@ -29,7 +30,13 @@ afterAll(() => {
 
 describe('Rust runtime worker', () => {
   it('initializes Wasm once and posts parsed cell results', async () => {
-    run_rust_cell.mockReturnValue(JSON.stringify({ stdout: 'ok', plots: [], outputs: [] }));
+    run_rust_cell.mockReturnValue(
+      JSON.stringify({
+        stdout: 'ok',
+        plots: [],
+        outputs: [{ kind: 'text', stream: 'stdout', content: 'ok' }]
+      })
+    );
 
     worker.listener?.({
       data: { requestId: 1, cellId: 'first', inputs: { count: 2 } }
@@ -44,7 +51,11 @@ describe('Rust runtime worker', () => {
     expect(worker.postMessage).toHaveBeenCalledWith({
       requestId: 1,
       ok: true,
-      result: { stdout: 'ok', plots: [], outputs: [] }
+      result: {
+        stdout: 'ok',
+        plots: [],
+        outputs: [{ kind: 'text', stream: 'stdout', content: 'ok' }]
+      }
     });
   });
 
@@ -65,6 +76,19 @@ describe('Rust runtime worker', () => {
     } as MessageEvent<RuntimeWorkerRequest>);
     await flushMicrotasks();
     expect(worker.postMessage).toHaveBeenCalledWith({ requestId: 4, ok: false, error: 'string failure' });
+
+    run_rust_cell.mockImplementationOnce(() => {
+      throw new Error('x'.repeat(outputArtifactLimits.bytesPerError + 1));
+    });
+    worker.listener?.({
+      data: { requestId: 5, cellId: 'oversized-error', inputs: {} }
+    } as MessageEvent<RuntimeWorkerRequest>);
+    await flushMicrotasks();
+    const response = worker.postMessage.mock.calls.at(-1)?.[0];
+    expect(response?.ok).toBe(false);
+    if (response?.ok === false) {
+      expect(utf8ByteLength(response.error)).toBeLessThanOrEqual(outputArtifactLimits.bytesPerError);
+    }
   });
 });
 

--- a/tests/unit/sidebar-toggle.test.ts
+++ b/tests/unit/sidebar-toggle.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { defineStarlightSidebarToggle } from '../../packages/oxiquill/src/components/starlight/sidebar-toggle';
+
+type TestMediaQuery = MediaQueryList & {
+  listeners: Set<(event: MediaQueryListEvent) => void>;
+};
+
+function createMediaQuery(matches = true): TestMediaQuery {
+  const listeners = new Set<(event: MediaQueryListEvent) => void>();
+  return {
+    matches,
+    media: '(min-width: 50rem)',
+    onchange: null,
+    listeners,
+    addEventListener: vi.fn((_type, listener: (event: MediaQueryListEvent) => void) => listeners.add(listener)),
+    removeEventListener: vi.fn((_type, listener: (event: MediaQueryListEvent) => void) => listeners.delete(listener)),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn()
+  } as unknown as TestMediaQuery;
+}
+
+function sidebarMarkup(collapse = 'Collapse sidebar', expand = 'Expand sidebar'): HTMLElement {
+  const toggle = document.createElement('starlight-sidebar-toggle');
+  toggle.dataset.collapseLabel = collapse;
+  toggle.dataset.expandLabel = expand;
+  toggle.innerHTML = '<button type="button" aria-controls="test-sidebar"></button>';
+  return toggle;
+}
+
+describe('StarlightSidebarToggle', () => {
+  let mediaQuery: TestMediaQuery;
+
+  beforeEach(() => {
+    document.body.replaceChildren();
+    document.documentElement.removeAttribute('data-sidebar-collapsed');
+    document.documentElement.removeAttribute('style');
+    sessionStorage.clear();
+    mediaQuery = createMediaQuery();
+    vi.stubGlobal(
+      'matchMedia',
+      vi.fn(() => mediaQuery)
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('upgrades parser-like markup that existed before definition', () => {
+    const sidebar = document.createElement('div');
+    sidebar.id = 'test-sidebar';
+    const toggle = sidebarMarkup();
+    document.body.append(sidebar, toggle);
+
+    defineStarlightSidebarToggle();
+
+    const button = toggle.querySelector('button') as HTMLButtonElement;
+    expect(button).toHaveAttribute('aria-label', 'Collapse sidebar');
+    button.click();
+    expect(document.documentElement).toHaveAttribute('data-sidebar-collapsed');
+    expect(sidebar).toHaveAttribute('inert');
+  });
+
+  it('handles already-defined insertion, malformed markup, and reconnects idempotently', () => {
+    defineStarlightSidebarToggle();
+    const malformed = document.createElement('starlight-sidebar-toggle');
+    expect(() => document.body.append(malformed)).not.toThrow();
+
+    const sidebar = document.createElement('div');
+    sidebar.id = 'test-sidebar';
+    const toggle = sidebarMarkup('折りたたむ', '展開する');
+    document.body.append(sidebar, toggle);
+    const firstButton = toggle.querySelector('button') as HTMLButtonElement;
+    expect(mediaQuery.listeners).toHaveLength(1);
+
+    toggle.remove();
+    expect(mediaQuery.listeners).toHaveLength(0);
+    toggle.innerHTML = '<button type="button" aria-controls="test-sidebar"></button>';
+    document.body.append(toggle);
+    expect(mediaQuery.listeners).toHaveLength(1);
+    const replacementButton = toggle.querySelector('button') as HTMLButtonElement;
+    replacementButton.click();
+    expect(replacementButton).toHaveAttribute('aria-label', '展開する');
+
+    firstButton.click();
+    expect(replacementButton).toHaveAttribute('aria-label', '展開する');
+  });
+
+  it('applies stored state after a replacement connects', () => {
+    defineStarlightSidebarToggle();
+    sessionStorage.setItem('oxiquill-sidebar-collapsed', 'true');
+    const sidebar = document.createElement('div');
+    sidebar.id = 'test-sidebar';
+    const toggle = sidebarMarkup();
+
+    document.body.append(sidebar, toggle);
+
+    expect(document.documentElement).toHaveAttribute('data-sidebar-collapsed');
+    expect(toggle.querySelector('button')).toHaveAttribute('aria-expanded', 'false');
+    expect(sidebar).toHaveAttribute('aria-hidden', 'true');
+  });
+});

--- a/tests/unit/table-of-contents-toggle.test.ts
+++ b/tests/unit/table-of-contents-toggle.test.ts
@@ -1,0 +1,137 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { defineStarlightTableOfContentsToggle } from '../../packages/oxiquill/src/components/starlight/table-of-contents-toggle';
+
+type TestMediaQuery = MediaQueryList & {
+  listeners: Set<(event: MediaQueryListEvent) => void>;
+};
+
+function createMediaQuery(matches = true): TestMediaQuery {
+  const listeners = new Set<(event: MediaQueryListEvent) => void>();
+  return {
+    matches,
+    media: '(min-width: 72rem)',
+    onchange: null,
+    listeners,
+    addEventListener: vi.fn((_type, listener: (event: MediaQueryListEvent) => void) => listeners.add(listener)),
+    removeEventListener: vi.fn((_type, listener: (event: MediaQueryListEvent) => void) => listeners.delete(listener)),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn()
+  } as unknown as TestMediaQuery;
+}
+
+function tableOfContentsMarkup(
+  collapse = 'Collapse table of contents',
+  expand = 'Expand table of contents'
+): HTMLElement {
+  const toggle = document.createElement('starlight-table-of-contents-toggle');
+  toggle.dataset.collapseLabel = collapse;
+  toggle.dataset.expandLabel = expand;
+  toggle.innerHTML = '<button type="button" aria-controls="test-table-of-contents"></button>';
+  return toggle;
+}
+
+describe('StarlightTableOfContentsToggle', () => {
+  let mediaQuery: TestMediaQuery;
+
+  beforeEach(() => {
+    document.body.replaceChildren();
+    document.documentElement.removeAttribute('data-sidebar-collapsed');
+    document.documentElement.removeAttribute('data-table-of-contents-collapsed');
+    sessionStorage.clear();
+    mediaQuery = createMediaQuery();
+    vi.stubGlobal(
+      'matchMedia',
+      vi.fn(() => mediaQuery)
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('toggles an independent persisted state and accessible disclosure attributes', () => {
+    const tableOfContents = document.createElement('aside');
+    tableOfContents.id = 'test-table-of-contents';
+    const toggle = tableOfContentsMarkup();
+    document.body.append(tableOfContents, toggle);
+
+    defineStarlightTableOfContentsToggle();
+
+    const button = toggle.querySelector('button') as HTMLButtonElement;
+    expect(button).toHaveAttribute('aria-expanded', 'true');
+    expect(button).toHaveAttribute('aria-label', 'Collapse table of contents');
+
+    button.click();
+
+    expect(document.documentElement).toHaveAttribute('data-table-of-contents-collapsed');
+    expect(document.documentElement).not.toHaveAttribute('data-sidebar-collapsed');
+    expect(button).toHaveAttribute('aria-expanded', 'false');
+    expect(button).toHaveAttribute('aria-label', 'Expand table of contents');
+    expect(button).toHaveAttribute('title', 'Expand table of contents');
+    expect(tableOfContents).toHaveAttribute('aria-hidden', 'true');
+    expect(tableOfContents).toHaveAttribute('inert');
+    expect(sessionStorage.getItem('oxiquill-table-of-contents-collapsed')).toBe('true');
+    expect(sessionStorage.getItem('oxiquill-sidebar-collapsed')).toBeNull();
+
+    button.click();
+
+    expect(document.documentElement).not.toHaveAttribute('data-table-of-contents-collapsed');
+    expect(tableOfContents).not.toHaveAttribute('aria-hidden');
+    expect(tableOfContents).not.toHaveAttribute('inert');
+    expect(sessionStorage.getItem('oxiquill-table-of-contents-collapsed')).toBeNull();
+  });
+
+  it('restores storage on reconnect without duplicate listeners', () => {
+    defineStarlightTableOfContentsToggle();
+    sessionStorage.setItem('oxiquill-table-of-contents-collapsed', 'true');
+    const tableOfContents = document.createElement('aside');
+    tableOfContents.id = 'test-table-of-contents';
+    const toggle = tableOfContentsMarkup('目次を折りたたむ', '目次を展開する');
+    document.body.append(tableOfContents, toggle);
+
+    expect(mediaQuery.listeners).toHaveLength(1);
+    expect(document.documentElement).toHaveAttribute('data-table-of-contents-collapsed');
+    expect(toggle.querySelector('button')).toHaveAttribute('aria-label', '目次を展開する');
+
+    toggle.remove();
+    expect(mediaQuery.listeners).toHaveLength(0);
+    document.body.append(toggle);
+
+    expect(mediaQuery.listeners).toHaveLength(1);
+    expect(toggle.querySelector('button')).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('keeps the mobile table of contents interactive and restores focus before a desktop collapse', () => {
+    defineStarlightTableOfContentsToggle();
+    Object.defineProperty(mediaQuery, 'matches', { configurable: true, value: false });
+    sessionStorage.setItem('oxiquill-table-of-contents-collapsed', 'true');
+    const tableOfContents = document.createElement('aside');
+    tableOfContents.id = 'test-table-of-contents';
+    const link = document.createElement('a');
+    link.href = '#heading';
+    tableOfContents.append(link);
+    const toggle = tableOfContentsMarkup();
+    document.body.append(tableOfContents, toggle);
+
+    const button = toggle.querySelector('button') as HTMLButtonElement;
+    expect(document.documentElement).not.toHaveAttribute('data-table-of-contents-collapsed');
+    expect(tableOfContents).not.toHaveAttribute('inert');
+    expect(button).toHaveAttribute('aria-expanded', 'true');
+
+    link.focus();
+    Object.defineProperty(mediaQuery, 'matches', { configurable: true, value: true });
+    mediaQuery.listeners.forEach((listener) => listener({ matches: true } as MediaQueryListEvent));
+
+    expect(button).toHaveFocus();
+    expect(tableOfContents).toHaveAttribute('inert');
+  });
+
+  it('ignores malformed or missing table-of-contents markup', () => {
+    defineStarlightTableOfContentsToggle();
+    const malformed = document.createElement('starlight-table-of-contents-toggle');
+
+    expect(() => document.body.append(malformed)).not.toThrow();
+    expect(mediaQuery.listeners).toHaveLength(0);
+  });
+});

--- a/tests/unit/toggle-localization.test.ts
+++ b/tests/unit/toggle-localization.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { togglePresentation } from '../../packages/oxiquill/src/components/starlight/toggle-localization';
+
+describe('togglePresentation', () => {
+  it.each(['ja', 'ja-JP', 'JA-jp', 'ja_JP'])('uses the primary Japanese language subtag for %s', (language) => {
+    expect(togglePresentation(language, 'ltr', 'tableOfContents')).toMatchObject({
+      collapseLabel: '目次を折りたたむ',
+      expandLabel: '目次を展開する'
+    });
+  });
+
+  it('falls back to English labels', () => {
+    expect(togglePresentation('en-US', 'ltr', 'tableOfContents')).toMatchObject({
+      collapseLabel: 'Collapse table of contents',
+      expandLabel: 'Expand table of contents'
+    });
+  });
+
+  it('points collapse controls toward the correct logical edge in LTR and RTL layouts', () => {
+    expect(togglePresentation('en', 'ltr', 'sidebar')).toMatchObject({
+      collapseIcon: 'left-arrow',
+      expandIcon: 'right-arrow'
+    });
+    expect(togglePresentation('en', 'ltr', 'tableOfContents')).toMatchObject({
+      collapseIcon: 'right-arrow',
+      expandIcon: 'left-arrow'
+    });
+    expect(togglePresentation('en', 'rtl', 'sidebar')).toMatchObject({
+      collapseIcon: 'right-arrow',
+      expandIcon: 'left-arrow'
+    });
+    expect(togglePresentation('en', 'rtl', 'tableOfContents')).toMatchObject({
+      collapseIcon: 'left-arrow',
+      expandIcon: 'right-arrow'
+    });
+  });
+});

--- a/tests/unit/watch-doc-runtime.test.mjs
+++ b/tests/unit/watch-doc-runtime.test.mjs
@@ -34,6 +34,7 @@ describe('runtime watcher entrypoint', () => {
     const services = {
       createDocRuntimeContext: vi.fn(async () => ({ highlighter: {}, paths })),
       loadProjectConfig: vi.fn(async () => ({ paths })),
+      prepareCleanupOwnership: vi.fn(async () => []),
       syncDocRuntime: vi.fn().mockResolvedValueOnce(initial).mockResolvedValueOnce(current),
       watch: vi.fn(() => watcher)
     };
@@ -42,6 +43,11 @@ describe('runtime watcher entrypoint', () => {
 
     await main(['--skip-initial'], services);
 
+    expect(services.prepareCleanupOwnership).toHaveBeenCalledWith({
+      configFile: undefined,
+      fields: ['cacheDir', 'publicAssetsDir'],
+      paths
+    });
     expect(services.watch).toHaveBeenCalledWith(expect.arrayContaining([expect.any(String)]), {
       cwd: workspaceRoot,
       ignoreInitial: true
@@ -70,6 +76,7 @@ describe('runtime watcher entrypoint', () => {
     const services = {
       createDocRuntimeContext: vi.fn(async () => ({ highlighter: {}, paths })),
       loadProjectConfig: vi.fn(async () => ({ paths })),
+      prepareCleanupOwnership: vi.fn(async () => []),
       syncDocRuntime: vi.fn(async () => ({
         cellCount: 0,
         plan: { languages: { haskell: { public: 'keep' }, rust: { public: 'keep' } } }


### PR DESCRIPTION
## Summary

- make generated-output cleanup fail closed, validate ownership before builds, and protect authored public content
- align the documented Astro/content configuration surface and canonical dual-license metadata
- harden interactive scheduling, numeric inputs, component lifecycles, rich-output validation, accessibility, and output budgets
- parse helper manifests as TOML and stage Pyodide assets through streaming, verified, atomic cache updates
- unify the packed Preact runtime used by Mermaid during pnpm development SSR
- add an accessible, localized, persistent desktop table-of-contents toggle with independent sidebar behavior
- extend unit, documentation, package-consumer, Wasm/Haskell, accessibility, and cross-browser coverage

## Validation

- pnpm test

Closes #81
Closes #82
Closes #83
Closes #84
Closes #85
Closes #87
Closes #96