### PR TITLE
Fix Dependabot permission for npm release verification

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -35,7 +35,7 @@ jobs:
     permissions:
       contents: read
       issues: read # Required to enforce the release-blocker milestone gate.
-      security-events: read # Required to enforce the Dependabot alert gate.
+      vulnerability-alerts: read # Required to enforce the Dependabot alert gate.
     outputs:
       archive_filename: ${{ steps.archive.outputs.archive_filename }}
       artifact_name: ${{ steps.archive.outputs.artifact_name }}

--- a/tests/unit/release-workflow.test.mjs
+++ b/tests/unit/release-workflow.test.mjs
@@ -96,6 +96,13 @@ describe('release-bound version verification', () => {
 });
 
 describe('release identity verification', () => {
+  it('grants the release verifier read-only Dependabot alert access', async () => {
+    const workflow = await readFile(path.join(repositoryRoot, '.github/workflows/npm-publish.yml'), 'utf8');
+
+    expect(workflow).toContain('vulnerability-alerts: read # Required to enforce the Dependabot alert gate.');
+    expect(workflow).not.toContain('security-events:');
+  });
+
   it('accepts an exact stable tag and matching package versions', () => {
     expect(() =>
       assertReleaseIdentity({


### PR DESCRIPTION
## Summary

- grant the release verifier the dedicated read-only Dependabot alerts permission
- guard the workflow permission against regression

## Context

The v0.3.0 manual dry run failed before building an archive because the workflow used `security-events: read`, which does not authorize the Dependabot alerts endpoint. The release tag remains unchanged.

## Validation

- `pnpm exec vitest run tests/unit/release-workflow.test.mjs` (35 passed)
- `pnpm exec eslint tests/unit/release-workflow.test.mjs --max-warnings=0`
- `pnpm exec prettier .github/workflows/npm-publish.yml tests/unit/release-workflow.test.mjs --check`
- `git diff --check`