### PR TITLE
Fix release control API compatibility

### DIFF
--- a/.github/scripts/github-api.mjs
+++ b/.github/scripts/github-api.mjs
@@ -1,0 +1,71 @@
+export const GITHUB_API_VERSION = '2026-03-10';
+
+const githubApiOrigin = 'https://api.github.com';
+
+export function githubHeaders(token, accept = 'application/vnd.github+json', additional = {}) {
+  return {
+    Accept: accept,
+    ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    'User-Agent': 'oxiquill-release-control',
+    'X-GitHub-Api-Version': GITHUB_API_VERSION,
+    ...additional
+  };
+}
+
+export async function requestGitHubJson(fetchImplementation, url, token) {
+  const response = await fetchImplementation(url, { headers: githubHeaders(token) });
+  if (!response.ok) {
+    throw new Error(`GitHub API request failed with ${response.status}: ${await response.text()}`);
+  }
+  return response.json();
+}
+
+export async function fetchAllGitHubPages(
+  url,
+  { fetchImplementation = fetch, responseName = 'GitHub API', token } = {}
+) {
+  const results = [];
+  const visited = new Set();
+  let nextUrl = assertGitHubApiUrl(url);
+
+  while (nextUrl) {
+    if (visited.has(nextUrl)) throw new Error('GitHub API pagination contains a cycle.');
+    visited.add(nextUrl);
+
+    const response = await fetchImplementation(nextUrl, { headers: githubHeaders(token) });
+    if (!response.ok) {
+      throw new Error(`GitHub API request failed with ${response.status}: ${await response.text()}`);
+    }
+
+    const values = await response.json();
+    if (!Array.isArray(values)) throw new Error(`${responseName} returned a non-array response.`);
+    results.push(...values);
+    nextUrl = nextPageUrl(response.headers?.get?.('link'));
+  }
+
+  return results;
+}
+
+function nextPageUrl(linkHeader) {
+  if (!linkHeader) return null;
+
+  for (const part of linkHeader.split(/,\s*(?=<)/u)) {
+    const target = /^\s*<([^>]+)>/u.exec(part)?.[1];
+    const relationship = /;\s*rel="([^"]+)"/u.exec(part)?.[1];
+    if (target && relationship?.split(/\s+/u).includes('next')) return assertGitHubApiUrl(target);
+  }
+  return null;
+}
+
+function assertGitHubApiUrl(value) {
+  let url;
+  try {
+    url = new URL(value);
+  } catch (error) {
+    throw new Error('GitHub API pagination returned an invalid URL.', { cause: error });
+  }
+  if (url.origin !== githubApiOrigin || url.username || url.password) {
+    throw new Error(`GitHub API pagination returned an untrusted URL: ${url.href}`);
+  }
+  return url.href;
+}

--- a/.github/scripts/release-archive.mjs
+++ b/.github/scripts/release-archive.mjs
@@ -2,14 +2,21 @@ import { execFileSync, spawnSync } from 'node:child_process';
 import { createHash } from 'node:crypto';
 import { appendFile, mkdir, readFile, readdir, writeFile } from 'node:fs/promises';
 import path from 'node:path';
-import { fileURLToPath, pathToFileURL } from 'node:url';
+import { pathToFileURL } from 'node:url';
 
 export const CHECKSUM_FILE = 'SHA256SUMS';
 export const MANIFEST_FILE = 'release-manifest.json';
 
