### PR TITLE
Fix runtime watcher startup ordering

### DIFF
--- a/examples/docs-site/content/docs/ja/reference/cli.mdx
+++ b/examples/docs-site/content/docs/ja/reference/cli.mdx
@@ -36,6 +36,8 @@ unknown option、option value の欠落、unknown command、余分な positional
 | `doc-rust`           | dependency を除いて helper crate documentation を build します。                                                    |
 | `test-wasm`          | runtime を生成し、すべての generated Rust/Haskell cell を default input で実行します。                              |
 
+`dev:runtime` は source change の監視を始める前に、runtime を一度初回同期します。runtime が生成済みの場合は `oxiquill dev:runtime --skip-initial` を使います。この option は起動時に同期せず watcher を登録し、最初の関連 docs/crate event を待ちます。統合された `dev` command は明示的な起動時生成を一度だけ行い、内部でこの mode を使います。
+
 `dev`、`dev:astro`、`build`、`preview`、`check` は documented Astro argument を受け取り、`--` より後の値もそのまま渡します。
 
 ```sh

--- a/examples/docs-site/content/docs/reference/cli.mdx
+++ b/examples/docs-site/content/docs/reference/cli.mdx
@@ -36,6 +36,8 @@ Unknown options, missing option values, unknown commands, and extra positional a
 | `doc-rust`           | Build helper-crate documentation without dependencies.                                                                 |
 | `test-wasm`          | Generate runtimes and execute every generated Rust/Haskell cell with defaults.                                         |
 
+`dev:runtime` performs one initial runtime synchronization before waiting for source changes. Use `oxiquill dev:runtime --skip-initial` when the runtime has already been generated: it registers the watcher without synchronizing at startup and waits for the first relevant docs or crate event. The combined `dev` command performs its explicit startup generation once and uses this mode internally.
+
 `dev`, `dev:astro`, `build`, `preview`, and `check` accept their documented Astro arguments, including values after `--`. For example:
 
 ```sh

--- a/packages/oxiquill/src/generator/watch-doc-runtime.mjs
+++ b/packages/oxiquill/src/generator/watch-doc-runtime.mjs
@@ -51,25 +51,17 @@ export async function watchDocRuntime({ projectConfig, serviceOverrides = {}, sk
     fields: ['cacheDir', 'publicAssetsDir'],
     paths
   });
-  const initialContext = await services.createDocRuntimeContext({ paths });
-  const workspaceRoot = pathFromUrl(initialContext.paths.workspaceRoot);
+  const workspaceRoot = pathFromUrl(paths.workspaceRoot);
+  let highlighter;
   let changeKinds = skipInitial ? new Set() : new Set(['docs']);
