### PR TITLE
Fix MDX math discovery and categorical heatmap rendering

### DIFF
--- a/examples/docs-site/content/docs/features/rich-output.mdx
+++ b/examples/docs-site/content/docs/features/rich-output.mdx
@@ -33,18 +33,19 @@ Table columns contain `key`, `label`, and optional `type`: `string`, `number`, `
 
 ## Chart Schema
 
-All chart specs accept optional `title`, `xLabel`, `yLabel`, `xType`, `yType`, `legend`, `tooltip`, and `dataZoom`. Axis types are `value`, `category`, `time`, and `log`. Unspecified axes default to `value`, except the category axes intrinsic to bar/histogram charts and heatmap axes with a corresponding categories array.
+All chart specs accept optional `title`, `xLabel`, `yLabel`, `xType`, `yType`, `legend`, `tooltip`, and `dataZoom`. Axis types are `value`, `category`, `time`, and `log`. Unspecified axes default to `value`, except the category axes intrinsic to bar/histogram charts. A heatmap always has category axes on both dimensions: its `xType` and `yType` may be omitted or set to `category`, while `value`, `time`, and `log` are rejected.
 
 - `value` coordinates are finite numbers, and `log` coordinates are finite numbers greater than zero.
 - `time` coordinates are finite epoch milliseconds or ISO-8601 strings in `YYYY-MM-DDTHH:mm:ss[.sss]Z` or `YYYY-MM-DDTHH:mm:ss[.sss]±HH:mm` form. Calendar fields and the explicit time zone must be valid.
-- `category` coordinates are strings or finite numbers. When a heatmap supplies `xCategories` or `yCategories`, a coordinate must be a listed string or an in-range zero-based integer index. A declared categories array makes that axis categorical; a conflicting axis type is rejected.
+- `category` coordinates are strings or finite numbers. For a heatmap axis with an explicit `xCategories` or `yCategories` array, each coordinate must be an exact listed string or a safe, in-range zero-based integer index. An index resolves to the category name at that position; it is never converted into a new numeric-looking category name.
+- For a heatmap axis without an explicit categories array, finite numbers and strings are normalized with `String(coordinate)`. Categories are inferred in first-appearance order, so values with the same normalized label, such as `1` and `"1"`, share one category. X and Y are normalized independently when only one axis declares categories.
 
 - `line`, `scatter`, and `area`: `series[]`, each with optional `name` and `[x, y]` points.
 - `bar`: string `categories[]` plus series of numeric-or-null `values[]` with matching length.
 - `histogram`: `bins[]` as finite `[lower, upper, count]` tuples, where `lower < upper` and count is non-negative.
-- `heatmap`: optional `xCategories`/`yCategories` and finite `[x, y, value]` cells.
+- `heatmap`: optional string `xCategories`/`yCategories` arrays and finite `[x, y, value]` cells on two category axes.
 
-Empty charts and equal point domains are valid. Heatmaps report X, Y, and heat-value ranges separately; their color scale uses the actual heat values, with a `0–1` fallback only for an empty dataset. Charts expose a textual title/caption and bounded accessible summary or equivalent table. The implementation canvas is hidden from accessibility APIs when that equivalent is present.
+Empty charts and equal point domains are valid. Heatmaps report X- and Y-category counts plus the heat-value range; their color scale uses the actual heat values, with a `0–1` fallback only for an empty dataset. Charts expose a textual title/caption and bounded accessible summary or equivalent table. The implementation canvas is hidden from accessibility APIs when that equivalent is present.
 
 Charts use contrast-aware colors for the current Starlight light/dark theme, recreate their ECharts instance when `html[data-theme]` changes, and expose a retry action after a transient renderer load failure.
 
@@ -131,11 +132,13 @@ let columns = vec![
     serde_json::json!({"key": "label", "label": "Label", "type": "string"}),
     serde_json::json!({"key": "score", "label": "Score", "type": "integer"}),
 ];
+let heatmap = [[0, 0, 1], [1, 0, 3], [0, 1, 2], [1, 1, 4]];
 
 emit_json!(&serde_json::json!({"status": "ok", "rows": rows.len()}));
 emit_records_table!(&rows);
 emit_table_with_columns!(&columns, &rows);
 emit_bar_chart!(&["alpha", "beta", "gamma"], &[3, 5, 4]);
+emit_heatmap!(&heatmap);
 emit_svg!(
     r##"<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 48"><rect width="160" height="48" fill="#ecfeff"/><circle cx="32" cy="24" r="14" fill="#0f766e"/><rect x="64" y="12" width="72" height="24" rx="4" fill="#2563eb"/></svg>"##,
     "Simple generated SVG"

--- a/examples/docs-site/content/docs/ja/features/rich-output.mdx
+++ b/examples/docs-site/content/docs/ja/features/rich-output.mdx
@@ -33,18 +33,19 @@ table column は `key`、`label`、optional `type` を持ちます。type は `s
 
 ## Chart schema
 
-すべての chart spec は optional `title`、`xLabel`、`yLabel`、`xType`、`yType`、`legend`、`tooltip`、`dataZoom` を受け取ります。axis type は `value`、`category`、`time`、`log` です。未指定 axis は `value` が default ですが、bar/histogram 固有の category axis と、対応する categories array を持つ heatmap axis は `category` になります。
+すべての chart spec は optional `title`、`xLabel`、`yLabel`、`xType`、`yType`、`legend`、`tooltip`、`dataZoom` を受け取ります。axis type は `value`、`category`、`time`、`log` です。未指定 axis は `value` が default ですが、bar/histogram 固有の axis は category です。heatmap は常に X/Y 両方が category axis であり、`xType` と `yType` は省略するか `category` にできますが、`value`、`time`、`log` は reject されます。
 
 - `value` coordinate は finite number、`log` coordinate は 0 より大きい finite number です。
 - `time` coordinate は finite epoch millisecond、または `YYYY-MM-DDTHH:mm:ss[.sss]Z` / `YYYY-MM-DDTHH:mm:ss[.sss]±HH:mm` 形式の ISO-8601 string です。calendar field と明示的な time zone も valid である必要があります。
-- `category` coordinate は string または finite number です。heatmap が `xCategories` / `yCategories` を持つ場合は、listed string または範囲内の zero-based integer index に限定されます。categories array を宣言した axis は category になり、矛盾する axis type は reject されます。
+- `category` coordinate は string または finite number です。heatmap axis に明示的な `xCategories` / `yCategories` array がある場合、coordinate は完全一致する listed string、または範囲内の safe な zero-based integer index に限定されます。index はその位置の category name に解決され、数値らしい新しい category name には変換されません。
+- heatmap axis に明示的な categories array がない場合、finite number と string は `String(coordinate)` で正規化され、category は初出順に推論されます。`1` と `"1"` のように同じ label に正規化される値は一つの category を共有します。片方の axis だけ categories を宣言した場合も、X と Y は独立して正規化されます。
 
 - `line`、`scatter`、`area`: optional `name` と `[x, y]` point を持つ `series[]`。
 - `bar`: string `categories[]` と同じ length の numeric-or-null `values[]` series。
 - `histogram`: `lower < upper` かつ count が non-negative の finite `[lower, upper, count]` tuple の `bins[]`。