-const packageRoot = fileURLToPath(new URL('../../packages/oxiquill', import.meta.url));
-
-export async function createReleaseArchive(destination, { outputFile = process.env.GITHUB_OUTPUT } = {}) {
+export async function createReleaseArchive(
+  destination,
+  {
+    outputFile = process.env.GITHUB_OUTPUT,
+    repositoryRoot = process.cwd(),
+    workflowCommit = process.env.GITHUB_WORKFLOW_SHA
+  } = {}
+) {
+  assertCommit(workflowCommit, 'Workflow commit');
+  const packageRoot = path.join(repositoryRoot, 'packages/oxiquill');
   await mkdir(destination, { recursive: true });
   const existing = await readdir(destination);
   if (existing.length > 0) {
@@ -43,8 +50,9 @@ export async function createReleaseArchive(destination, { outputFile = process.e
     commit: gitOutput(['rev-parse', 'HEAD'], packageRoot),
     name: pack.name,
     pack,
-    schemaVersion: 2,
-    version: pack.version
+    schemaVersion: 3,
+    version: pack.version,
+    workflowCommit
   };
   await writeFile(path.join(destination, MANIFEST_FILE), `${JSON.stringify(manifest, null, 2)}\n`);
   await writeFile(path.join(destination, CHECKSUM_FILE), `${archiveSha256}  ${pack.filename}\n`);
@@ -63,12 +71,23 @@ export async function createReleaseArchive(destination, { outputFile = process.e
 export async function verifyReleaseArchive(
   destination,
   expectedVersion,
-  { environment = process.env, expectedCommit, outputFile = process.env.GITHUB_OUTPUT, requireOidc = false } = {}
+  {
+    environment = process.env,
+    expectedCommit,
+    expectedWorkflowCommit = process.env.GITHUB_WORKFLOW_SHA,
+    outputFile = process.env.GITHUB_OUTPUT,
+    requireOidc = false
+  } = {}
 ) {
   if (requireOidc) assertPublishEnvironment(environment);
 
   const manifest = JSON.parse(await readFile(path.join(destination, MANIFEST_FILE), 'utf8'));
-  assertReleaseManifest(manifest, { commit: expectedCommit, name: 'oxiquill', version: expectedVersion });
+  assertReleaseManifest(manifest, {
+    commit: expectedCommit,
+    name: 'oxiquill',
+    version: expectedVersion,
+    workflowCommit: expectedWorkflowCommit
+  });
   assertPackManifest(manifest.pack, { name: 'oxiquill', version: expectedVersion });
   await assertArtifactFileSet(destination, manifest.pack.filename);
 
@@ -92,16 +111,23 @@ export async function verifyReleaseArchive(
 
 export function assertReleaseManifest(manifest, expected) {
   if (
-    manifest?.schemaVersion !== 2 ||
+    manifest?.schemaVersion !== 3 ||
     typeof manifest.archiveSha256 !== 'string' ||
     !/^[0-9a-f]{64}$/u.test(manifest.archiveSha256) ||
     typeof manifest.commit !== 'string' ||
-    !/^[0-9a-f]{40}$/u.test(manifest.commit)
+    !/^[0-9a-f]{40}$/u.test(manifest.commit) ||
+    typeof manifest.workflowCommit !== 'string' ||
+    !/^[0-9a-f]{40}$/u.test(manifest.workflowCommit)
   ) {
     throw new Error('Release manifest has an unsupported schema or invalid identity fields.');
   }
   if (!expected.commit || manifest.commit !== expected.commit) {
     throw new Error(`Release manifest commit ${manifest.commit} does not match ${String(expected.commit)}.`);
+  }
+  if (!expected.workflowCommit || manifest.workflowCommit !== expected.workflowCommit) {
+    throw new Error(
+      `Release manifest workflow commit ${manifest.workflowCommit} does not match ${String(expected.workflowCommit)}.`
+    );
   }
   if (manifest.name !== expected.name || manifest.version !== expected.version) {
     throw new Error(`Release manifest identity mismatch: expected ${expected.name}@${expected.version}.`);
@@ -176,6 +202,10 @@ function gitOutput(args, cwd) {
   return execFileSync('git', args, { cwd, encoding: 'utf8' }).trim();
 }
 
+function assertCommit(value, label) {
+  if (!/^[0-9a-f]{40}$/u.test(value)) throw new Error(`${label} must be a full Git SHA.`);
+}
+
 async function main() {
   const [command, destination, expectedVersion, ...flags] = process.argv.slice(2);
   if (command === 'create' && destination && !expectedVersion) {
@@ -185,7 +215,7 @@ async function main() {
   }
   if (command === 'verify' && destination && expectedVersion) {
     const requireOidc = flags.includes('--require-oidc');
-    const expectedCommit = gitOutput(['rev-parse', 'HEAD'], packageRoot);
+    const expectedCommit = gitOutput(['rev-parse', 'HEAD'], process.cwd());
     const { archivePath } = await verifyReleaseArchive(destination, expectedVersion, { expectedCommit, requireOidc });
     console.log(`Verified ${archivePath}.`);
     return;

--- a/.github/scripts/release-assets.mjs
+++ b/.github/scripts/release-assets.mjs
@@ -2,33 +2,41 @@ import { execFileSync } from 'node:child_process';
 import { readFile, readdir } from 'node:fs/promises';
 import path from 'node:path';
 import { pathToFileURL } from 'node:url';
+import { fetchAllGitHubPages, githubHeaders, requestGitHubJson } from './github-api.mjs';
 import { verifyReleaseArchive } from './release-archive.mjs';
-
-const apiVersion = '2022-11-28';
 
 export async function uploadReleaseAssets({
   directory,
   expectedCommit,
+  expectedWorkflowCommit,
   expectedVersion,
   fetchImplementation = fetch,
   repository,
   tag,
   token
 }) {
-  assertInputs({ expectedCommit, expectedVersion, repository, tag, token });
-  await verifyReleaseArchive(directory, expectedVersion, { expectedCommit, outputFile: null });
+  assertInputs({ expectedCommit, expectedVersion, expectedWorkflowCommit, repository, tag, token });
+  await verifyReleaseArchive(directory, expectedVersion, {
+    expectedCommit,
+    expectedWorkflowCommit,
+    outputFile: null
+  });
 
   const apiRoot = `https://api.github.com/repos/${repository}`;
-  const release = await requestJson(fetchImplementation, `${apiRoot}/releases/tags/${encodeURIComponent(tag)}`, token);
+  const release = await requestGitHubJson(
+    fetchImplementation,
+    `${apiRoot}/releases/tags/${encodeURIComponent(tag)}`,
+    token
+  );
   if (release.tag_name !== tag || !Number.isInteger(release.id)) {
     throw new Error(`GitHub Release identity does not match ${tag}.`);
   }
 
-  const assets = await fetchAllPages(
+  const assets = await fetchAllGitHubPages(`${apiRoot}/releases/${release.id}/assets?per_page=100`, {
     fetchImplementation,
-    `${apiRoot}/releases/${release.id}/assets?per_page=100`,
+    responseName: 'GitHub Release assets API',
     token
-  );
+  });
   const filenames = (await readdir(directory)).sort();
   const results = [];
 
@@ -65,31 +73,16 @@ export async function uploadReleaseAssets({
   return results;
 }
 
-function assertInputs({ expectedCommit, expectedVersion, repository, tag, token }) {
+function assertInputs({ expectedCommit, expectedVersion, expectedWorkflowCommit, repository, tag, token }) {
   if (!/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/u.test(repository)) {
     throw new Error(`Invalid GitHub repository identifier: ${repository}`);
   }
   if (!/^[0-9a-f]{40}$/u.test(expectedCommit)) throw new Error('Expected release commit must be a full Git SHA.');
+  if (!/^[0-9a-f]{40}$/u.test(expectedWorkflowCommit)) {
+    throw new Error('Expected workflow commit must be a full Git SHA.');
+  }
   if (tag !== `v${expectedVersion}`) throw new Error(`Release tag ${tag} does not match version ${expectedVersion}.`);
   if (!token) throw new Error('GITHUB_TOKEN must be set.');
-}
-
-async function fetchAllPages(fetchImplementation, url, token) {
-  const results = [];
-  let page = 1;
-  while (true) {
-    const response = await requestJson(fetchImplementation, `${url}&page=${page}`, token);
-    if (!Array.isArray(response)) throw new Error('GitHub Release assets API returned a non-array response.');
-    results.push(...response);
-    if (response.length < 100) return results;
-    page += 1;
-  }
-}
-
-async function requestJson(fetchImplementation, url, token) {
-  const response = await fetchImplementation(url, { headers: githubHeaders(token) });
-  if (!response.ok) throw new Error(`GitHub API request failed with ${response.status}: ${await response.text()}`);
-  return response.json();
 }
 
 async function requestBytes(fetchImplementation, url, token) {
@@ -100,16 +93,6 @@ async function requestBytes(fetchImplementation, url, token) {
     throw new Error(`GitHub Release asset download failed with ${response.status}: ${await response.text()}`);
   }
   return Buffer.from(await response.arrayBuffer());
-}
-
-function githubHeaders(token, accept = 'application/vnd.github+json', additional = {}) {
-  return {
-    Accept: accept,
-    Authorization: `Bearer ${token}`,
-    'User-Agent': 'oxiquill-release-assets',
-    'X-GitHub-Api-Version': apiVersion,
-    ...additional
-  };
 }
 
 function gitOutput(args) {
@@ -126,6 +109,7 @@ if (isMainModule) {
     const results = await uploadReleaseAssets({
       directory,
       expectedCommit: gitOutput(['rev-parse', 'HEAD']),
+      expectedWorkflowCommit: process.env.GITHUB_WORKFLOW_SHA,
       expectedVersion,
       repository: process.env.GITHUB_REPOSITORY,
       tag,

--- a/.github/scripts/verify-release.mjs
+++ b/.github/scripts/verify-release.mjs
@@ -1,6 +1,7 @@
 import { execFileSync, spawnSync } from 'node:child_process';
 import { appendFile } from 'node:fs/promises';
 import { pathToFileURL } from 'node:url';
+import { fetchAllGitHubPages } from './github-api.mjs';
 import { verifyReleaseVersions } from './verify-release-version.mjs';
 
 export const BLOCKER_LABEL = 'release-blocker';
@@ -52,7 +53,7 @@ export function assertNoOpenDependabotAlerts(alerts) {
 
 export async function fetchOpenDependabotAlerts({ fetchImplementation = fetch, repository, token }) {
   assertRepositoryIdentifier(repository);
-  const alerts = await fetchAllPages(
+  const alerts = await fetchAllGitHubPages(
     `https://api.github.com/repos/${repository}/dependabot/alerts?state=open&per_page=100`,
     { fetchImplementation, token }
   );
@@ -68,7 +69,7 @@ export async function fetchOpenReleaseBlockers({ fetchImplementation = fetch, re
   assertRepositoryIdentifier(repository);
 
   const apiRoot = `https://api.github.com/repos/${repository}`;
-  const milestones = await fetchAllPages(`${apiRoot}/milestones?state=all&per_page=100`, {
+  const milestones = await fetchAllGitHubPages(`${apiRoot}/milestones?state=all&per_page=100`, {
     fetchImplementation,
     token
   });
@@ -78,7 +79,7 @@ export async function fetchOpenReleaseBlockers({ fetchImplementation = fetch, re
   }
 
   const label = encodeURIComponent(BLOCKER_LABEL);
-  const issues = await fetchAllPages(
+  const issues = await fetchAllGitHubPages(
     `${apiRoot}/issues?milestone=${milestone.number}&state=open&labels=${label}&per_page=100`,
     { fetchImplementation, token }
   );
@@ -129,33 +130,6 @@ export async function verifyRelease({ environment = process.env, repositoryRoot 
 function assertRepositoryIdentifier(repository) {
   if (!/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/u.test(repository)) {
     throw new Error(`Invalid GitHub repository identifier: ${repository}`);
-  }
-}
-
-async function fetchAllPages(url, { fetchImplementation, token }) {
-  const results = [];
-  let page = 1;
-
-  while (true) {
-    const separator = url.includes('?') ? '&' : '?';
-    const response = await fetchImplementation(`${url}${separator}page=${page}`, {
-      headers: {
-        Accept: 'application/vnd.github+json',
-        ...(token ? { Authorization: `Bearer ${token}` } : {}),
-        'X-GitHub-Api-Version': '2022-11-28'
-      }
-    });
-    if (!response.ok) {
-      throw new Error(`GitHub API request failed with ${response.status}: ${await response.text()}`);
-    }
-
-    const values = await response.json();
-    if (!Array.isArray(values)) {
-      throw new Error('GitHub API returned a non-array response.');
-    }
-    results.push(...values);
-    if (values.length < 100) return results;
-    page += 1;
   }
 }
 

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -50,6 +50,14 @@ jobs:
           persist-credentials: false
           ref: ${{ github.event.release.tag_name || inputs.release_tag }}
 
+      - name: Check out the release control plane
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          path: .release-control
+          persist-credentials: false
+          ref: ${{ github.workflow_sha }}
+          sparse-checkout: .github/scripts
+
       - name: Verify the release tag is on main
         env:
           RELEASE_TAG: ${{ github.event.release.tag_name || inputs.release_tag }}
@@ -68,6 +76,10 @@ jobs:
           fi
           if ! git merge-base --is-ancestor "$tag_commit" origin/main; then
             echo "Release tag $RELEASE_TAG is not contained in origin/main" >&2
+            exit 1
+          fi
+          if ! git merge-base --is-ancestor "$GITHUB_WORKFLOW_SHA" origin/main; then
+            echo "Workflow commit $GITHUB_WORKFLOW_SHA is not contained in origin/main" >&2
             exit 1
           fi
 
@@ -93,7 +105,7 @@ jobs:
           RELEASE_PRERELEASE: ${{ github.event.release.prerelease || false }}
           RELEASE_TAG: ${{ github.event.release.tag_name || inputs.release_tag }}
         run: |
-          node .github/scripts/verify-release.mjs
+          node .release-control/.github/scripts/verify-release.mjs
           legacy_license_pattern='AG''PL|Aff''ero'
           if git grep -n -E "$legacy_license_pattern"; then
             echo "Tracked current-license references must be removed before publishing" >&2
@@ -114,7 +126,7 @@ jobs:
 
       - name: Install ghc-wasm
         shell: bash
-        run: bash .github/scripts/install-ghc-wasm.sh
+        run: bash .release-control/.github/scripts/install-ghc-wasm.sh
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -130,7 +142,7 @@ jobs:
 
       - name: Build the release archive once
         id: archive
-        run: node .github/scripts/release-archive.mjs create "$RUNNER_TEMP/npm-release"
+        run: node .release-control/.github/scripts/release-archive.mjs create "$RUNNER_TEMP/npm-release"
 
       - name: Upload the verified release archive
         uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
@@ -151,11 +163,19 @@ jobs:
       contents: write # Required only to attach immutable assets to the matching GitHub Release.
 
     steps:
-      - name: Check out release verification code
+      - name: Check out the release tag
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           persist-credentials: false
           ref: ${{ needs.verify.outputs.release_tag }}
+
+      - name: Check out the release control plane
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          path: .release-control
+          persist-credentials: false
+          ref: ${{ github.workflow_sha }}
+          sparse-checkout: .github/scripts
 
       - name: Set up Node.js
         uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
@@ -174,10 +194,10 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
           RELEASE_TAG: ${{ needs.verify.outputs.release_tag }}
           RELEASE_VERSION: ${{ needs.verify.outputs.release_version }}
-        run: node .github/scripts/release-assets.mjs "$RUNNER_TEMP/npm-release" "$RELEASE_VERSION" "$RELEASE_TAG"
+        run: node .release-control/.github/scripts/release-assets.mjs "$RUNNER_TEMP/npm-release" "$RELEASE_VERSION" "$RELEASE_TAG"
 
   publish:
-    name: Stage npm package
+    name: Publish npm package
     if: github.event_name == 'release' && needs.verify.outputs.release_version != '0.3.0'
     needs:
       - release-assets
@@ -191,11 +211,19 @@ jobs:
       id-token: write # Required for npm Trusted Publishing and provenance.
 
     steps:
-      - name: Check out release verification code
+      - name: Check out the release tag
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           persist-credentials: false
           ref: ${{ needs.verify.outputs.release_tag }}
+
+      - name: Check out the release control plane
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          path: .release-control
+          persist-credentials: false
+          ref: ${{ github.workflow_sha }}
+          sparse-checkout: .github/scripts
 
       - name: Set up Node.js
         uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
@@ -216,9 +244,9 @@ jobs:
         id: archive
         env:
           RELEASE_VERSION: ${{ needs.verify.outputs.release_version }}
-        run: node .github/scripts/release-archive.mjs verify "$RUNNER_TEMP/npm-release" "$RELEASE_VERSION" --require-oidc
+        run: node .release-control/.github/scripts/release-archive.mjs verify "$RUNNER_TEMP/npm-release" "$RELEASE_VERSION" --require-oidc
 
-      - name: Submit package for staged publication
+      - name: Publish the verified package
         env:
           RELEASE_ARCHIVE: ${{ steps.archive.outputs.archive_path }}
-        run: npm stage publish "$RELEASE_ARCHIVE" --registry https://registry.npmjs.org/
+        run: npm publish "$RELEASE_ARCHIVE" --access public --registry https://registry.npmjs.org/

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -9,9 +9,9 @@ This runbook covers the one-time npm package bootstrap and every later stable re
 - Required CI is green on the latest `main`.
 - The release version is stable `MAJOR.MINOR.PATCH`; prereleases require a separately reviewed runbook change.
 - Node.js 24+, npm 11.15.0+, the repository's pinned pnpm/Rust tools, `wasm-pack`, `cargo-llvm-cov`, `wasm32-wasi-ghc`, Playwright, and GitHub CLI are available.
-- The protected publish environment and npm staged trusted publisher are configured for normal releases.
+- The protected publish environment and npm Trusted Publisher are configured for normal releases.
 
-The GitHub environment is named `npm-publish`. It has `kakune` as a required reviewer, permits only tags matching `v*`, allows self-review for the sole maintainer, and contains no npm credential. The npm Trusted Publisher must match repository `kakune/oxiquill`, workflow filename `npm-publish.yml`, environment `npm-publish`, and only the `npm stage publish` action.
+The GitHub environment is named `npm-publish`. It has `kakune` as a required reviewer, permits only tags matching `v*`, allows self-review for the sole maintainer, and contains no npm credential. The npm Trusted Publisher must match repository `kakune/oxiquill`, workflow filename `npm-publish.yml`, environment `npm-publish`, and only the `npm publish` action.
 
 Never reuse, move, or replace a published tag. npm versions are immutable; recover from a bad release with deprecation and a patch release.
 
@@ -44,14 +44,18 @@ pnpm test:consumer
 
 The package and consumer tests inspect temporary packs locally. The immutable release archive is produced later by the workflow from the tag on `main`.
 
-## Merge, Tag, and Dry Run
+## Merge, Tag, and Optional Dry Run
 
 1. Open an English pull request from `release/vX.Y.Z` to `main` with the validation results and release checklist.
 2. Bring the branch up to date with `main`, resolve every review conversation, and wait for all required checks.
 3. Squash-merge the release pull request. Do not merge, rebase-merge, or push directly to `main`.
 4. Record the resulting squash commit on `main` and confirm its tree contains the reviewed release state.
 5. Create annotated tag `vX.Y.Z` on that resulting `main` commit and push the tag. Do not tag the release branch commit.
-6. Dispatch `npm-publish.yml` against that exact tag with `release_tag` set to the same `vX.Y.Z` value.
+6. For the bootstrap release, release-control changes, toolchain changes, or another high-risk release, dispatch `npm-publish.yml` from `main` with `release_tag` set to the exact `vX.Y.Z` value. A routine normal release proceeds directly to the stable GitHub Release because its protected workflow performs the same validation before publication.
+
+   ```sh
+   gh workflow run npm-publish.yml --ref main --field release_tag=vX.Y.Z
+   ```
 
 The manual path never contacts an npm publish endpoint. It must verify:
 
@@ -60,7 +64,7 @@ The manual path never contacts an npm publish endpoint. It must verify:
 - zero open release blockers and zero production advisories;
 - all required checks and language/browser/consumer fixtures;
 - the complete npm tarball allowlist and README/licenses;
-- one tarball built exactly once, with its SHA-256, package identity, and tagged commit recorded.
+- one tarball built exactly once, with its SHA-256, package identity, tagged source commit, and workflow commit recorded.
 
 Download artifact `oxiquill-X.Y.Z`. It contains only `oxiquill-X.Y.Z.tgz`, `SHA256SUMS`, and `release-manifest.json`. Verify and inspect it from an isolated directory:
 
@@ -70,7 +74,7 @@ tar -tzf oxiquill-X.Y.Z.tgz
 npm pack --dry-run --json ./oxiquill-X.Y.Z.tgz
 ```
 
-On macOS, use `shasum -a 256 -c SHA256SUMS` if `sha256sum` is unavailable. Confirm the manifest records every tarball path, the expected package/version and tag commit, npm integrity, and the same SHA-256. Do not rebuild or rename the archive.
+On macOS, use `shasum -a 256 -c SHA256SUMS` if `sha256sum` is unavailable. Confirm the manifest records every tarball path, the expected package/version, tag commit, workflow commit, npm integrity, and the same SHA-256. Do not rebuild or rename the archive.
 
 For a published GitHub Release, the workflow attaches the same three verified files with a dedicated `contents: write` job. A rerun accepts byte-identical assets and fails on conflicting content instead of replacing it.
 
@@ -86,38 +90,41 @@ Use this section only for the first publication of the unscoped `oxiquill` packa
    npm publish ./oxiquill-0.3.0.tgz --access public --provenance=false
    ```
 
-4. Immediately configure the GitHub Trusted Publisher with the repository, workflow, environment, and stage-only permission listed in Preconditions.
+4. Immediately configure the GitHub Trusted Publisher with the repository, workflow, environment, and publish-only permission listed in Preconditions. With npm 11.15.0 or later, the equivalent interactive commands are:
+
+   ```sh
+   npm trust github oxiquill --file npm-publish.yml --repo kakune/oxiquill --env npm-publish --allow-publish
+   npm trust list oxiquill
+   ```
+
 5. Configure publishing access to require 2FA and disallow token-based publication.
 6. Remove or revoke every bootstrap credential and end the interactive session. Do not add `NPM_TOKEN`, `NODE_AUTH_TOKEN`, or a permanent token fallback to GitHub.
-7. Create the stable GitHub Release for `v0.3.0` from the exact tag and changelog entry. The workflow re-verifies and archives this release, but deliberately skips the staged publish job for the one-time bootstrap version.
+7. Create the stable GitHub Release for `v0.3.0` from the exact tag and changelog entry. The workflow re-verifies and archives this release, but deliberately skips the publish job for the one-time bootstrap version.
 8. Verify the installed package, tarball hash/contents, package README, and generated license files. Record that provenance begins with subsequent OIDC-published versions.
 
 Record completion in the GitHub Release without exposing credentials or private account data. This exception is never used again.
 
-## Normal Staged Publication
+## Normal Trusted Publication
 
 1. Create the stable GitHub Release from the exact `vX.Y.Z` tag and changelog entry. Do not mark a stable release as a prerelease.
-2. Wait for the least-privilege verify job to finish, then download that release run's `oxiquill-X.Y.Z` artifact and repeat the hash/manifest/archive inspection. The workflow rejects a non-main tag, version mismatch, open release blocker, advisory, failed validation, or changed archive.
-3. Approve the waiting `npm-publish` environment only after inspecting that exact artifact. The publish job obtains only `contents: read` and `id-token: write`, downloads the same artifact, verifies it without rebuilding, and submits the tarball with `npm stage publish` through OIDC.
-4. Inspect the staged package through npmjs.com or the current npm CLI. Download it and compare its hash and contents with the GitHub artifact before approval:
-
-   ```sh
-   npm stage list oxiquill
-   npm stage view <stage-id>
-   npm stage download <stage-id>
-   ```
-
-5. Approve the stage through npmjs.com or run `npm stage approve <stage-id>` and complete the required npm 2FA challenge.
-6. Confirm the exact version is public, installable with npm and pnpm, and shows npm provenance/publish attestations tied to this repository, workflow, tag, and protected environment.
-7. Verify the package exports, README, licenses, static starter, check, build, preview, and language fixtures from the published package rather than a workspace link.
+2. Wait for the least-privilege verify and release-assets jobs to finish, then download that release run's `oxiquill-X.Y.Z` artifact and repeat the hash/manifest/archive inspection. The workflow rejects a non-main tag, non-main workflow commit, version mismatch, open release blocker, advisory, failed validation, or changed archive.
+3. Approve the waiting `npm-publish` environment only after inspecting that exact artifact. The publish job obtains only `contents: read` and `id-token: write`, downloads the same artifact, verifies it without rebuilding, and publishes the tarball through OIDC.
+4. Confirm the exact version is public, installable with npm and pnpm, and shows npm provenance/publish attestations tied to this repository, workflow, tag, and protected environment.
+5. Verify the package exports, README, licenses, static starter, check, build, preview, and language fixtures from the published package rather than a workspace link.
 
 No normal release uses a long-lived npm write token.
+
+## Dependency Update Freeze
+
+Routine Dependabot version updates may be queued while a release candidate is frozen, but an open Dependabot security alert always blocks release. Do not merge unrelated dependency churn into a protected release branch.
+
+After the release, reopen queued updates one at a time so Dependabot rebases each branch onto the latest `main`. Process grouped minor/patch updates first, then GitHub Actions major updates, then JavaScript tooling major updates. Review breaking changes and pass all required checks before each squash merge; do not auto-merge major updates.
 
 ## Rollback and Deprecation
 
 Do not delete or retag a broken release and do not silently replace its GitHub assets.
 
-1. Stop staged approval if the version is not public yet.
+1. Stop before approving the protected `npm-publish` environment if the version is not public yet.
 2. If public, assess user/security impact and deprecate only the affected version with a concise upgrade message, for example `npm deprecate oxiquill@X.Y.Z "Use X.Y.(Z+1); see <advisory-or-issue>."`.
 3. Revert or fix the defect on a normal topic branch, add regression coverage, and prepare the next patch through the complete runbook.
 4. Update the affected GitHub Release and advisory/issue with the deprecation and replacement version. Preserve original artifacts for auditability.

--- a/packages/oxiquill/src/generator/doc-runtime/file-system.mjs
+++ b/packages/oxiquill/src/generator/doc-runtime/file-system.mjs
@@ -4,6 +4,8 @@ import path from 'node:path';
 import { pathFromUrl } from '../../config/paths.mjs';
 import { createSha256, hashBytes } from './hashing.mjs';
 
+const pendingCopies = new Map();
+
 export const defaultFileSystem = {
   copyFile,
   createReadStream,
@@ -45,6 +47,20 @@ export async function writeIfChanged(filePath, content, { fileSystem = defaultFi
 export async function copyFileIfChanged(sourcePath, targetPath, { fileSystem = defaultFileSystem } = {}) {
   const sourceFilePath = pathFromUrl(sourcePath);
   const targetFilePath = pathFromUrl(targetPath);
+  const previousCopy = pendingCopies.get(targetFilePath) ?? Promise.resolve();
+  const copy = previousCopy
+    .catch(() => {})
+    .then(() => copyFileIfChangedOnce(sourceFilePath, targetFilePath, { fileSystem }));
+  pendingCopies.set(targetFilePath, copy);
+
+  try {
+    return await copy;
+  } finally {
+    if (pendingCopies.get(targetFilePath) === copy) pendingCopies.delete(targetFilePath);
+  }
+}
+
+async function copyFileIfChangedOnce(sourceFilePath, targetFilePath, { fileSystem }) {
   await fileSystem.mkdir(path.dirname(targetFilePath), { recursive: true });
 
   if (await hasBinaryContent(sourceFilePath, targetFilePath, { fileSystem })) return false;

--- a/tests/unit/doc-runtime-service.test.mjs
+++ b/tests/unit/doc-runtime-service.test.mjs
@@ -565,6 +565,38 @@ describe('doc runtime service', () => {
     ).rejects.toThrow('broken read');
   });
 
+  it('serializes concurrent copies to the same target', async () => {
+    const fileSystem = createMemoryFileSystem({ '/repo/source.bin': Buffer.from([1, 2, 3]) });
+    let activeCopy = false;
+    let copies = 0;
+    const lockingFileSystem = {
+      ...fileSystem,
+      copyFile: async (...arguments_) => {
+        copies += 1;
+        if (activeCopy) {
+          const error = new Error('resource busy');
+          error.code = 'EBUSY';
+          throw error;
+        }
+        activeCopy = true;
+        await new Promise((resolve) => setTimeout(resolve, 5));
+        try {
+          await fileSystem.copyFile(...arguments_);
+        } finally {
+          activeCopy = false;
+        }
+      }
+    };
+
+    await expect(
+      Promise.all([
+        copyFileIfChanged('/repo/source.bin', '/repo/target.bin', { fileSystem: lockingFileSystem }),
+        copyFileIfChanged('/repo/source.bin', '/repo/target.bin', { fileSystem: lockingFileSystem })
+      ])
+    ).resolves.toEqual([true, false]);
+    expect(copies).toBe(1);
+  });
+
   it('copies Pyodide assets from a package-graph resolution', async () => {
     const paths = createDocRuntimePaths('/repo');
     const lockFile = {

--- a/tests/unit/release-workflow.test.mjs
+++ b/tests/unit/release-workflow.test.mjs
@@ -27,6 +27,7 @@ import { verifyReleaseVersions } from '../../.github/scripts/verify-release-vers
 
 const repositoryRoot = fileURLToPath(new URL('../..', import.meta.url));
 const releaseCommit = 'a'.repeat(40);
+const workflowCommit = 'c'.repeat(40);
 const temporaryDirectories = [];
 
 afterEach(async () => {
@@ -96,11 +97,15 @@ describe('release-bound version verification', () => {
 });
 
 describe('release identity verification', () => {
-  it('grants the release verifier read-only Dependabot alert access', async () => {
+  it('grants read-only Dependabot access and pins the control plane to the workflow commit', async () => {
     const workflow = await readFile(path.join(repositoryRoot, '.github/workflows/npm-publish.yml'), 'utf8');
 
     expect(workflow).toContain('vulnerability-alerts: read # Required to enforce the Dependabot alert gate.');
     expect(workflow).not.toContain('security-events:');
+    expect(workflow.match(/ref: \$\{\{ github\.workflow_sha \}\}/gu)).toHaveLength(3);
+    expect(workflow.match(/path: \.release-control/gu)).toHaveLength(3);
+    expect(workflow).toContain('node .release-control/.github/scripts/verify-release.mjs');
+    expect(workflow).toContain('Workflow commit $GITHUB_WORKFLOW_SHA is not contained in origin/main');
   });
 
   it('accepts an exact stable tag and matching package versions', () => {
@@ -175,6 +180,43 @@ describe('release identity verification', () => {
       }
     ]);
     expect(fetchImplementation.mock.calls[0][0]).toContain('/dependabot/alerts?state=open');
+    expect(new URL(fetchImplementation.mock.calls[0][0]).searchParams.has('page')).toBe(false);
+    expect(fetchImplementation.mock.calls[0][1].headers['X-GitHub-Api-Version']).toBe('2026-03-10');
+  });
+
+  it('follows cursor pagination from the GitHub Link header', async () => {
+    const firstPage = Array.from({ length: 100 }, (_, index) => dependabotAlert(index + 1));
+    const nextUrl =
+      'https://api.github.com/repos/kakune/oxiquill/dependabot/alerts?state=open&per_page=100&after=cursor';
+    const fetchImplementation = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse(firstPage, { link: `<${nextUrl}>; rel="next"` }))
+      .mockResolvedValueOnce(jsonResponse([dependabotAlert(101)]));
+
+    const alerts = await fetchOpenDependabotAlerts({
+      fetchImplementation,
+      repository: 'kakune/oxiquill',
+      token: 'token'
+    });
+
+    expect(alerts).toHaveLength(101);
+    expect(fetchImplementation).toHaveBeenCalledTimes(2);
+    expect(fetchImplementation.mock.calls[1][0]).toBe(nextUrl);
+  });
+
+  it('rejects untrusted and cyclic pagination links', async () => {
+    const untrustedFetch = vi
+      .fn()
+      .mockResolvedValue(jsonResponse([], { link: '<https://example.test/alerts?after=cursor>; rel="next"' }));
+    await expect(
+      fetchOpenDependabotAlerts({ fetchImplementation: untrustedFetch, repository: 'kakune/oxiquill' })
+    ).rejects.toThrow('untrusted URL');
+
+    const initialUrl = 'https://api.github.com/repos/kakune/oxiquill/dependabot/alerts?state=open&per_page=100';
+    const cyclicFetch = vi.fn().mockResolvedValue(jsonResponse([], { link: `<${initialUrl}>; rel="next"` }));
+    await expect(
+      fetchOpenDependabotAlerts({ fetchImplementation: cyclicFetch, repository: 'kakune/oxiquill' })
+    ).rejects.toThrow('contains a cycle');
   });
 
   it('loads milestone blockers and excludes pull requests', async () => {
@@ -225,6 +267,7 @@ describe('release archive verification', () => {
       verifyReleaseArchive(directory, '1.2.3', {
         environment: oidcEnvironment(),
         expectedCommit: releaseCommit,
+        expectedWorkflowCommit: workflowCommit,
         outputFile: null,
         requireOidc: true
       })
@@ -235,29 +278,56 @@ describe('release archive verification', () => {
     const changedArchive = await createArtifact();
     await writeFile(path.join(changedArchive, 'oxiquill-1.2.3.tgz'), 'changed');
     await expect(
-      verifyReleaseArchive(changedArchive, '1.2.3', { expectedCommit: releaseCommit, outputFile: null })
+      verifyReleaseArchive(changedArchive, '1.2.3', {
+        expectedCommit: releaseCommit,
+        expectedWorkflowCommit: workflowCommit,
+        outputFile: null
+      })
     ).rejects.toThrow('SHA-256 mismatch');
 
     const extraFile = await createArtifact();
     await writeFile(path.join(extraFile, 'substitute.tgz'), 'substitute');
     await expect(
-      verifyReleaseArchive(extraFile, '1.2.3', { expectedCommit: releaseCommit, outputFile: null })
+      verifyReleaseArchive(extraFile, '1.2.3', {
+        expectedCommit: releaseCommit,
+        expectedWorkflowCommit: workflowCommit,
+        outputFile: null
+      })
     ).rejects.toThrow('unexpected files');
   });
 
   it('rejects a manifest from a different commit', async () => {
     const directory = await createArtifact();
     await expect(
-      verifyReleaseArchive(directory, '1.2.3', { expectedCommit: 'b'.repeat(40), outputFile: null })
+      verifyReleaseArchive(directory, '1.2.3', {
+        expectedCommit: 'b'.repeat(40),
+        expectedWorkflowCommit: workflowCommit,
+        outputFile: null
+      })
     ).rejects.toThrow('does not match');
+
+    await expect(
+      verifyReleaseArchive(directory, '1.2.3', {
+        expectedCommit: releaseCommit,
+        expectedWorkflowCommit: 'b'.repeat(40),
+        outputFile: null
+      })
+    ).rejects.toThrow('workflow commit');
   });
 
   it('requires complete release manifest identity fields', () => {
     const pack = packManifest(Buffer.from('archive'));
     expect(() =>
       assertReleaseManifest(
-        { archiveSha256: '0'.repeat(64), commit: releaseCommit, name: 'oxiquill', pack, schemaVersion: 2 },
-        { commit: releaseCommit, name: 'oxiquill', version: '1.2.3' }
+        {
+          archiveSha256: '0'.repeat(64),
+          commit: releaseCommit,
+          name: 'oxiquill',
+          pack,
+          schemaVersion: 3,
+          workflowCommit
+        },
+        { commit: releaseCommit, name: 'oxiquill', version: '1.2.3', workflowCommit }
       )
     ).toThrow('identity mismatch');
   });
@@ -300,6 +370,7 @@ describe('GitHub Release asset upload', () => {
       uploadReleaseAssets({
         directory,
         expectedCommit: releaseCommit,
+        expectedWorkflowCommit: workflowCommit,
         expectedVersion: '1.2.3',
         fetchImplementation,
         repository: 'kakune/oxiquill',
@@ -333,6 +404,7 @@ describe('GitHub Release asset upload', () => {
       uploadReleaseAssets({
         directory,
         expectedCommit: releaseCommit,
+        expectedWorkflowCommit: workflowCommit,
         expectedVersion: '1.2.3',
         fetchImplementation,
         repository: 'kakune/oxiquill',
@@ -355,6 +427,7 @@ describe('GitHub Release asset upload', () => {
       uploadReleaseAssets({
         directory,
         expectedCommit: releaseCommit,
+        expectedWorkflowCommit: workflowCommit,
         expectedVersion: '1.2.3',
         fetchImplementation,
         repository: 'kakune/oxiquill',
@@ -393,7 +466,7 @@ describe('workflow supply-chain policy', () => {
     }
   });
 
-  it('keeps release OIDC and staged publishing isolated to the protected publish job', async () => {
+  it('keeps release OIDC and direct publishing isolated to the protected publish job', async () => {
     const source = await readFile(path.join(repositoryRoot, '.github/workflows/npm-publish.yml'), 'utf8');
     const [verifySource, releaseAndPublishSource] = source.split('\n  release-assets:\n');
     const [releaseAssetsSource, publishSource] = releaseAndPublishSource.split('\n  publish:\n');
@@ -407,9 +480,10 @@ describe('workflow supply-chain policy', () => {
     expect(source.match(/contents: write/gu)).toHaveLength(1);
     expect(publishSource).toContain('name: npm-publish');
     expect(publishSource).toContain("needs.verify.outputs.release_version != '0.3.0'");
-    expect(publishSource).toContain('npm stage publish');
+    expect(publishSource).toContain('npm publish "$RELEASE_ARCHIVE" --access public');
+    expect(publishSource).not.toContain('npm stage publish');
     expect(source).not.toMatch(/\bNPM_TOKEN\b|\bNODE_AUTH_TOKEN\b/u);
-    expect(source).not.toMatch(/run:\s+npm publish/u);
+    expect(source.match(/npm publish "\$RELEASE_ARCHIVE"/gu)).toHaveLength(1);
   });
 
   it('never pipes mutable remote installer content into an interpreter', async () => {
@@ -445,8 +519,9 @@ async function createArtifact() {
         commit: releaseCommit,
         name: pack.name,
         pack,
-        schemaVersion: 2,
-        version: pack.version
+        schemaVersion: 3,
+        version: pack.version,
+        workflowCommit
       },
       null,
       2
@@ -501,12 +576,22 @@ function digest(algorithm, value, encoding) {
   return createHash(algorithm).update(value).digest(encoding);
 }
 
-function jsonResponse(value) {
+function jsonResponse(value, { link = null } = {}) {
   return {
+    headers: { get: (name) => (name.toLowerCase() === 'link' ? link : null) },
     json: async () => value,
     ok: true,
     status: 200,
     text: async () => JSON.stringify(value)
+  };
+}
+
+function dependabotAlert(number) {
+  return {
+    dependency: { package: { name: `dependency-${number}` } },
+    html_url: `https://github.test/alerts/${number}`,
+    number,
+    security_advisory: { summary: `Advisory ${number}` }
   };
 }
 


### PR DESCRIPTION
## Summary

- follow GitHub REST Link headers so cursor- and page-based APIs share one fail-closed pagination path
- execute release control from the exact workflow commit while keeping package source pinned to the immutable release tag
- record both source and workflow commits in the verified release manifest
- use protected, tokenless direct OIDC publication for releases after the v0.3.0 bootstrap
- document the streamlined normal release and post-freeze Dependabot process

## Validation

- pnpm lint:js
- pnpm format:check
- pnpm exec vitest run tests/unit/release-workflow.test.mjs (37 passed)
- pnpm verify:release-version
- local create/verify/checksum inspection of an oxiquill 0.3.0 release archive (234 entries)
- full pnpm test previously completed successfully for the v0.3.0 candidate, as confirmed by the maintainer