-
-  if (skipInitial) {
-    const baseline = await services.syncDocRuntime({
-      ...initialContext,
-      mode: 'dev',
-      tolerateHaskellBuildFailure: true
-    });
-    console.log(`[runtime] baseline ready: ${baseline.cellCount} interactive cell(s)`);
-  }
 
   async function syncRuntime() {
     if (!shouldSyncRuntime(changeKinds)) return;
 
     const currentKinds = changeKinds;
     changeKinds = new Set();
-    const context = await services.createDocRuntimeContext({ paths, highlighter: initialContext.highlighter });
+    const context = await services.createDocRuntimeContext({ paths, highlighter });
+    highlighter = context.highlighter;
 
     console.log(`[runtime] syncing after ${describeChangeKinds(currentKinds)}`);
     const current = await services.syncDocRuntime({
@@ -99,18 +91,14 @@ export async function watchDocRuntime({ projectConfig, serviceOverrides = {}, sk
     }
   });
 
-  if (!skipInitial) {
-    queue.enqueue();
-  }
-
   // Chokidar v4 does not expand globs, so watch stable roots and classify events ourselves.
-  const watcher = services.watch(createRuntimeWatchPaths(initialContext.paths), {
+  const watcher = services.watch(createRuntimeWatchPaths(paths), {
     cwd: workspaceRoot,
     ignoreInitial: true
   });
 
   watcher.on('all', (_event, filePath) => {
-    const kind = classifyChangedPath(toWatchEventRelativePath(workspaceRoot, filePath), initialContext.paths);
+    const kind = classifyChangedPath(toWatchEventRelativePath(workspaceRoot, filePath), paths);
     if (kind === 'other') return;
 
     changeKinds = mergeChangeKinds(changeKinds, kind);
@@ -120,6 +108,10 @@ export async function watchDocRuntime({ projectConfig, serviceOverrides = {}, sk
   watcher.on('ready', () => {
     console.log('[runtime] watching MDX, Rust, and Haskell cell sources');
   });
+
+  if (!skipInitial) {
+    queue.enqueue();
+  }
 
   return watcher;
 }

--- a/tests/docs/check-documentation.mjs
+++ b/tests/docs/check-documentation.mjs
@@ -171,7 +171,7 @@ async function checkPublicContracts() {
       assert.ok(reference.includes(`\`${command}`), `CLI reference is missing ${command}.`);
     }
   }
-  for (const option of ['--help', '-h', '--version', '--debug', '--config', '--']) {
+  for (const option of ['--help', '-h', '--version', '--debug', '--config', '--skip-initial', '--']) {
     for (const reference of cliReferences) {
       assert.ok(reference.includes(option), `CLI reference is missing ${option}.`);
     }

--- a/tests/unit/cli.test.mjs
+++ b/tests/unit/cli.test.mjs
@@ -295,6 +295,7 @@ describe('oxiquill CLI', () => {
       expect.arrayContaining(['dev', '--host', '0.0.0.0', '--port', '4321']),
       expect.objectContaining({ cwd: actualRepoRoot, successfulSignals: ['SIGTERM'] })
     );
+    expect(cliMocks.syncDocRuntime).toHaveBeenCalledOnce();
     expect(cliMocks.watchDocRuntime).toHaveBeenCalledWith({ projectConfig: actualProjectConfig, skipInitial: true });
   });
 

--- a/tests/unit/watch-doc-runtime.test.mjs
+++ b/tests/unit/watch-doc-runtime.test.mjs
@@ -14,30 +14,17 @@ beforeEach(() => {
 });
 
 describe('runtime watcher entrypoint', () => {
-  it('rebuilds changed Rust and Haskell runtimes from a ready baseline', async () => {
-    const handlers = new Map();
-    const watcher = {
-      on: vi.fn((event, handler) => {
-        handlers.set(event, handler);
-        return watcher;
-      })
-    };
-    const initial = {
-      cellCount: 1,
-      plan: { languages: { haskell: { public: 'keep' }, rust: { public: 'keep' } } }
-    };
-    const current = {
-      cellCount: 2,
-      haskellBuildResult: { ok: false, error: new Error('compiler failed') },
-      plan: { languages: { haskell: { public: 'build' }, rust: { public: 'build' } } }
-    };
-    const services = {
-      createDocRuntimeContext: vi.fn(async () => ({ highlighter: {}, paths })),
-      loadProjectConfig: vi.fn(async () => ({ paths })),
-      prepareCleanupOwnership: vi.fn(async () => []),
-      syncDocRuntime: vi.fn().mockResolvedValueOnce(initial).mockResolvedValueOnce(current),
-      watch: vi.fn(() => watcher)
-    };
+  it('skips synchronization until a relevant filesystem event arrives', async () => {
+    const { handlers, services } = createServices({
+      syncDocRuntime: vi.fn(async () =>
+        runtimeSummary({
+          cellCount: 2,
+          haskellBuildResult: { ok: false, error: new Error('compiler failed') },
+          haskellPlan: 'build',
+          rustPlan: 'build'
+        })
+      )
+    });
     const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
     const warning = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
 
@@ -52,14 +39,22 @@ describe('runtime watcher entrypoint', () => {
       cwd: workspaceRoot,
       ignoreInitial: true
     });
+    expect(handlers.has('all')).toBe(true);
+    expect(handlers.has('ready')).toBe(true);
+    expect(services.createDocRuntimeContext).not.toHaveBeenCalled();
+    expect(services.syncDocRuntime).not.toHaveBeenCalled();
+
     handlers.get('ready')();
     handlers.get('all')('change', path.join(root, 'README.md'));
-    expect(services.syncDocRuntime).toHaveBeenCalledTimes(1);
-
-    handlers.get('all')('change', path.join(root, 'examples/docs-site/content/docs/index.mdx'));
     await flushMicrotasks();
 
-    expect(services.syncDocRuntime).toHaveBeenLastCalledWith(
+    expect(services.syncDocRuntime).not.toHaveBeenCalled();
+
+    handlers.get('all')('change', path.join(workspaceRoot, 'content/docs/index.mdx'));
+    await waitForCallCount(services.syncDocRuntime, 1);
+
+    expect(services.syncDocRuntime).toHaveBeenCalledOnce();
+    expect(services.syncDocRuntime).toHaveBeenCalledWith(
       expect.objectContaining({
         forceRustBuild: false,
         mode: 'dev',
@@ -69,31 +64,118 @@ describe('runtime watcher entrypoint', () => {
     );
     expect(warning).toHaveBeenCalledWith('[runtime] Haskell/WASI runtime unavailable: compiler failed');
     expect(log).toHaveBeenCalledWith('[runtime] watching MDX, Rust, and Haskell cell sources');
+    expect(log).not.toHaveBeenCalledWith(expect.stringContaining('baseline ready'));
   });
 
-  it('queues an initial documentation sync when no baseline is requested', async () => {
-    const watcher = { on: vi.fn(() => watcher) };
-    const services = {
-      createDocRuntimeContext: vi.fn(async () => ({ highlighter: {}, paths })),
-      loadProjectConfig: vi.fn(async () => ({ paths })),
-      prepareCleanupOwnership: vi.fn(async () => []),
-      syncDocRuntime: vi.fn(async () => ({
-        cellCount: 0,
-        plan: { languages: { haskell: { public: 'keep' }, rust: { public: 'keep' } } }
-      })),
-      watch: vi.fn(() => watcher)
-    };
+  it('registers watcher handlers before queuing exactly one initial documentation sync', async () => {
+    const registrationsAtSync = [];
+    const { handlers, services } = createServices({
+      syncDocRuntime: vi.fn(async () => {
+        registrationsAtSync.push(new Set(handlers.keys()));
+        return runtimeSummary();
+      })
+    });
     vi.spyOn(console, 'log').mockImplementation(() => undefined);
 
     await main([], services);
+    await waitForCallCount(services.syncDocRuntime, 1);
     await flushMicrotasks();
 
-    expect(services.syncDocRuntime).toHaveBeenCalledTimes(1);
+    expect(services.syncDocRuntime).toHaveBeenCalledOnce();
+    expect(registrationsAtSync).toEqual([new Set(['all', 'ready'])]);
     expect(services.syncDocRuntime).toHaveBeenCalledWith(
-      expect.objectContaining({ mode: 'dev', tolerateHaskellBuildFailure: true })
+      expect.objectContaining({
+        forceRustBuild: false,
+        mode: 'dev',
+        tolerateHaskellBuildFailure: true
+      })
     );
   });
+
+  it('coalesces events received during the initial sync and reuses its highlighter', async () => {
+    const firstSync = createDeferred();
+    const highlighter = {};
+    const { handlers, services } = createServices({
+      createDocRuntimeContext: vi
+        .fn()
+        .mockResolvedValueOnce({ highlighter, paths })
+        .mockResolvedValueOnce({ highlighter, paths }),
+      syncDocRuntime: vi
+        .fn()
+        .mockImplementationOnce(async () => firstSync.promise)
+        .mockResolvedValueOnce(runtimeSummary({ cellCount: 2, haskellPlan: 'build', rustPlan: 'build' }))
+    });
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    await main([], services);
+    await waitForCallCount(services.syncDocRuntime, 1);
+
+    handlers.get('all')('change', path.join(workspaceRoot, 'content/docs/index.mdx'));
+    handlers.get('all')('change', path.join(workspaceRoot, 'crates/doc-rust/src/lib.rs'));
+    handlers.get('all')('change', path.join(workspaceRoot, 'content/docs/guide.mdx'));
+    await flushMicrotasks();
+
+    expect(services.syncDocRuntime).toHaveBeenCalledOnce();
+
+    firstSync.resolve(runtimeSummary());
+    await waitForCallCount(services.syncDocRuntime, 2);
+    await flushMicrotasks();
+
+    expect(services.syncDocRuntime).toHaveBeenCalledTimes(2);
+    expect(services.createDocRuntimeContext).toHaveBeenNthCalledWith(1, { highlighter: undefined, paths });
+    expect(services.createDocRuntimeContext).toHaveBeenNthCalledWith(2, { highlighter, paths });
+    expect(services.syncDocRuntime).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ forceRustBuild: true, mode: 'dev', tolerateHaskellBuildFailure: true })
+    );
+    expect(log).toHaveBeenCalledWith('[runtime] rebuilt Rust/Wasm cells');
+    expect(log).toHaveBeenCalledWith('[runtime] rebuilt Haskell/WASI cells');
+  });
 });
+
+function createServices({ createDocRuntimeContext, syncDocRuntime }) {
+  const handlers = new Map();
+  const watcher = {
+    on: vi.fn((event, handler) => {
+      handlers.set(event, handler);
+      return watcher;
+    })
+  };
+  const services = {
+    createDocRuntimeContext: createDocRuntimeContext ?? vi.fn(async () => ({ highlighter: {}, paths })),
+    loadProjectConfig: vi.fn(async () => ({ paths })),
+    prepareCleanupOwnership: vi.fn(async () => []),
+    syncDocRuntime,
+    watch: vi.fn(() => watcher)
+  };
+
+  return { handlers, services, watcher };
+}
+
+function runtimeSummary({ cellCount = 0, haskellBuildResult, haskellPlan = 'keep', rustPlan = 'keep' } = {}) {
+  return {
+    cellCount,
+    haskellBuildResult,
+    plan: { languages: { haskell: { public: haskellPlan }, rust: { public: rustPlan } } }
+  };
+}
+
+function createDeferred() {
+  let resolve;
+  const promise = new Promise((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+
+  return { promise, resolve };
+}
+
+async function waitForCallCount(mock, count) {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    if (mock.mock.calls.length >= count) return;
+    await Promise.resolve();
+  }
+  throw new Error(`Expected ${count} call(s), received ${mock.mock.calls.length}.`);
+}
 
 async function flushMicrotasks() {
   await Promise.resolve();


### PR DESCRIPTION
## Summary

- honor --skip-initial by waiting for the first relevant filesystem event instead of performing a startup synchronization
- register Chokidar handlers before the queued initial synchronization and coalesce changes received while it is running
- preserve highlighter reuse and forced Rust rebuilds, prevent duplicate dev generation, and document the behavior in English and Japanese

## Testing

- pnpm exec vitest run tests/unit/doc-runtime-watch-core.test.mjs tests/unit/watch-doc-runtime.test.mjs tests/unit/cli.test.mjs
- pnpm test:unit:coverage
- pnpm test:docs
- pnpm lint
- pnpm check

Closes #108