### PR TITLE
Fix Mermaid hydration in pnpm Vite development

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,8 +188,15 @@ jobs:
         run: bash .github/scripts/install-ghc-wasm.sh
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-      - name: Test packed consumer
-        run: pnpm "test:consumer:${{ matrix.package-manager }}"
+      - name: Install Chromium for pnpm hydration tests
+        if: matrix.package-manager == 'pnpm'
+        run: pnpm exec playwright install --with-deps chromium
+      - name: Test packed npm consumer
+        if: matrix.package-manager == 'npm'
+        run: pnpm test:consumer:npm
+      - name: Test packed pnpm consumer with Chromium hydration
+        if: matrix.package-manager == 'pnpm'
+        run: pnpm test:consumer:pnpm -- --browser
 
   packed-browser:
     name: Packed browser (Chromium)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ### Fixed
 
 - Downstream Preact and SSR dependency resolution, custom consumer paths, runtime cleanup, Haskell execution, and Pyodide package availability.
+- Early desktop table-of-contents state restoration without browser reference errors.
+- Mermaid Flowchart and Gantt hydration in pnpm consumer development servers by routing Mermaid through Vite dependency optimization ([#100](https://github.com/kakune/oxiquill/issues/100)).
 - Production dependency advisories present in the v0.2.0 dependency graph.
 
 ### Security

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "test:consumer": "pnpm test:consumer:npm && pnpm test:consumer:pnpm",
     "test:consumer:npm": "node tests/package/consumer-smoke.mjs --package-manager npm",
     "test:consumer:pnpm": "node tests/package/consumer-smoke.mjs --package-manager pnpm",
-    "test:packed-browser": "node tests/package/consumer-smoke.mjs --package-manager npm --browser",
+    "test:packed-browser": "node tests/package/consumer-smoke.mjs --package-manager pnpm --browser",
     "test:consumer:registry:npm": "node tests/package/consumer-smoke.mjs --package-manager npm --registry",
     "test:consumer:registry:pnpm": "node tests/package/consumer-smoke.mjs --package-manager pnpm --registry",
     "verify:release-version": "node .github/scripts/verify-release-version.mjs",

--- a/packages/oxiquill/src/astro/index.ts
+++ b/packages/oxiquill/src/astro/index.ts
@@ -97,6 +97,7 @@ const viteAliasedPackageNames = [
 ];
 const viteSsrNoExternalPackageNames = ['@astrojs/preact', 'oxiquill', 'preact', 'preact-render-to-string'];
 const viteResolveDedupePackageNames = ['@preact/signals', 'preact', 'preact-render-to-string'];
+const viteOptimizeDepsInclude = ['oxiquill > mermaid'];
 
 export interface OxiquillFrameworkOptions<StarlightOptions extends object = object> {
   preact?: PreactIntegrationFactory;
@@ -483,10 +484,15 @@ function mergeViteConfig(
   const serverFs = server.fs ?? {};
   const ssr = vite.ssr ?? {};
   const resolve = vite.resolve ?? {};
+  const optimizeDeps = vite.optimizeDeps ?? {};
   const alias = mergeAlias(oxiquillDependencyAliases(paths), resolve.alias);
 
   return {
     ...vite,
+    optimizeDeps: {
+      ...optimizeDeps,
+      include: mergeStringList(optimizeDeps.include, viteOptimizeDepsInclude)
+    },
     resolve: {
       ...resolve,
       ...(alias ? { alias } : {}),

--- a/packages/oxiquill/src/components/starlight/TwoColumnContent.astro
+++ b/packages/oxiquill/src/components/starlight/TwoColumnContent.astro
@@ -4,23 +4,20 @@ import { togglePresentation } from './toggle-localization.js';
 
 const { dir, lang, toc } = Astro.locals.starlightRoute;
 const presentation = togglePresentation(lang, dir, 'tableOfContents');
+const hasTableOfContents = Boolean(toc);
 ---
 
-<script is:inline>
-  {
-    `
-		(() => {
-			let collapsed = false;
-			try {
-				collapsed =
-					${Boolean(toc)} &&
-					matchMedia('(min-width: 72rem)').matches &&
-					sessionStorage.getItem('oxiquill-table-of-contents-collapsed') === 'true';
-			} catch {}
-			document.documentElement.toggleAttribute('data-table-of-contents-collapsed', collapsed);
-		})();
-	`;
-  }
+<script is:inline define:vars={{ hasTableOfContents }}>
+  (() => {
+    let collapsed = false;
+    try {
+      collapsed =
+        hasTableOfContents &&
+        matchMedia('(min-width: 72rem)').matches &&
+        sessionStorage.getItem('oxiquill-table-of-contents-collapsed') === 'true';
+    } catch {}
+    document.documentElement.toggleAttribute('data-table-of-contents-collapsed', collapsed);
+  })();
 </script>
 
 <div class="two-column-content lg:sl-flex">

--- a/tests/package/consumer-smoke.mjs
+++ b/tests/package/consumer-smoke.mjs
@@ -172,9 +172,25 @@ try {
   if (packageManager === 'pnpm') {
     await appendFile(
       path.join(consumerRoot, 'content/docs/index.mdx'),
-      ['', '```mermaid', 'graph TD', '  core --> linalg', '```', ''].join('\n')
+      [
+        '',
+        '```mermaid',
+        'flowchart TD',
+        '  core --> linalg',
+        '```',
+        '',
+        '```mermaid',
+        'gantt',
+        '  title Packed consumer release schedule',
+        '  dateFormat YYYY-MM-DD',
+        '  section Release',
+        '  Fix hydration :done, fix, 2026-08-29, 1d',
+        '  Publish package :publish, after fix, 1d',
+        '```',
+        ''
+      ].join('\n')
     );
-    await runInstalledDevSmoke({ consumerRoot });
+    await runInstalledDevSmoke({ browserEnabled: browserSmoke, consumerRoot });
   }
 
   const nodeOnlyEnvironment = createNodeOnlyEnvironment();
@@ -391,7 +407,9 @@ async function runInstalledBrowserSmoke({ consumerRoot, installedCliPath, projec
       ...(executablePath ? { executablePath } : {})
     });
     const page = await browser.newPage();
+    const pageErrors = collectPageErrors(page);
     await page.goto(`http://127.0.0.1:${port}/`);
+    await assertMermaidHydration(page);
     const tableOfContentsToggle = page.locator('starlight-table-of-contents-toggle button');
     await tableOfContentsToggle.waitFor({ state: 'visible' });
     assert.equal(await tableOfContentsToggle.getAttribute('aria-expanded'), 'true');
@@ -421,6 +439,7 @@ async function runInstalledBrowserSmoke({ consumerRoot, installedCliPath, projec
       await haskellOutput.waitFor({ state: 'visible', timeout: 60_000 });
       assert.match(await haskellOutput.textContent(), /packed-consumer: Haskell\/WASI/u);
     }
+    assertNoPageErrors(pageErrors, 'packed production preview');
   } finally {
     await browser?.close();
     if (serverReady) stopAstroPreview(packageManager, consumerRoot);
@@ -434,8 +453,9 @@ async function runInstalledBrowserSmoke({ consumerRoot, installedCliPath, projec
   }
 }
 
-async function runInstalledDevSmoke({ consumerRoot }) {
+async function runInstalledDevSmoke({ browserEnabled, consumerRoot }) {
   const port = 4_386;
+  let browser;
 
   try {
     run(
@@ -452,9 +472,64 @@ async function runInstalledDevSmoke({ consumerRoot }) {
       !/Cannot read properties of undefined|__H/u.test(html),
       'packed development response contained a Preact hook error'
     );
+
+    if (browserEnabled) {
+      const executablePath = process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH?.trim();
+      browser = await chromium.launch({
+        headless: true,
+        ...(executablePath ? { executablePath } : {})
+      });
+      const page = await browser.newPage();
+      const pageErrors = collectPageErrors(page);
+      await page.goto(`http://127.0.0.1:${port}/`);
+      await assertMermaidHydration(page);
+      assertNoPageErrors(pageErrors, 'packed development server');
+    }
   } finally {
+    await browser?.close();
     stopAstroDev(packageManager, consumerRoot);
   }
+}
+
+async function assertMermaidHydration(page) {
+  const diagrams = page.getByTestId('mermaid-diagram');
+  await diagrams.first().waitFor({ state: 'visible', timeout: 60_000 });
+  assert.equal(await diagrams.count(), 2, 'packed consumer must render the Flowchart and Gantt fixtures');
+  await page.waitForFunction(
+    (expectedCount) => {
+      const elements = [...document.querySelectorAll('[data-testid="mermaid-diagram"]')];
+      return elements.length === expectedCount && elements.every((element) => element.dataset.state === 'ready');
+    },
+    2,
+    { timeout: 60_000 }
+  );
+
+  for (let index = 0; index < 2; index += 1) {
+    const diagram = diagrams.nth(index);
+    assert.equal(await diagram.getAttribute('data-state'), 'ready');
+    const svg = diagram.locator('.mermaid-diagram__surface > svg');
+    await svg.waitFor({ state: 'visible', timeout: 60_000 });
+    assert.equal(await svg.count(), 1, `Mermaid fixture ${index + 1} did not render exactly one SVG`);
+    assert.equal(
+      await diagram.getByRole('alert').count(),
+      0,
+      `Mermaid fixture ${index + 1} rendered an error fallback`
+    );
+  }
+}
+
+function collectPageErrors(page) {
+  const errors = [];
+  page.on('pageerror', (error) => errors.push(error));
+  return errors;
+}
+
+function assertNoPageErrors(errors, stage) {
+  assert.equal(
+    errors.length,
+    0,
+    `${stage} emitted page errors:\n${errors.map((error) => error.stack ?? error.message).join('\n')}`
+  );
 }
 
 async function waitForHttpResponse(url, timeoutMs) {

--- a/tests/package/consumer-smoke.mjs
+++ b/tests/package/consumer-smoke.mjs
@@ -374,7 +374,7 @@ try {
   await assertFile(path.join(projectRoot, 'content/docs/index.mdx'));
   console.log(`Packed consumer smoke test passed with ${packageManager} in ${consumerRoot}.`);
 } finally {
-  await rm(temporaryRoot, { force: true, recursive: true });
+  await rm(temporaryRoot, { force: true, maxRetries: 10, recursive: true, retryDelay: 250 });
 }
 
 async function runInstalledBrowserSmoke({ consumerRoot, installedCliPath, projectRoot }) {
@@ -391,6 +391,7 @@ async function runInstalledBrowserSmoke({ consumerRoot, installedCliPath, projec
   const serverOutput = [];
   let serverError;
   let serverReady = false;
+  let serverPid;
   server.stdout.on('data', (chunk) => serverOutput.push(String(chunk)));
   server.stderr.on('data', (chunk) => serverOutput.push(String(chunk)));
   server.once('error', (error) => {
@@ -401,6 +402,7 @@ async function runInstalledBrowserSmoke({ consumerRoot, installedCliPath, projec
   try {
     await waitForHttp(`http://127.0.0.1:${port}/`, 60_000, server, serverOutput, () => serverError);
     serverReady = true;
+    serverPid = await readBackgroundServerPid(projectRoot, 'preview');
     const executablePath = process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH?.trim();
     browser = await chromium.launch({
       headless: true,
@@ -442,13 +444,18 @@ async function runInstalledBrowserSmoke({ consumerRoot, installedCliPath, projec
     assertNoPageErrors(pageErrors, 'packed production preview');
   } finally {
     await browser?.close();
-    if (serverReady) stopAstroPreview(packageManager, consumerRoot);
-    if (server.exitCode === null && !server.signalCode) {
-      server.kill('SIGTERM');
-      await Promise.race([
-        new Promise((resolve) => server.once('exit', resolve)),
-        new Promise((resolve) => setTimeout(resolve, 5_000))
-      ]);
+    try {
+      if (serverReady) {
+        await stopAstroBackgroundServer({ command: 'preview', cwd: consumerRoot, pid: serverPid, root: projectRoot });
+      }
+    } finally {
+      if (server.exitCode === null && !server.signalCode) {
+        server.kill('SIGTERM');
+        await Promise.race([
+          new Promise((resolve) => server.once('exit', resolve)),
+          new Promise((resolve) => setTimeout(resolve, 5_000))
+        ]);
+      }
     }
   }
 }
@@ -456,6 +463,7 @@ async function runInstalledBrowserSmoke({ consumerRoot, installedCliPath, projec
 async function runInstalledDevSmoke({ browserEnabled, consumerRoot }) {
   const port = 4_386;
   let browser;
+  let serverPid;
 
   try {
     run(
@@ -464,6 +472,7 @@ async function runInstalledDevSmoke({ browserEnabled, consumerRoot }) {
       consumerRoot
     );
     const response = await waitForHttpResponse(`http://127.0.0.1:${port}/`, 60_000);
+    serverPid = await readBackgroundServerPid(consumerRoot, 'dev');
     const html = await response.text();
 
     assert.equal(response.status, 200, `packed development server returned ${response.status}`);
@@ -487,7 +496,7 @@ async function runInstalledDevSmoke({ browserEnabled, consumerRoot }) {
     }
   } finally {
     await browser?.close();
-    stopAstroDev(packageManager, consumerRoot);
+    await stopAstroBackgroundServer({ command: 'dev', cwd: consumerRoot, pid: serverPid });
   }
 }
 
@@ -530,6 +539,58 @@ function assertNoPageErrors(errors, stage) {
     0,
     `${stage} emitted page errors:\n${errors.map((error) => error.stack ?? error.message).join('\n')}`
   );
+}
+
+async function readBackgroundServerPid(cwd, command) {
+  const state = JSON.parse(await readFile(path.join(cwd, '.astro', `${command}.json`), 'utf8'));
+  assert.ok(Number.isSafeInteger(state.pid) && state.pid > 0, `Astro ${command} state did not contain a valid PID`);
+  return state.pid;
+}
+
+async function stopAstroBackgroundServer({ command, cwd, pid, root }) {
+  let stopError;
+  try {
+    if (command === 'dev') stopAstroDev(packageManager, cwd);
+    else stopAstroPreview(packageManager, cwd, root);
+  } catch (error) {
+    stopError = error;
+  }
+
+  if (pid !== undefined && !(await waitForProcessExit(pid, 1_000))) {
+    try {
+      process.kill(pid, 'SIGTERM');
+    } catch {
+      // The process exited between the liveness check and the signal.
+    }
+    if (!(await waitForProcessExit(pid, 5_000))) {
+      try {
+        process.kill(pid, 'SIGKILL');
+      } catch {
+        // The process exited between the liveness check and the signal.
+      }
+      assert.ok(await waitForProcessExit(pid, 5_000), `Astro ${command} server process ${pid} did not exit`);
+    }
+  }
+
+  if (stopError) throw stopError;
+}
+
+async function waitForProcessExit(pid, timeoutMs) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (!isProcessAlive(pid)) return true;
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  return !isProcessAlive(pid);
+}
+
+function isProcessAlive(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 async function waitForHttpResponse(url, timeoutMs) {
@@ -610,9 +671,11 @@ function initializeConsumer(packageManager, packageSource, target, cwd) {
   run(packageManager, args, cwd);
 }
 
-function stopAstroPreview(packageManager, cwd) {
+function stopAstroPreview(packageManager, cwd, root) {
   const args =
-    packageManager === 'npm' ? ['exec', '--', 'astro', 'preview', 'stop'] : ['exec', 'astro', 'preview', 'stop'];
+    packageManager === 'npm'
+      ? ['exec', '--', 'astro', 'preview', 'stop', ...(root ? ['--root', root] : [])]
+      : ['exec', 'astro', 'preview', 'stop', ...(root ? ['--root', root] : [])];
   run(packageManager, args, cwd);
 }
 

--- a/tests/unit/astro-config.test.mjs
+++ b/tests/unit/astro-config.test.mjs
@@ -482,6 +482,30 @@ describe('defineOxiquillConfig', () => {
     );
   });
 
+  it('merges Mermaid into consumer Vite dependency optimization without duplicates', () => {
+    const config = defineOxiquillConfig({
+      sidebar: [],
+      title: 'Docs',
+      vite: {
+        optimizeDeps: {
+          entries: ['consumer-entry.ts'],
+          exclude: ['consumer-runtime'],
+          include: ['consumer-runtime', 'oxiquill > mermaid', 'oxiquill > mermaid'],
+          noDiscovery: true
+        }
+      }
+    });
+
+    const update = runConfigSetup(config, linkedConsumerRoot);
+
+    expect(update.vite.optimizeDeps).toEqual({
+      entries: ['consumer-entry.ts'],
+      exclude: ['consumer-runtime'],
+      include: ['consumer-runtime', 'oxiquill > mermaid'],
+      noDiscovery: true
+    });
+  });
+
   it('normalizes singular consumer SSR noExternal entries when merging Oxiquill defaults', () => {
     for (const noExternal of ['consumer-package', /^consumer-/]) {
       const config = defineOxiquillConfig({
@@ -528,6 +552,7 @@ describe('defineOxiquillConfig', () => {
       '@bjorn3/browser_wasi_shim',
       'aria-query',
       'html-escaper',
+      'mermaid',
       'astro/app',
       'astro/content/runtime',
       'astro/jsx-runtime',
@@ -547,6 +572,7 @@ describe('defineOxiquillConfig', () => {
     expect(resolved['@preact/signals']).toEqual(expect.any(String));
     expect(resolved['aria-query']).toEqual(expect.any(String));
     expect(resolved['html-escaper']).toEqual(expect.any(String));
+    expect(resolved.mermaid).toEqual(expect.any(String));
     expect(resolved['astro/app']).toEqual(expect.any(String));
     expect(resolved['astro/content/runtime']).toEqual(expect.any(String));
     expect(resolved['astro/jsx-runtime']).toEqual(expect.any(String));

--- a/tests/unit/release-workflow.test.mjs
+++ b/tests/unit/release-workflow.test.mjs
@@ -443,12 +443,16 @@ describe('workflow supply-chain policy', () => {
     const source = await readFile(path.join(repositoryRoot, '.github/workflows/ci.yml'), 'utf8');
     const packageJson = JSON.parse(await readFile(path.join(repositoryRoot, 'package.json'), 'utf8'));
 
-    expect(source).toContain('pnpm "test:consumer:${{ matrix.package-manager }}"');
+    expect(source).toContain("if: matrix.package-manager == 'npm'");
+    expect(source).toContain('run: pnpm test:consumer:npm');
+    expect(source).toContain("if: matrix.package-manager == 'pnpm'");
+    expect(source).toContain('run: pnpm test:consumer:pnpm -- --browser');
     expect(source).toContain('run: pnpm test:packed-browser');
     expect(source).toContain('run: pnpm exec playwright install --with-deps chromium');
     expect(source).not.toContain('${PACKAGE_MANAGER}');
+    expect(source).not.toContain('test:consumer:${{ matrix.package-manager }}');
     expect(packageJson.scripts['test:packed-browser']).toBe(
-      'node tests/package/consumer-smoke.mjs --package-manager npm --browser'
+      'node tests/package/consumer-smoke.mjs --package-manager pnpm --browser'
     );
   });
 


### PR DESCRIPTION
## Summary

- include `oxiquill > mermaid` in the merged Vite dependency optimizer configuration without changing consumer aliases or direct dependencies
- exercise Flowchart and date-based Gantt hydration in packed pnpm consumers under dev and production preview
- run Chromium hydration coverage for pnpm consumers on Linux, macOS, and Windows
- remove an existing table-of-contents initialization page error surfaced by the new browser gate

## Validation

- `pnpm lint`
- `pnpm check`
- `pnpm test:unit`
- `pnpm test:unit:coverage`
- `pnpm test:package`
- `pnpm test:consumer:pnpm`
- `pnpm test:packed-browser`

Fixes #100