-- `heatmap`: optional `xCategories`/`yCategories` と finite `[x, y, value]` cell。
+- `heatmap`: optional string `xCategories`/`yCategories` array と、二つの category axis 上の finite `[x, y, value]` cell。
 
-empty chart と equal point domain は valid です。heatmap は X、Y、heat value の範囲を別々に示し、color scale には実際の heat value を使います。empty dataset だけは `0–1` を fallback にします。chart は textual title/caption と bounded accessible summary または equivalent table を提供します。equivalent がある場合、implementation canvas は accessibility API から隠されます。
+empty chart と equal point domain は valid です。heatmap は X/Y の category 数と heat value の範囲を示し、color scale には実際の heat value を使います。empty dataset だけは `0–1` を fallback にします。chart は textual title/caption と bounded accessible summary または equivalent table を提供します。equivalent がある場合、implementation canvas は accessibility API から隠されます。
 
 chart は現在の Starlight light/dark theme に合わせた contrast-aware color を使い、`html[data-theme]` の変更時に ECharts instance を作り直します。一時的な renderer load failure の後には retry action を表示します。
 
@@ -131,11 +132,13 @@ let columns = vec![
     serde_json::json!({"key": "label", "label": "Label", "type": "string"}),
     serde_json::json!({"key": "score", "label": "Score", "type": "integer"}),
 ];
+let heatmap = [[0, 0, 1], [1, 0, 3], [0, 1, 2], [1, 1, 4]];
 
 emit_json!(&serde_json::json!({"status": "ok", "rows": rows.len()}));
 emit_records_table!(&rows);
 emit_table_with_columns!(&columns, &rows);
 emit_bar_chart!(&["alpha", "beta", "gamma"], &[3, 5, 4]);
