### PR TITLE
Chore: remove stale jsdom undici override

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,6 @@ settings:
 
 overrides:
   '@astrojs/markdown-satteri': 0.3.6
-  jsdom>undici: 7.29.0
 
 importers:
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,4 +8,3 @@ allowBuilds:
 
 overrides:
   '@astrojs/markdown-satteri': 0.3.6
-  'jsdom>undici': 7.29.0


### PR DESCRIPTION
## Summary

- remove the jsdom 29-specific override that forced undici 7.29.0
- keep the current frozen lock resolution unchanged for jsdom 29
- allow the separately reviewed jsdom 30 update in #95 to resolve its declared undici ^8.9.0 dependency instead of an out-of-range major

## Validation

- pnpm install --lockfile-only
- pnpm install --frozen-lockfile
- pnpm lint
- pnpm test:unit (501 passed, 1 skipped)