+emit_heatmap!(&heatmap);
 emit_svg!(
     r##"<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 48"><rect width="160" height="48" fill="#ecfeff"/><circle cx="32" cy="24" r="14" fill="#0f766e"/><rect x="64" y="12" width="72" height="24" rx="4" fill="#2563eb"/></svg>"##,
     "Simple generated SVG"

--- a/packages/oxiquill/src/components/doc-runtime/ChartOutput.tsx
+++ b/packages/oxiquill/src/components/doc-runtime/ChartOutput.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'preact/hooks';
+import { normalizeHeatmapSpec, type NormalizedHeatmapSpec } from '../../lib/doc-runtime/heatmap-normalization.js';
 import { boundedErrorMessage } from '../../lib/doc-runtime/output-limits.mjs';
 import type { RuntimeLabels } from '../../lib/doc-runtime/runtime-localization.js';
 import type { ChartArtifact, ChartSpec } from '../../lib/doc-runtime/types.js';
@@ -175,7 +176,8 @@ export function currentChartTheme(): ChartTheme {
 }
 
 export function chartSpecToEChartsOptions(spec: ChartSpec, theme: ChartTheme = 'light'): EChartsOptions {
-  const series = chartSeries(spec);
+  const structure = chartStructure(spec);
+  const { series } = structure;
   const colors = chartColors[theme];
   const axisStyle = {
     axisLabel: { color: colors.axis },
@@ -202,14 +204,14 @@ export function chartSpecToEChartsOptions(spec: ChartSpec, theme: ChartTheme = '
     title: spec.title
       ? { text: spec.title, left: 'center', textStyle: { color: colors.text, fontSize: 14, fontWeight: 600 } }
       : undefined,
-    xAxis: { ...xAxis(spec), ...axisStyle },
-    yAxis: { ...yAxis(spec), ...axisStyle },
+    xAxis: { ...structure.xAxis, ...axisStyle },
+    yAxis: { ...structure.yAxis, ...axisStyle },
     dataZoom: spec.dataZoom === false ? undefined : [{ type: 'inside' }],
     series
   };
 
-  if (spec.kind === 'heatmap') {
-    const valueRange = numericBounds(spec.data, (item) => item[2]);
+  if (structure.heatmap) {
+    const valueRange = numericBounds(structure.heatmap.data, (item) => item[2]);
     return {
       ...base,
       dataZoom: undefined,
@@ -308,24 +310,20 @@ function chartSummaryDetails(spec: ChartSpec, labels: RuntimeLabels) {
           spec.yType
         )
       };
-    case 'heatmap':
+    case 'heatmap': {
+      const heatmap = normalizeHeatmapSpec(spec);
       return {
         dataCount: spec.data.length,
         seriesCount: 1,
         seriesNames: '',
-        xRange: range(
-          spec.data.map((item) => item[0]),
-          spec.xCategories ? 'category' : spec.xType
-        ),
-        yRange: range(
-          spec.data.map((item) => item[1]),
-          spec.yCategories ? 'category' : spec.yType
-        ),
+        xCategoryCount: heatmap.xCategories.length,
+        yCategoryCount: heatmap.yCategories.length,
         valueRange: numericRange(
-          spec.data.map((item) => item[2]),
+          heatmap.data.map((item) => item[2]),
           numberFormat
         )
       };
+    }
   }
 }
 
@@ -380,7 +378,30 @@ function boundedSummary(value: string, maximumLength = 4_000): string {
   return value.length <= maximumLength ? value : `${value.slice(0, maximumLength - 1)}…`;
 }
 
-function chartSeries(spec: ChartSpec): readonly Record<string, unknown>[] {
+function chartStructure(spec: ChartSpec): {
+  heatmap?: NormalizedHeatmapSpec;
+  series: readonly Record<string, unknown>[];
+  xAxis: Record<string, unknown>;
+  yAxis: Record<string, unknown>;
+} {
+  if (spec.kind === 'heatmap') {
+    const heatmap = normalizeHeatmapSpec(spec);
+    return {
+      heatmap,
+      series: [{ type: 'heatmap', data: heatmap.data }],
+      xAxis: categoryAxis(heatmap.xCategories, spec.xLabel),
+      yAxis: categoryAxis(heatmap.yCategories, spec.yLabel)
+    };
+  }
+
+  return {
+    series: chartSeries(spec),
+    xAxis: xAxis(spec),
+    yAxis: yAxis(spec)
+  };
+}
+
+function chartSeries(spec: Exclude<ChartSpec, { kind: 'heatmap' }>): readonly Record<string, unknown>[] {
   switch (spec.kind) {
     case 'line':
       return spec.series.map((series) => ({
@@ -418,14 +439,12 @@ function chartSeries(spec: ChartSpec): readonly Record<string, unknown>[] {
         areaStyle: { opacity: 0.18 },
         data: series.points
       }));
-    case 'heatmap':
-      return [{ type: 'heatmap', data: spec.data }];
     default:
       return [];
   }
 }
 
-function xAxis(spec: ChartSpec): Record<string, unknown> {
+function xAxis(spec: Exclude<ChartSpec, { kind: 'heatmap' }>): Record<string, unknown> {
   if (spec.kind === 'bar') {
     return categoryAxis(spec.categories, spec.xLabel);
   }
@@ -437,18 +456,10 @@ function xAxis(spec: ChartSpec): Record<string, unknown> {
     );
   }
 
-  if (spec.kind === 'heatmap' && spec.xCategories) {
-    return categoryAxis(spec.xCategories, spec.xLabel);
-  }
-
   return valueAxis(spec.xType ?? 'value', spec.xLabel);
 }
 
-function yAxis(spec: ChartSpec): Record<string, unknown> {
-  if (spec.kind === 'heatmap' && spec.yCategories) {
-    return categoryAxis(spec.yCategories, spec.yLabel);
-  }
-
+function yAxis(spec: Exclude<ChartSpec, { kind: 'heatmap' }>): Record<string, unknown> {
   return valueAxis(spec.yType ?? 'value', spec.yLabel);
 }
 

--- a/packages/oxiquill/src/generator/doc-runtime/cell-parser.mjs
+++ b/packages/oxiquill/src/generator/doc-runtime/cell-parser.mjs
@@ -1,4 +1,5 @@
 import { unified } from 'unified';
+import remarkMath from 'remark-math';
 import remarkMdx from 'remark-mdx';
 import remarkParse from 'remark-parse';
 import {
@@ -11,7 +12,7 @@ import { sourceThemes } from './constants.mjs';
 import { assertUniqueCellIds } from './validators.mjs';
 
 const markdownParser = unified().use(remarkParse);
-const mdxParser = unified().use(remarkParse).use(remarkMdx);
+const mdxParser = unified().use(remarkParse).use(remarkMath).use(remarkMdx);
 
 export function parseCellsFromMarkdown(source, pagePath) {
   const parser = String(pagePath).endsWith('.mdx') ? mdxParser : markdownParser;

--- a/packages/oxiquill/src/lib/doc-runtime/heatmap-normalization.ts
+++ b/packages/oxiquill/src/lib/doc-runtime/heatmap-normalization.ts
@@ -1,0 +1,52 @@
+import type { HeatmapChartSpec } from './types.js';
+
+export interface NormalizedHeatmapSpec {
+  data: readonly (readonly [string, string, number])[];
+  xCategories: readonly string[];
+  yCategories: readonly string[];
+}
+
+type HeatmapCoordinate = HeatmapChartSpec['data'][number][0];
+
+export function normalizeHeatmapSpec(spec: HeatmapChartSpec): NormalizedHeatmapSpec {
+  const xAxis = heatmapAxisNormalizer(spec.xCategories);
+  const yAxis = heatmapAxisNormalizer(spec.yCategories);
+  const data = spec.data.map(([x, y, value]) => [xAxis.normalize(x), yAxis.normalize(y), value] as const);
+
+  return {
+    data,
+    xCategories: xAxis.categories,
+    yCategories: yAxis.categories
+  };
+}
+
+function heatmapAxisNormalizer(explicitCategories?: readonly string[]): {
+  categories: readonly string[];
+  normalize: (coordinate: HeatmapCoordinate) => string;
+} {
+  if (explicitCategories) {
+    return {
+      categories: explicitCategories,
+      normalize: (coordinate) => {
+        if (typeof coordinate === 'string') return coordinate;
+        const category = explicitCategories[coordinate];
+        if (category == null) throw new Error('Validated heatmap category index is out of range.');
+        return category;
+      }
+    };
+  }
+
+  const categories: string[] = [];
+  const categoryNames = new Set<string>();
+  return {
+    categories,
+    normalize: (coordinate) => {
+      const category = String(coordinate);
+      if (!categoryNames.has(category)) {
+        categoryNames.add(category);
+        categories.push(category);
+      }
+      return category;
+    }
+  };
+}

--- a/packages/oxiquill/src/lib/doc-runtime/output-artifact-validation.ts
+++ b/packages/oxiquill/src/lib/doc-runtime/output-artifact-validation.ts
@@ -1,5 +1,6 @@
 import type {
   ArtifactStream,
+  BaseChartSpec,
   ChartAxisType,
   ChartSpec,
   HtmlArtifact,
@@ -436,8 +437,24 @@ function validateChartSpec(value: unknown): ChartSpec {
   const base = validateBaseChartSpec(record);
 
   switch (kind) {
-    case 'line':
-    case 'scatter':
+    case 'line': {
+      const xType = base.xType ?? 'value';
+      const yType = base.yType ?? 'value';
+      return {
+        ...base,
+        kind,
+        series: validateXySeries(requiredOwnValue(record, 'series', `${kind} chart`), xType, yType)
+      };
+    }
+    case 'scatter': {
+      const xType = base.xType ?? 'value';
+      const yType = base.yType ?? 'value';
+      return {
+        ...base,
+        kind,
+        series: validateXySeries(requiredOwnValue(record, 'series', `${kind} chart`), xType, yType)
+      };
+    }
     case 'area': {
       const xType = base.xType ?? 'value';
       const yType = base.yType ?? 'value';
@@ -504,25 +521,32 @@ function validateChartSpec(value: unknown): ChartSpec {
       return { ...base, kind, bins };
     }
     case 'heatmap': {
+      const { xType: declaredXType, yType: declaredYType, ...heatmapBase } = base;
       const xCategories = optionalStringArray(record, 'xCategories', 'Heatmap chart');
       const yCategories = optionalStringArray(record, 'yCategories', 'Heatmap chart');
-      if (xCategories) requireUniqueCategories(xCategories, 'Heatmap chart xCategories');
-      if (yCategories) requireUniqueCategories(yCategories, 'Heatmap chart yCategories');
-      const xType = heatmapAxisType(base.xType, xCategories, 'x');
-      const yType = heatmapAxisType(base.yType, yCategories, 'y');
+      const xCategoryNames = xCategories
+        ? requireUniqueCategories(xCategories, 'Heatmap chart xCategories')
+        : undefined;
+      const yCategoryNames = yCategories
+        ? requireUniqueCategories(yCategories, 'Heatmap chart yCategories')
+        : undefined;
+      requireEffectiveAxis(declaredXType, 'category', 'Heatmap chart x axis');
+      requireEffectiveAxis(declaredYType, 'category', 'Heatmap chart y axis');
       const rawData = plainArray(requiredOwnValue(record, 'data', 'Heatmap chart'), 'Heatmap chart data');
       if (rawData.length > outputArtifactLimits.chartDataItems) throw chartLimitError(rawData.length);
       const data = rawData.map((cell, cellIndex) => {
         const tuple = fixedTuple(cell, 3, `Heatmap chart cell ${cellIndex + 1}`);
         return [
-          chartCoordinate(tuple[0], xType, `Heatmap chart cell ${cellIndex + 1} x coordinate`, xCategories),
-          chartCoordinate(tuple[1], yType, `Heatmap chart cell ${cellIndex + 1} y coordinate`, yCategories),
+          heatmapCoordinate(tuple[0], `Heatmap chart cell ${cellIndex + 1} x coordinate`, xCategories, xCategoryNames),
+          heatmapCoordinate(tuple[1], `Heatmap chart cell ${cellIndex + 1} y coordinate`, yCategories, yCategoryNames),
           finiteNumber(tuple[2], `Heatmap chart cell ${cellIndex + 1} value`)
         ] as const;
       });
       return {
-        ...base,
+        ...heatmapBase,
         kind,
+        ...(declaredXType == null ? {} : { xType: 'category' as const }),
+        ...(declaredYType == null ? {} : { yType: 'category' as const }),
         ...(xCategories == null ? {} : { xCategories }),
         ...(yCategories == null ? {} : { yCategories }),
         data
@@ -533,7 +557,7 @@ function validateChartSpec(value: unknown): ChartSpec {
   }
 }
 
-function validateBaseChartSpec(record: Record<string, unknown>): Omit<ChartSpec, 'kind'> {
+function validateBaseChartSpec(record: Record<string, unknown>): BaseChartSpec {
   const title = optionalString(record, 'title', 'Chart spec');
   const xLabel = optionalString(record, 'xLabel', 'Chart spec');
   const yLabel = optionalString(record, 'yLabel', 'Chart spec');
@@ -997,12 +1021,7 @@ function finiteNumber(value: unknown, context: string): number {
   return value;
 }
 
-function chartCoordinate(
-  value: unknown,
-  axisType: ChartAxisType,
-  context: string,
-  categories?: readonly string[]
-): number | string {
+function chartCoordinate(value: unknown, axisType: ChartAxisType, context: string): number | string {
   switch (axisType) {
     case 'value':
     case 'log':
@@ -1017,12 +1036,31 @@ function chartCoordinate(
       if (typeof value !== 'string' && (typeof value !== 'number' || !Number.isFinite(value))) {
         throw new ArtifactValidationError(`${context} must be a string or finite numeric category coordinate.`);
       }
-      if (categories && !isCategoryMember(value, categories)) {
-        throw new ArtifactValidationError(`${context} is not present in the declared categories.`);
-      }
       return value;
     }
   }
+}
+
+function heatmapCoordinate(
+  value: unknown,
+  context: string,
+  categories?: readonly string[],
+  categoryNames?: ReadonlySet<string>
+): number | string {
+  if (typeof value === 'string') {
+    if (categoryNames && !categoryNames.has(value)) {
+      throw new ArtifactValidationError(`${context} is not present in the declared categories.`);
+    }
+    return value;
+  }
+
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    throw new ArtifactValidationError(`${context} must be a string or finite numeric category coordinate.`);
+  }
+  if (categories && (!Number.isSafeInteger(value) || value < 0 || value >= categories.length)) {
+    throw new ArtifactValidationError(`${context} must be a safe integer index into the declared categories.`);
+  }
+  return value;
 }
 
 function numericCoordinate(value: unknown, axisType: 'value' | 'log' | 'time', context: string): number {
@@ -1031,16 +1069,6 @@ function numericCoordinate(value: unknown, axisType: 'value' | 'log' | 'time', c
     throw new ArtifactValidationError(`${context} must be strictly positive for a log axis.`);
   }
   return number;
-}
-
-function heatmapAxisType(
-  declaredType: ChartAxisType | undefined,
-  categories: readonly string[] | undefined,
-  axis: 'x' | 'y'
-): ChartAxisType {
-  if (!categories) return declaredType ?? 'value';
-  requireEffectiveAxis(declaredType, 'category', `Heatmap chart ${axis} axis`);
-  return 'category';
 }
 
 function requireEffectiveAxis(
@@ -1060,15 +1088,12 @@ function numericAxisType(declaredType: ChartAxisType | undefined, context: strin
   return declaredType ?? 'value';
 }
 
-function requireUniqueCategories(categories: readonly string[], context: string): void {
-  if (new Set(categories).size !== categories.length) {
+function requireUniqueCategories(categories: readonly string[], context: string): ReadonlySet<string> {
+  const categoryNames = new Set(categories);
+  if (categoryNames.size !== categories.length) {
     throw new ArtifactValidationError(`${context} must not contain duplicate values.`);
   }
-}
-
-function isCategoryMember(value: string | number, categories: readonly string[]): boolean {
-  if (typeof value === 'string') return categories.includes(value);
-  return Number.isSafeInteger(value) && value >= 0 && value < categories.length;
+  return categoryNames;
 }
 
 function isSupportedIsoDateTime(value: string): boolean {

--- a/packages/oxiquill/src/lib/doc-runtime/runtime-localization.ts
+++ b/packages/oxiquill/src/lib/doc-runtime/runtime-localization.ts
@@ -9,7 +9,9 @@ export type ChartSummaryDetails = {
   seriesCount: number;
   seriesNames: string;
   valueRange?: string;
+  xCategoryCount?: number;
   xRange?: string;
+  yCategoryCount?: number;
   yRange?: string;
 };
 
@@ -127,8 +129,17 @@ const runtimeLabels = {
     chartLoadError: (detail) => `Chart renderer could not be loaded: ${detail}`,
     chartLoading: 'Loading chart renderer...',
     chartRetry: 'Retry chart rendering',
-    chartSummary: ({ dataCount, seriesCount, seriesNames, valueRange, xRange, yRange }) =>
-      `Series: ${seriesCount}${seriesNames ? ` (${seriesNames})` : ''}. Data items: ${dataCount}.${xRange ? ` X range: ${xRange}.` : ''}${yRange ? ` Y range: ${yRange}.` : ''}${valueRange ? ` Heat value range: ${valueRange}.` : ''}`,
+    chartSummary: ({
+      dataCount,
+      seriesCount,
+      seriesNames,
+      valueRange,
+      xCategoryCount,
+      xRange,
+      yCategoryCount,
+      yRange
+    }) =>
+      `Series: ${seriesCount}${seriesNames ? ` (${seriesNames})` : ''}. Data items: ${dataCount}.${xCategoryCount == null ? '' : ` X categories: ${xCategoryCount}.`}${yCategoryCount == null ? '' : ` Y categories: ${yCategoryCount}.`}${xRange ? ` X range: ${xRange}.` : ''}${yRange ? ` Y range: ${yRange}.` : ''}${valueRange ? ` Heat value range: ${valueRange}.` : ''}`,
     chartTitle: (kind) => chartTitles.en[kind],
     clipboardUnavailable: 'Clipboard access is unavailable.',
     copyCsv: 'Copy visible rows as CSV',
@@ -184,8 +195,17 @@ const runtimeLabels = {
     chartLoadError: (detail) => `グラフ表示を読み込めませんでした: ${detail}`,
     chartLoading: 'グラフ表示を読み込んでいます…',
     chartRetry: 'グラフ表示を再試行',
-    chartSummary: ({ dataCount, seriesCount, seriesNames, valueRange, xRange, yRange }) =>
-      `系列数: ${seriesCount}${seriesNames ? `（${seriesNames}）` : ''}。データ数: ${dataCount}。${xRange ? `X の範囲: ${xRange}。` : ''}${yRange ? `Y の範囲: ${yRange}。` : ''}${valueRange ? `ヒート値の範囲: ${valueRange}。` : ''}`,
+    chartSummary: ({
+      dataCount,
+      seriesCount,
+      seriesNames,
+      valueRange,
+      xCategoryCount,
+      xRange,
+      yCategoryCount,
+      yRange
+    }) =>
+      `系列数: ${seriesCount}${seriesNames ? `（${seriesNames}）` : ''}。データ数: ${dataCount}。${xCategoryCount == null ? '' : `X カテゴリ数: ${xCategoryCount}。`}${yCategoryCount == null ? '' : `Y カテゴリ数: ${yCategoryCount}。`}${xRange ? `X の範囲: ${xRange}。` : ''}${yRange ? `Y の範囲: ${yRange}。` : ''}${valueRange ? `ヒート値の範囲: ${valueRange}。` : ''}`,
     chartTitle: (kind) => chartTitles.ja[kind],
     clipboardUnavailable: 'クリップボードを利用できません。',
     copyCsv: '表示中の行を CSV としてコピー',

--- a/packages/oxiquill/src/lib/doc-runtime/types.ts
+++ b/packages/oxiquill/src/lib/doc-runtime/types.ts
@@ -155,6 +155,8 @@ export interface AreaChartSpec extends BaseChartSpec {
 
 export interface HeatmapChartSpec extends BaseChartSpec {
   kind: 'heatmap';
+  xType?: 'category';
+  yType?: 'category';
   xCategories?: readonly string[];
   yCategories?: readonly string[];
   data: readonly (readonly [number | string, number | string, number])[];

--- a/tests/e2e/accessibility.spec.ts
+++ b/tests/e2e/accessibility.spec.ts
@@ -72,13 +72,15 @@ test.describe('runtime accessibility', () => {
         path: '/features/rich-output/',
         cellId: 'cell-features__rich-output__rust-rich-outputs',
         runLabel: 'Run',
-        tableLabel: 'Data table'
+        tableLabel: 'Data table',
+        heatmapDescription: /X categories: 2\. Y categories: 2\. Heat value range: 1–4\./u
       },
       {
         path: '/ja/features/rich-output/',
         cellId: 'cell-ja__features__rich-output__rust-rich-outputs',
         runLabel: '実行',
-        tableLabel: 'データ表'
+        tableLabel: 'データ表',
+        heatmapDescription: /X カテゴリ数: 2。Y カテゴリ数: 2。ヒート値の範囲: 1–4。/u
       }
     ]) {
       await page.goto(example.path);
@@ -86,8 +88,13 @@ test.describe('runtime accessibility', () => {
       await hydrateCell(cell);
       await cell.getByRole('button', { name: example.runLabel }).press('Enter');
       await expect(cell.getByRole('table', { name: example.tableLabel }).first()).toBeVisible();
-      await expect(cell.getByRole('figure').first()).toHaveAccessibleDescription(/Data items|データ数/u);
+      const figures = cell.locator('figure.doc-chart-output');
+      await expect(figures).toHaveCount(2);
+      await expect(figures.first()).toHaveAccessibleDescription(/Data items|データ数/u);
+      await expect(figures.nth(1)).toHaveAccessibleDescription(example.heatmapDescription);
+      await expect(cell.getByTestId('doc-plot')).toHaveCount(2);
       await expect(cell.getByTestId('doc-plot').first()).toHaveAttribute('aria-hidden', 'true');
+      await expect(cell.getByTestId('doc-plot').nth(1)).toHaveAttribute('aria-hidden', 'true');
       await expectNoWcag22AAViolations(page, browserName);
     }
   });

--- a/tests/e2e/interactive.spec.ts
+++ b/tests/e2e/interactive.spec.ts
@@ -421,19 +421,32 @@ test('rich output examples render browser-visible artifacts', async ({ page }) =
   await explicitTable.getByRole('button', { name: 'Score' }).click();
   await expect(explicitTable.getByRole('columnheader', { name: 'Score' })).toHaveAttribute('aria-sort', 'ascending');
 
-  const rustChart = rust.getByTestId('doc-plot');
-  await expect(rustChart.locator('canvas')).toHaveCount(1);
-  await expect(rustChart).toHaveAttribute('data-chart-theme', 'light');
-  expect((await canvasStats(rustChart.locator('canvas'))).inkPixels).toBeGreaterThan(1_000);
+  const rustCharts = rust.getByTestId('doc-plot');
+  await expect(rustCharts).toHaveCount(2);
+  const rustBarChart = rustCharts.first();
+  const rustHeatmap = rustCharts.nth(1);
+  await expect(rustBarChart.locator('canvas')).toHaveCount(1);
+  await expect(rustHeatmap.locator('canvas').first()).toBeVisible();
+  await expect(rustBarChart).toHaveAttribute('data-chart-theme', 'light');
+  await expect(rustHeatmap).toHaveAttribute('data-chart-theme', 'light');
+  expect((await canvasStats(rustBarChart.locator('canvas'))).inkPixels).toBeGreaterThan(1_000);
+  const heatmapCanvases = rustHeatmap.locator('canvas');
+  const heatmapStats = await Promise.all(
+    Array.from({ length: await heatmapCanvases.count() }, (_, index) => canvasStats(heatmapCanvases.nth(index)))
+  );
+  expect(Math.max(...heatmapStats.map(({ inkPixels }) => inkPixels))).toBeGreaterThan(500);
   await page.evaluate(() => {
     document.documentElement.dataset.theme = 'dark';
   });
-  await expect(rustChart).toHaveAttribute('data-chart-theme', 'dark');
-  await expect(rustChart.locator('canvas')).toHaveCount(1);
+  await expect(rustBarChart).toHaveAttribute('data-chart-theme', 'dark');
+  await expect(rustHeatmap).toHaveAttribute('data-chart-theme', 'dark');
+  await expect(rustBarChart.locator('canvas')).toHaveCount(1);
+  await expect(rustHeatmap.locator('canvas').first()).toBeVisible();
   await page.evaluate(() => {
     document.documentElement.dataset.theme = 'light';
   });
-  await expect(rustChart).toHaveAttribute('data-chart-theme', 'light');
+  await expect(rustBarChart).toHaveAttribute('data-chart-theme', 'light');
+  await expect(rustHeatmap).toHaveAttribute('data-chart-theme', 'light');
   await expect(rust.getByTestId('image-output')).toHaveAttribute('src', /data:image\/svg\+xml/);
   const htmlOutput = rust.getByTestId('html-output');
   await expect(htmlOutput).toHaveAttribute('sandbox', '');
@@ -508,11 +521,23 @@ test('chart rendering recovers after a transient chunk load failure', async ({ b
   const rust = page.getByTestId('cell-features__rich-output__rust-rich-outputs');
   await hydrateCell(rust);
   await rust.getByRole('button', { name: 'Run' }).click();
-  await expect(rust.getByRole('alert')).toContainText('Chart renderer could not be loaded');
+  const alerts = rust.getByRole('alert');
+  const charts = rust.getByTestId('doc-plot');
+  await expect.poll(async () => (await alerts.count()) + (await charts.count())).toBe(2);
+  const failedChartCount = await alerts.count();
+  expect(failedChartCount).toBeGreaterThan(0);
+  await expect(alerts.first()).toContainText('Chart renderer could not be loaded');
   expect(failedOnce).toBe(true);
 
-  await rust.getByRole('button', { name: 'Retry chart rendering' }).click();
-  await expect(rust.getByTestId('doc-plot').locator('canvas')).toHaveCount(1);
+  const retryButtons = rust.getByRole('button', { name: 'Retry chart rendering' });
+  await expect(retryButtons).toHaveCount(failedChartCount);
+  for (let remaining = failedChartCount; remaining > 0; remaining -= 1) {
+    await retryButtons.first().click();
+    await expect(retryButtons).toHaveCount(remaining - 1);
+  }
+  await expect(charts).toHaveCount(2);
+  await expect(charts.first().locator('canvas').first()).toBeVisible();
+  await expect(charts.nth(1).locator('canvas').first()).toBeVisible();
 });
 
 test('theme note and Mermaid examples are available without author-side TSX imports', async ({ page }) => {

--- a/tests/unit/components.test.tsx
+++ b/tests/unit/components.test.tsx
@@ -1084,15 +1084,103 @@ describe('ChartOutput options', () => {
           [1, 0, -2]
         ]
       })
-    ).toMatchObject({ visualMap: { min: -8, max: -2 } });
+    ).toMatchObject({
+      xAxis: { type: 'category', data: ['0', '1'] },
+      yAxis: { type: 'category', data: ['0'] },
+      visualMap: { min: -8, max: -2 },
+      series: [
+        {
+          type: 'heatmap',
+          data: [
+            ['0', '0', -8],
+            ['1', '0', -2]
+          ]
+        }
+      ]
+    });
     expect(chartSpecToEChartsOptions({ kind: 'heatmap', data: [] })).toMatchObject({
-      visualMap: { min: 0, max: 1 }
+      xAxis: { type: 'category', data: [] },
+      yAxis: { type: 'category', data: [] },
+      visualMap: { min: 0, max: 1 },
+      series: [{ type: 'heatmap', data: [] }]
     });
     expect(chartSpecToEChartsOptions({ kind: 'line', series: [] }, 'dark')).toMatchObject({
       textStyle: { color: '#f3f4f6' },
       xAxis: { axisLabel: { color: '#d1d5db' } },
       yAxis: { axisLabel: { color: '#d1d5db' } }
     });
+  });
+
+  it('normalizes explicit and inferred heatmap axes independently', () => {
+    expect(
+      chartSpecToEChartsOptions({
+        kind: 'heatmap',
+        data: [
+          [2, 'row-b', 3],
+          [1, 'row-a', 4],
+          ['2', 'row-b', 5]
+        ]
+      })
+    ).toMatchObject({
+      xAxis: { type: 'category', data: ['2', '1'] },
+      yAxis: { type: 'category', data: ['row-b', 'row-a'] },
+      visualMap: { min: 3, max: 5 },
+      series: [
+        {
+          type: 'heatmap',
+          data: [
+            ['2', 'row-b', 3],
+            ['1', 'row-a', 4],
+            ['2', 'row-b', 5]
+          ]
+        }
+      ]
+    });
+
+    expect(
+      chartSpecToEChartsOptions({
+        kind: 'heatmap',
+        xCategories: ['first', 'second'],
+        yCategories: ['top', 'bottom'],
+        data: [[1, 0, 7]]
+      })
+    ).toMatchObject({
+      xAxis: { data: ['first', 'second'] },
+      yAxis: { data: ['top', 'bottom'] },
+      series: [{ type: 'heatmap', data: [['second', 'top', 7]] }]
+    });
+
+    expect(
+      chartSpecToEChartsOptions({
+        kind: 'heatmap',
+        xCategories: ['first', 'second'],
+        data: [
+          [1, 2, 4],
+          ['first', '2', 5]
+        ]
+      })
+    ).toMatchObject({
+      xAxis: { data: ['first', 'second'] },
+      yAxis: { data: ['2'] },
+      series: [
+        {
+          type: 'heatmap',
+          data: [
+            ['second', '2', 4],
+            ['first', '2', 5]
+          ]
+        }
+      ]
+    });
+
+    expect(() =>
+      chartSpecToEChartsOptions({
+        kind: 'heatmap',
+        xCategories: ['only'],
+        yCategories: ['row'],
+        data: [[1, 0, 1]]
+      })
+    ).toThrow('Validated heatmap category index is out of range');
   });
 
   it('summarizes chart series and ranges in the selected locale', () => {
@@ -1130,7 +1218,7 @@ describe('ChartOutput options', () => {
         },
         labelsForLanguage('en')
       )
-    ).toBe('Series: 1. Data items: 2. X range: -2–4. Y range: 10–20. Heat value range: -8–6.');
+    ).toBe('Series: 1. Data items: 2. X categories: 2. Y categories: 2. Heat value range: -8–6.');
     expect(
       chartDataSummary(
         {
@@ -1141,11 +1229,19 @@ describe('ChartOutput options', () => {
         },
         labelsForLanguage('ja')
       )
-    ).toBe('系列数: 1。データ数: 1。ヒート値の範囲: 3。');
+    ).toBe('系列数: 1。データ数: 1。X カテゴリ数: 1。Y カテゴリ数: 1。ヒート値の範囲: 3。');
 
     const exactLimit = Array.from({ length: 100_000 }, (_, index) => [index, -index] as const);
     expect(chartDataSummary({ kind: 'line', series: [{ points: exactLimit }] }, labelsForLanguage('en'))).toContain(
       'Data items: 100000. X range: 0–99,999. Y range: -99,999–0.'
+    );
+
+    const exactHeatmapLimit = Array.from({ length: 100_000 }, (_, index) => [index, index % 2, index % 3] as const);
+    expect(chartDataSummary({ kind: 'heatmap', data: exactHeatmapLimit }, labelsForLanguage('en'))).toBe(
+      'Series: 1. Data items: 100000. X categories: 100000. Y categories: 2. Heat value range: 0–2.'
+    );
+    expect(chartDataSummary({ kind: 'heatmap', data: exactHeatmapLimit }, labelsForLanguage('ja'))).toBe(
+      '系列数: 1。データ数: 100000。X カテゴリ数: 100000。Y カテゴリ数: 2。ヒート値の範囲: 0–2。'
     );
   });
 

--- a/tests/unit/doc-runtime-core.test.mjs
+++ b/tests/unit/doc-runtime-core.test.mjs
@@ -151,6 +151,61 @@ describe('doc runtime core', () => {
     expect(cells[0].sourceHtml).toContain('data-lang="rust"');
   });
 
+  it('parses MDX math before discovering interactive cells', () => {
+    const source = [
+      'Inline math: $\\text{hello world}$.',
+      '',
+      'Complex inline math: $\\operatorname{arg max}_{x \\in X} f(x)$.',
+      '',
+      '$$',
+      '\\begin{aligned}',
+      'f(x) &= {x + 1} \\\\',
+      'g(x) &= \\frac{x}{2}',
+      '\\end{aligned}',
+      '$$',
+      '',
+      '```python',
+      '#| id: math-cell',
+      'print("ok")',
+      '```'
+    ].join('\n');
+
+    const parsed = parseCellsFromMarkdown(source, 'content/docs/page.mdx');
+    const inlineMathNodes = parsed.tree.children
+      .flatMap((node) => node.children ?? [])
+      .filter((node) => node.type === 'inlineMath');
+
+    expect(parsed.diagnostics).toEqual([]);
+    expect(parsed.cells).toMatchObject([
+      {
+        id: 'page__math-cell',
+        language: 'python',
+        source: 'print("ok")',
+        fenceStartLine: 12
+      }
+    ]);
+    expect(inlineMathNodes).toMatchObject([
+      { type: 'inlineMath', value: '\\text{hello world}' },
+      { type: 'inlineMath', value: '\\operatorname{arg max}_{x \\in X} f(x)' }
+    ]);
+    expect(parsed.tree.children).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'math',
+          value: ['\\begin{aligned}', 'f(x) &= {x + 1} \\\\', 'g(x) &= \\frac{x}{2}', '\\end{aligned}'].join('\n')
+        })
+      ])
+    );
+  });
+
+  it('rejects malformed MDX outside math spans', () => {
+    const source = 'Valid math $\\text{ok}$ and invalid MDX {not valid JavaScript here}.';
+
+    expect(() => parseCellsFromMarkdown(source, 'content/docs/page.mdx')).toThrow(
+      'Could not parse expression with acorn'
+    );
+  });
+
   it.each([
     ['malformed YAML', '//| id: [', 'metadata'],
     ['invalid id', '//| id: Bad.id', 'id'],

--- a/tests/unit/doc-runtime-service.test.mjs
+++ b/tests/unit/doc-runtime-service.test.mjs
@@ -424,6 +424,40 @@ describe('doc runtime service', () => {
     await expect(listFiles('/repo/content/docs', { fileSystem: oddFileSystem })).resolves.toEqual([]);
   });
 
+  it('collects interactive cells from MDX pages containing math', async () => {
+    const fileSystem = createMemoryFileSystem({
+      '/repo/content/docs/page.mdx': [
+        'Inline math: $\\text{hello world}$.',
+        '',
+        '$$',
+        '\\frac{x + 1}{y}',
+        '$$',
+        '',
+        '```python',
+        '#| id: example',
+        'print("ok")',
+        '```'
+      ].join('\n')
+    });
+
+    await expect(
+      collectCells({
+        fileSystem,
+        helperCrates: new Map(),
+        highlighter,
+        paths: createDocRuntimePaths('/repo'),
+        root: '/repo'
+      })
+    ).resolves.toMatchObject([
+      {
+        id: 'page__example',
+        language: 'python',
+        pagePath: 'content/docs/page.mdx',
+        source: 'print("ok")'
+      }
+    ]);
+  });
+
   it('fails clearly when an MDX Rust cell references an unknown helper crate', async () => {
     const fileSystem = createMemoryFileSystem({
       '/repo/content/docs/page.mdx': '```rust\n//| id: a\n//| crates: [missing-helper]\nprintln!("a");\n```'

--- a/tests/unit/echarts-heatmap.test.mjs
+++ b/tests/unit/echarts-heatmap.test.mjs
@@ -1,0 +1,57 @@
+// @vitest-environment node
+
+import { createRequire } from 'node:module';
+import { resolve } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { chartSpecToEChartsOptions } from '../../packages/oxiquill/src/components/doc-runtime/ChartOutput';
+
+const requireFromPackage = createRequire(resolve(process.cwd(), 'packages/oxiquill/package.json'));
+const echarts = requireFromPackage('echarts');
+const charts = [];
+
+afterEach(() => {
+  charts.splice(0).forEach((chart) => chart.dispose());
+});
+
+describe('real ECharts heatmap rendering', () => {
+  it('renders inferred numeric categories', () => {
+    const chart = renderHeatmap({
+      kind: 'heatmap',
+      data: [
+        [0, 0, 1],
+        [1, 0, 2]
+      ]
+    });
+
+    expect(chart.getModel().getSeriesByIndex(0).getData().count()).toBe(2);
+    expect(chart.renderToSVGString()).toContain('<svg');
+  });
+
+  it('renders explicit numeric category indices as their canonical names', () => {
+    const chart = renderHeatmap({
+      kind: 'heatmap',
+      xCategories: ['first', 'second'],
+      yCategories: ['row'],
+      data: [[1, 0, 7]]
+    });
+    const data = chart.getModel().getSeriesByIndex(0).getData();
+
+    expect(data.count()).toBe(1);
+    expect(data.getRawDataItem(0)).toEqual(['second', 'row', 7]);
+    expect(chart.renderToSVGString()).toContain('<svg');
+  });
+
+  it('renders an empty categorical heatmap', () => {
+    const chart = renderHeatmap({ kind: 'heatmap', data: [] });
+
+    expect(chart.getModel().getSeriesByIndex(0).getData().count()).toBe(0);
+    expect(chart.renderToSVGString()).toContain('<svg');
+  });
+});
+
+function renderHeatmap(spec) {
+  const chart = echarts.init(null, null, { renderer: 'svg', ssr: true, width: 320, height: 240 });
+  charts.push(chart);
+  expect(() => chart.setOption(chartSpecToEChartsOptions(spec))).not.toThrow();
+  return chart;
+}

--- a/tests/unit/output-artifact-validation.test.ts
+++ b/tests/unit/output-artifact-validation.test.ts
@@ -1,10 +1,11 @@
 import { Buffer } from 'node:buffer';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, expectTypeOf, it } from 'vitest';
 import {
   outputArtifactLimits,
   validateOutputArtifacts,
   type ValidatedOutputArtifact
 } from '../../packages/oxiquill/src/lib/doc-runtime/output-artifact-validation';
+import type { HeatmapChartSpec } from '../../packages/oxiquill/src/lib/doc-runtime/types';
 
 const pngBase64 = 'iVBORw0KGgo=';
 const jpegBase64 = '/9j/';
@@ -24,6 +25,11 @@ function validationError(value: unknown): string {
 }
 
 describe('output artifact validation', () => {
+  it('exposes category-only heatmap axis declarations', () => {
+    expectTypeOf<HeatmapChartSpec['xType']>().toEqualTypeOf<'category' | undefined>();
+    expectTypeOf<HeatmapChartSpec['yType']>().toEqualTypeOf<'category' | undefined>();
+  });
+
   it('validates every public artifact kind and copies supported metadata', () => {
     expect(
       validArtifact({
@@ -319,6 +325,75 @@ describe('output artifact validation', () => {
         spec: { kind: 'line', xType: 'time', series: [{ points: [['2026-02-30T00:00:00Z', 1]] }] }
       })
     ).toContain('ISO-8601');
+  });
+
+  it.each([
+    ['numeric inferred coordinates', { kind: 'heatmap', data: [[0, 1, 2]] }],
+    ['string inferred coordinates', { kind: 'heatmap', data: [['column', 'row', 2]] }],
+    ['mixed explicit and inferred axes', { kind: 'heatmap', xCategories: ['first', 'second'], data: [[1, 'row', 2]] }],
+    [
+      'explicit category names',
+      {
+        kind: 'heatmap',
+        xCategories: ['column'],
+        yCategories: ['row'],
+        data: [['column', 'row', 2]]
+      }
+    ],
+    [
+      'explicit category indices',
+      {
+        kind: 'heatmap',
+        xCategories: ['first', 'second'],
+        yCategories: ['row'],
+        data: [[1, 0, 2]]
+      }
+    ],
+    ['empty categories and data', { kind: 'heatmap', xCategories: [], yCategories: [], data: [] }],
+    [
+      'colliding inferred labels',
+      {
+        kind: 'heatmap',
+        data: [
+          [1, 0, 2],
+          ['1', '0', 3]
+        ]
+      }
+    ]
+  ])('accepts heatmaps with $0', (_label, spec) => {
+    expect(validArtifact({ kind: 'chart', spec })).toMatchObject({ kind: 'chart' });
+  });
+
+  it.each([
+    ['fractional', 0.5],
+    ['negative', -1],
+    ['non-finite', Number.POSITIVE_INFINITY],
+    ['unsafe', Number.MAX_SAFE_INTEGER + 1],
+    ['out-of-range', 2]
+  ])('rejects $0 explicit heatmap category indices', (_label, coordinate) => {
+    expect(
+      validationError({
+        kind: 'chart',
+        spec: {
+          kind: 'heatmap',
+          xCategories: ['first', 'second'],
+          yCategories: ['row'],
+          data: [[coordinate, 0, 1]]
+        }
+      })
+    ).toContain(coordinate === Number.POSITIVE_INFINITY ? 'finite numeric' : 'safe integer index');
+  });
+
+  it.each(['value', 'time', 'log'] as const)('rejects explicit %s axes for heatmaps', (axisType) => {
+    expect(validationError({ kind: 'chart', spec: { kind: 'heatmap', xType: axisType, data: [] } })).toContain(
+      `x axis is always category; received ${axisType}`
+    );
+    expect(validationError({ kind: 'chart', spec: { kind: 'heatmap', yType: axisType, data: [] } })).toContain(
+      `y axis is always category; received ${axisType}`
+    );
+  });
+
+  it('rejects unknown and duplicate explicit heatmap categories', () => {
     expect(
       validationError({
         kind: 'chart',
@@ -331,16 +406,11 @@ describe('output artifact validation', () => {
       })
     ).toContain('declared categories');
     expect(
-      validArtifact({
+      validationError({
         kind: 'chart',
-        spec: {
-          kind: 'heatmap',
-          xCategories: ['first', 'second'],
-          yCategories: ['row'],
-          data: [[1, 0, 1]]
-        }
+        spec: { kind: 'heatmap', xCategories: ['duplicate', 'duplicate'], data: [] }
       })
-    ).toMatchObject({ kind: 'chart' });
+    ).toContain('duplicate values');
   });
 
   it('accepts empty and equal chart domains while rejecting invalid histogram bins and axis overrides', () => {
@@ -483,6 +553,23 @@ describe('output artifact validation', () => {
   ])('accepts the exact $kind data limit and rejects one item over it', ({ exact, excessive }) => {
     expect(validArtifact({ kind: 'chart', spec: exact() })).toMatchObject({ kind: 'chart' });
     expect(validationError({ kind: 'chart', spec: excessive() })).toContain('maximum');
+  });
+
+  it('validates explicit heatmap category membership at the exact data limit', () => {
+    const categories = Array.from({ length: outputArtifactLimits.chartDataItems }, (_, index) => `category-${index}`);
+    const lastCategory = categories.at(-1);
+    expect(lastCategory).toBeDefined();
+    expect(
+      validArtifact({
+        kind: 'chart',
+        spec: {
+          kind: 'heatmap',
+          xCategories: categories,
+          yCategories: ['row'],
+          data: Array.from({ length: outputArtifactLimits.chartDataItems }, () => [lastCategory, 'row', 1])
+        }
+      })
+    ).toMatchObject({ kind: 'chart' });
   });
 
   it('validates image encodings, MIME declarations, signatures, and SVG payloads', () => {


### PR DESCRIPTION
## Summary

- parse math before MDX expressions during interactive-cell discovery so valid LaTeX braces do not break runtime generation
- enforce category axes for every accepted heatmap and reject explicit value, time, or log axes during validation
- normalize explicit category indices and inferred category labels consistently across ECharts options and accessible summaries
- exercise the generated Rust heatmap path with real ECharts SSR and browser rendering, and document the contract in English and Japanese

## Validation

- `pnpm lint`
- `pnpm test:unit:coverage` (526 passed, 1 skipped; coverage thresholds passed)
- `pnpm check`
- `pnpm wasm:dev`
- `pnpm test:wasm` (15 passed)
- `pnpm test:haskell` (4 generated cells)
- `pnpm test:rust` (8 passed)
- `pnpm doc:rust`
- `pnpm test:docs`
- `pnpm test:package`
- `pnpm test:consumer:npm`
- `pnpm test:consumer:pnpm`
- `pnpm test:e2e --project=chromium` (24 passed)
- `git diff --check origin/main...HEAD`

Closes #104
Closes #105