### PR TITLE
Fix manifest refresh coordination and runtime recovery

### DIFF
--- a/packages/oxiquill/src/astro/virtual-modules.mjs
+++ b/packages/oxiquill/src/astro/virtual-modules.mjs
@@ -97,10 +97,6 @@ export function oxiquillVirtualModulesPlugin(paths) {
     },
     configureServer(server) {
       server.watcher.add(watchedFiles);
-      server.watcher.on('change', (file) => {
-        const resolvedId = changedFileModuleIds.get(normalizePath(file));
-        if (resolvedId) sendManifestChanged(server, resolvedId);
-      });
       server.middlewares.use((request, response, next) => {
         const requestUrl = new URL(request.url ?? '/', 'http://localhost');
         if (requestUrl.pathname !== '/__oxiquill/manifest.json') {
@@ -177,14 +173,6 @@ function isMatchingVirtualModuleId(id, resolvedId) {
 
 function virtualModuleName(resolvedId) {
   return resolvedId.slice('\0virtual:oxiquill/'.length);
-}
-
-function sendManifestChanged(server, resolvedId) {
-  server.environments?.client?.hot?.send({
-    type: 'custom',
-    event: 'oxiquill:manifest-changed',
-    data: { module: virtualModuleName(resolvedId) }
-  });
 }
 
 function readGeneratedCellsJson(file) {

--- a/packages/oxiquill/src/components/doc-runtime/manifest-hooks.ts
+++ b/packages/oxiquill/src/components/doc-runtime/manifest-hooks.ts
@@ -1,23 +1,19 @@
 import { useEffect, useMemo, useState } from 'preact/hooks';
 import { labelsForLanguage } from '../../lib/doc-runtime/interactive-cell-model.js';
-import { getManifestSnapshot, refreshGeneratedManifest, subscribeManifest } from '../../lib/doc-runtime/manifest.js';
+import {
+  getManifestSnapshot,
+  scheduleGeneratedManifestRefresh,
+  subscribeManifest
+} from '../../lib/doc-runtime/manifest.js';
 
 export function useManifestSnapshot() {
   const [snapshot, setSnapshot] = useState(getManifestSnapshot);
 
   useEffect(() => {
     const unsubscribe = subscribeManifest(() => setSnapshot(getManifestSnapshot()));
-    const refreshSnapshot = () => {
-      void refreshGeneratedManifest().then(() => {
-        setSnapshot(getManifestSnapshot());
-      });
-    };
-    const timers = [0, 250, 1_000, 2_500, 5_000].map((delay) => window.setTimeout(refreshSnapshot, delay));
+    scheduleGeneratedManifestRefresh();
 
-    return () => {
-      unsubscribe();
-      for (const timer of timers) window.clearTimeout(timer);
-    };
+    return unsubscribe;
   }, []);
 
   return snapshot;

--- a/packages/oxiquill/src/lib/doc-runtime/haskell-worker.ts
+++ b/packages/oxiquill/src/lib/doc-runtime/haskell-worker.ts
@@ -176,9 +176,16 @@ export function createHaskellModuleLoader({
   return (expectedFingerprintHash) => {
     if (!wasmModuleReady || wasmModuleFingerprintHash !== expectedFingerprintHash) {
       wasmModuleFingerprintHash = expectedFingerprintHash;
-      wasmModuleReady = fetchStatus(statusUrl).then((status) => {
+      const runtime = fetchStatus(statusUrl).then((status) => {
         assertReadyHaskellRuntimeStatus(status, expectedFingerprintHash);
         return fetchModule(wasmUrl);
+      });
+      wasmModuleReady = runtime;
+      void runtime.catch(() => {
+        if (wasmModuleReady !== runtime || wasmModuleFingerprintHash !== expectedFingerprintHash) return;
+
+        wasmModuleReady = undefined;
+        wasmModuleFingerprintHash = undefined;
       });
     }
     return wasmModuleReady;

--- a/packages/oxiquill/src/lib/doc-runtime/manifest.ts
+++ b/packages/oxiquill/src/lib/doc-runtime/manifest.ts
@@ -18,11 +18,39 @@ type ManifestSnapshot = {
 
 type ManifestHotData = Partial<ManifestSnapshot>;
 
+type ManifestRefreshResult =
+  | {
+      snapshot: ManifestSnapshot;
+      status: 'success';
+    }
+  | {
+      status: 'failure';
+    };
+
+type ManifestRefreshWindow = Pick<Window, 'clearTimeout' | 'setTimeout'>;
+
+type ManifestRefreshGeneration = {
+  generation: number;
+  queued: boolean;
+  refresh: (options?: Pick<ManifestRefreshOptions, 'signal'>) => Promise<ManifestRefreshResult>;
+  succeeded: boolean;
+  timers: Set<number>;
+  windowObject: ManifestRefreshWindow;
+};
+
+type ActiveManifestRefresh = {
+  abortController: AbortController | undefined;
+  generation: ManifestRefreshGeneration;
+};
+
 const hotData = import.meta.hot?.data as ManifestHotData | undefined;
 let cellsSnapshot = initialCellsSnapshot(hotData);
 let versionSnapshot = initialVersionSnapshot(hotData);
 const listeners = new Set<() => void>();
 let freshImportSequence = 0;
+let refreshGenerationSequence = 0;
+let currentRefreshGeneration: ManifestRefreshGeneration | undefined;
+let activeManifestRefresh: ActiveManifestRefresh | undefined;
 
 export function getCell(cellId: string): CellManifest | undefined {
   return cellsSnapshot.find((cell) => cell.id === cellId);
@@ -52,6 +80,8 @@ if (import.meta.hot?.data) {
       applyRuntimeVersionSnapshot((module as unknown as RuntimeVersionModule).runtimeVersion);
     }
   });
+
+  import.meta.hot.dispose(disposeGeneratedManifestRefresh);
 }
 
 function initialCellsSnapshot(data: ManifestHotData | undefined): readonly CellManifest[] {
@@ -117,6 +147,7 @@ type ManifestRefreshOptions = {
   fetchImpl?: typeof fetch;
   hasHotRuntime?: boolean;
   now?: () => number;
+  signal?: AbortSignal;
   windowObject?: Window;
 };
 
@@ -124,44 +155,150 @@ export async function refreshGeneratedManifest({
   fetchImpl = globalThis.fetch,
   hasHotRuntime = Boolean(import.meta.hot),
   now = Date.now,
+  signal,
   windowObject = globalThis.window
-}: ManifestRefreshOptions = {}): Promise<void> {
-  if (!hasHotRuntime || !windowObject || typeof fetchImpl !== 'function') return;
+}: ManifestRefreshOptions = {}): Promise<ManifestRefreshResult> {
+  if (!hasHotRuntime || !windowObject || typeof fetchImpl !== 'function') return { status: 'failure' };
 
   try {
-    const response = await fetchImpl(freshManifestUrl(now), { cache: 'no-store' });
+    const response = await fetchImpl(freshManifestUrl(now), {
+      cache: 'no-store',
+      ...(signal ? { signal } : {})
+    });
     if (!response.ok) {
       throw new Error(`Received ${response.status} from the generated manifest endpoint.`);
     }
 
     const payload = (await response.json()) as GeneratedManifestPayload;
 
-    applyGeneratedSnapshot({
-      cells: payload.cells,
-      version: payload.runtimeVersion
-    });
+    return {
+      snapshot: {
+        cells: payload.cells,
+        version: payload.runtimeVersion
+      },
+      status: 'success'
+    };
   } catch (error) {
-    if (error instanceof TypeError) return;
+    if (signal?.aborted || error instanceof TypeError) return { status: 'failure' };
     console.warn('Oxiquill could not refresh the generated interactive cell manifest.', error);
+    return { status: 'failure' };
   }
 }
 
 type ManifestScheduleOptions = {
-  refresh?: () => Promise<void>;
-  windowObject?: Pick<Window, 'setTimeout'>;
+  refresh?: (options?: Pick<ManifestRefreshOptions, 'signal'>) => Promise<ManifestRefreshResult>;
+  windowObject?: ManifestRefreshWindow;
 };
 
 export function scheduleGeneratedManifestRefresh({
   refresh = refreshGeneratedManifest,
   windowObject = globalThis.window
-}: ManifestScheduleOptions = {}): void {
-  if (!windowObject) return;
+}: ManifestScheduleOptions = {}): () => void {
+  if (!windowObject) return disposeGeneratedManifestRefresh;
+
+  cancelRefreshGeneration(currentRefreshGeneration);
+  abortActiveManifestRefresh();
+
+  const generation: ManifestRefreshGeneration = {
+    generation: ++refreshGenerationSequence,
+    queued: false,
+    refresh,
+    succeeded: false,
+    timers: new Set(),
+    windowObject
+  };
+  currentRefreshGeneration = generation;
 
   for (const delay of [0, 250, 1_000, 2_500, 5_000]) {
-    windowObject.setTimeout(() => {
-      void refresh();
+    const timer = windowObject.setTimeout(() => {
+      generation.timers.delete(timer);
+      requestManifestRefresh(generation);
     }, delay);
+    generation.timers.add(timer);
   }
+
+  return disposeGeneratedManifestRefresh;
+}
+
+function requestManifestRefresh(generation: ManifestRefreshGeneration): void {
+  if (currentRefreshGeneration !== generation || generation.succeeded) return;
+
+  if (activeManifestRefresh) {
+    generation.queued = true;
+    return;
+  }
+
+  const attempt: ActiveManifestRefresh = {
+    abortController: typeof AbortController === 'undefined' ? undefined : new AbortController(),
+    generation
+  };
+  activeManifestRefresh = attempt;
+
+  void generation.refresh({ signal: attempt.abortController?.signal }).then(
+    (result) => finishManifestRefresh(attempt, result),
+    (error: unknown) => {
+      console.warn('Oxiquill could not refresh the generated interactive cell manifest.', error);
+      finishManifestRefresh(attempt, { status: 'failure' });
+    }
+  );
+}
+
+function finishManifestRefresh(attempt: ActiveManifestRefresh, result: ManifestRefreshResult): void {
+  if (activeManifestRefresh !== attempt) return;
+
+  activeManifestRefresh = undefined;
+  const generation = attempt.generation;
+  if (currentRefreshGeneration !== generation) {
+    requestQueuedManifestRefresh();
+    return;
+  }
+
+  if (result.status === 'success') {
+    generation.succeeded = true;
+    generation.queued = false;
+    cancelRefreshTimers(generation);
+    applyGeneratedSnapshot(result.snapshot);
+    return;
+  }
+
+  if (generation.queued) {
+    generation.queued = false;
+    requestManifestRefresh(generation);
+  }
+}
+
+function requestQueuedManifestRefresh(): void {
+  const generation = currentRefreshGeneration;
+  if (!generation?.queued) return;
+
+  generation.queued = false;
+  requestManifestRefresh(generation);
+}
+
+function disposeGeneratedManifestRefresh(): void {
+  cancelRefreshGeneration(currentRefreshGeneration);
+  currentRefreshGeneration = undefined;
+  abortActiveManifestRefresh();
+}
+
+function abortActiveManifestRefresh(): void {
+  const activeRefresh = activeManifestRefresh;
+  activeManifestRefresh = undefined;
+  activeRefresh?.abortController?.abort();
+}
+
+function cancelRefreshGeneration(generation: ManifestRefreshGeneration | undefined): void {
+  if (!generation) return;
+
+  generation.queued = false;
+  cancelRefreshTimers(generation);
+}
+
+function cancelRefreshTimers(generation: ManifestRefreshGeneration): void {
+  for (const timer of generation.timers) {
+    generation.windowObject.clearTimeout(timer);
+  }
+  generation.timers.clear();
 }
 
 export function freshManifestUrl(now: () => number = Date.now): string {

--- a/packages/oxiquill/src/lib/doc-runtime/python-worker.ts
+++ b/packages/oxiquill/src/lib/doc-runtime/python-worker.ts
@@ -118,12 +118,26 @@ export function createPythonRuntimeLoader({
   let loadPyodideReady: Promise<LoadPyodide> | undefined;
 
   return () => {
-    loadPyodideReady ??= importModule(moduleUrl).then((module) => module.loadPyodide);
-    pyodideReady ??= loadPyodideReady.then(async (loadPyodide) => {
-      const pyodide = await loadPyodide({ indexURL: indexUrl });
-      await pyodide.runPythonAsync(pythonDisplaySupportCode);
-      return pyodide;
-    });
+    if (!loadPyodideReady) {
+      const importedLoader = importModule(moduleUrl).then((module) => module.loadPyodide);
+      loadPyodideReady = importedLoader;
+      void importedLoader.catch(() => {
+        if (loadPyodideReady === importedLoader) loadPyodideReady = undefined;
+      });
+    }
+
+    if (!pyodideReady) {
+      const runtime = loadPyodideReady.then(async (loadPyodide) => {
+        const pyodide = await loadPyodide({ indexURL: indexUrl });
+        await pyodide.runPythonAsync(pythonDisplaySupportCode);
+        return pyodide;
+      });
+      pyodideReady = runtime;
+      void runtime.catch(() => {
+        if (pyodideReady === runtime) pyodideReady = undefined;
+      });
+    }
+
     return pyodideReady;
   };
 }

--- a/packages/oxiquill/src/lib/doc-runtime/rust-worker.ts
+++ b/packages/oxiquill/src/lib/doc-runtime/rust-worker.ts
@@ -9,7 +9,7 @@ type WorkerScope = {
 };
 
 const worker = self as unknown as WorkerScope;
-let wasmReady: Promise<void> | undefined;
+const ensureWasm = createRustRuntimeLoader({ init });
 
 worker.addEventListener('message', (event) => {
   void handleRequest(event.data);
@@ -32,6 +32,18 @@ async function handleRequest(request: RuntimeWorkerRequest): Promise<void> {
   }
 }
 
-function ensureWasm(): Promise<void> {
-  return (wasmReady ??= init().then(() => undefined));
+export function createRustRuntimeLoader({ init }: { init: () => Promise<unknown> }): () => Promise<void> {
+  let wasmReady: Promise<void> | undefined;
+
+  return () => {
+    if (!wasmReady) {
+      const runtime = init().then(() => undefined);
+      wasmReady = runtime;
+      void runtime.catch(() => {
+        if (wasmReady === runtime) wasmReady = undefined;
+      });
+    }
+
+    return wasmReady;
+  };
 }

--- a/tests/unit/components.test.tsx
+++ b/tests/unit/components.test.tsx
@@ -17,6 +17,8 @@ const runtimeMocks = vi.hoisted(() => ({
   getCell: vi.fn(),
   getManifestSnapshot: vi.fn<() => ManifestSnapshot>(() => ({ cells: [], version: 'v1' })),
   manifestListeners: [] as Array<() => void>,
+  manifestUnsubscribers: [] as Array<ReturnType<typeof vi.fn>>,
+  scheduleGeneratedManifestRefresh: vi.fn(),
   runInteractiveCell: vi.fn()
 }));
 
@@ -32,10 +34,12 @@ const mocks = {
 vi.mock('../../packages/oxiquill/src/lib/doc-runtime/manifest', () => ({
   getCell: runtimeMocks.getCell,
   getManifestSnapshot: runtimeMocks.getManifestSnapshot,
-  refreshGeneratedManifest: vi.fn(() => Promise.resolve()),
+  scheduleGeneratedManifestRefresh: runtimeMocks.scheduleGeneratedManifestRefresh,
   subscribeManifest: vi.fn((listener: () => void) => {
     runtimeMocks.manifestListeners.push(listener);
-    return vi.fn();
+    const unsubscribe = vi.fn();
+    runtimeMocks.manifestUnsubscribers.push(unsubscribe);
+    return unsubscribe;
   })
 }));
 vi.mock('../../packages/oxiquill/src/lib/doc-runtime/runtime-client', () => ({
@@ -157,7 +161,9 @@ beforeEach(() => {
   vi.clearAllMocks();
   setManifestCells([]);
   runtimeMocks.manifestListeners = [];
+  runtimeMocks.manifestUnsubscribers = [];
   mocks.manifestListeners = runtimeMocks.manifestListeners;
+  mocks.manifestUnsubscribers = runtimeMocks.manifestUnsubscribers;
   TestResizeObserver.instances = [];
   document.documentElement.lang = 'en';
   document.documentElement.removeAttribute('data-theme');
@@ -729,6 +735,24 @@ describe('InteractiveCell', () => {
     });
 
     await waitFor(() => expect(screen.getByText('println!("new");')).toBeVisible());
+  });
+
+  it('requests shared manifest refreshes and unsubscribes each mounted consumer independently', () => {
+    setManifestCells([makeCell()]);
+
+    const first = render(<InteractiveCell cellId="cell-one" />);
+    const second = render(<InteractiveCell cellId="cell-one" />);
+
+    expect(mocks.scheduleGeneratedManifestRefresh).toHaveBeenCalledTimes(2);
+    expect(mocks.manifestListeners).toHaveLength(2);
+    expect(mocks.manifestUnsubscribers).toHaveLength(2);
+
+    first.unmount();
+    expect(mocks.manifestUnsubscribers[0]).toHaveBeenCalledOnce();
+    expect(mocks.manifestUnsubscribers[1]).not.toHaveBeenCalled();
+
+    second.unmount();
+    expect(mocks.manifestUnsubscribers[1]).toHaveBeenCalledOnce();
   });
 });
 

--- a/tests/unit/haskell-worker.test.ts
+++ b/tests/unit/haskell-worker.test.ts
@@ -7,6 +7,7 @@ import {
   createOutputCapture,
   fetchHaskellModule,
   fetchHaskellRuntimeStatus,
+  type HaskellRuntimeStatus,
   parseHaskellRuntimeStatus,
   resolveHaskellRuntimeStatusUrl,
   resolveHaskellWasmUrl
@@ -103,6 +104,76 @@ describe('haskell worker helpers', () => {
     expect(fetchStatus).toHaveBeenCalledOnce();
     expect(fetchModule).toHaveBeenCalledOnce();
     await expect(loadModule('hash-two')).rejects.toThrow('generated runtime is stale');
+    expect(fetchStatus).toHaveBeenCalledTimes(2);
+    expect(fetchModule).toHaveBeenCalledOnce();
+  });
+
+  it('shares failures, retries only on later matching-fingerprint calls, and caches recovery', async () => {
+    const firstAttempt = createDeferred<HaskellRuntimeStatus>();
+    const firstFailure = new Error('first status request failed');
+    const secondFailure = new Error('second status request failed');
+    const module = {} as WebAssembly.Module;
+    const fetchStatus = vi
+      .fn()
+      .mockImplementationOnce(() => firstAttempt.promise)
+      .mockRejectedValueOnce(secondFailure)
+      .mockResolvedValueOnce({ status: 'ready', haskellFingerprintHash: 'hash-one', message: '' });
+    const fetchModule = vi.fn(async () => module);
+    const loadModule = createHaskellModuleLoader({
+      fetchModule,
+      fetchStatus,
+      statusUrl: '/status.json',
+      wasmUrl: '/runtime.wasm'
+    });
+
+    const first = loadModule('hash-one');
+    const second = loadModule('hash-one');
+    expect(first).toBe(second);
+    expect(fetchStatus).toHaveBeenCalledOnce();
+
+    firstAttempt.reject(firstFailure);
+    const failedCalls = await Promise.allSettled([first, second]);
+    expect(failedCalls).toEqual([
+      { reason: firstFailure, status: 'rejected' },
+      { reason: firstFailure, status: 'rejected' }
+    ]);
+
+    await expect(loadModule('hash-one')).rejects.toBe(secondFailure);
+    expect(fetchStatus).toHaveBeenCalledTimes(2);
+
+    const recovered = loadModule('hash-one');
+    await expect(recovered).resolves.toBe(module);
+    expect(loadModule('hash-one')).toBe(recovered);
+    expect(fetchStatus).toHaveBeenCalledTimes(3);
+    expect(fetchModule).toHaveBeenCalledOnce();
+  });
+
+  it('does not let a late fingerprint failure clear a newer fingerprint cache', async () => {
+    const firstAttempt = createDeferred<HaskellRuntimeStatus>();
+    const secondAttempt = createDeferred<HaskellRuntimeStatus>();
+    const firstFailure = new Error('fingerprint A failed late');
+    const module = {} as WebAssembly.Module;
+    const fetchStatus = vi
+      .fn()
+      .mockImplementationOnce(() => firstAttempt.promise)
+      .mockImplementationOnce(() => secondAttempt.promise);
+    const fetchModule = vi.fn(async () => module);
+    const loadModule = createHaskellModuleLoader({
+      fetchModule,
+      fetchStatus,
+      statusUrl: '/status.json',
+      wasmUrl: '/runtime.wasm'
+    });
+
+    const fingerprintA = loadModule('hash-a');
+    const fingerprintB = loadModule('hash-b');
+    firstAttempt.reject(firstFailure);
+    await expect(fingerprintA).rejects.toBe(firstFailure);
+    expect(loadModule('hash-b')).toBe(fingerprintB);
+
+    secondAttempt.resolve({ status: 'ready', haskellFingerprintHash: 'hash-b', message: '' });
+    await expect(fingerprintB).resolves.toBe(module);
+    expect(loadModule('hash-b')).toBe(fingerprintB);
     expect(fetchStatus).toHaveBeenCalledTimes(2);
     expect(fetchModule).toHaveBeenCalledOnce();
   });
@@ -239,3 +310,14 @@ describe('haskell worker helpers', () => {
     }
   });
 });
+
+function createDeferred<T>() {
+  let reject!: (reason: Error) => void;
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    reject = rejectPromise;
+    resolve = resolvePromise;
+  });
+
+  return { promise, reject, resolve };
+}

--- a/tests/unit/manifest.test.ts
+++ b/tests/unit/manifest.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   applyCellsSnapshot,
   applyGeneratedSnapshot,
@@ -15,11 +15,18 @@ import type { CellManifest } from '../../packages/oxiquill/src/lib/doc-runtime/t
 
 const firstCell = makeCell('first', '<pre>first</pre>');
 const secondCell = makeCell('second', '<pre>second</pre>');
+let disposeRefresh: (() => void) | undefined;
 
 beforeEach(() => {
   document.body.replaceChildren();
   applyGeneratedSnapshot({ cells: [], version: 'test-runtime-version' });
   vi.restoreAllMocks();
+});
+
+afterEach(() => {
+  disposeRefresh?.();
+  disposeRefresh = undefined;
+  vi.useRealTimers();
 });
 
 describe('generated manifest state', () => {
@@ -62,19 +69,25 @@ describe('generated manifest state', () => {
         })
     );
 
-    await refreshGeneratedManifest({ fetchImpl, hasHotRuntime: true, now: () => 123, windowObject: window });
+    await expect(
+      refreshGeneratedManifest({ fetchImpl, hasHotRuntime: true, now: () => 123, windowObject: window })
+    ).resolves.toEqual({
+      snapshot: { cells: [firstCell], version: 'fresh-version' },
+      status: 'success'
+    });
 
     expect(fetchImpl).toHaveBeenCalledWith(expect.stringMatching(/oxiquill-fresh=123-\d+$/u), {
       cache: 'no-store'
     });
-    expect(getManifestSnapshot()).toEqual({ cells: [firstCell], version: 'fresh-version' });
 
     const warning = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
-    await refreshGeneratedManifest({
-      fetchImpl: vi.fn(async () => new Response('', { status: 503 })),
-      hasHotRuntime: true,
-      windowObject: window
-    });
+    await expect(
+      refreshGeneratedManifest({
+        fetchImpl: vi.fn(async () => new Response('', { status: 503 })),
+        hasHotRuntime: true,
+        windowObject: window
+      })
+    ).resolves.toEqual({ status: 'failure' });
     expect(warning).toHaveBeenCalledWith(
       'Oxiquill could not refresh the generated interactive cell manifest.',
       expect.objectContaining({ message: expect.stringContaining('503') })
@@ -83,35 +96,139 @@ describe('generated manifest state', () => {
 
   it('ignores unavailable hot runtimes and transient network errors', async () => {
     const fetchImpl = vi.fn();
-    await refreshGeneratedManifest({ fetchImpl, hasHotRuntime: false, windowObject: window });
+    await expect(refreshGeneratedManifest({ fetchImpl, hasHotRuntime: false, windowObject: window })).resolves.toEqual({
+      status: 'failure'
+    });
     expect(fetchImpl).not.toHaveBeenCalled();
 
     const warning = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
-    await refreshGeneratedManifest({
-      fetchImpl: vi.fn(async () => {
-        throw new TypeError('network changed during HMR');
-      }),
-      hasHotRuntime: true,
-      windowObject: window
-    });
+    await expect(
+      refreshGeneratedManifest({
+        fetchImpl: vi.fn(async () => {
+          throw new TypeError('network changed during HMR');
+        }),
+        hasHotRuntime: true,
+        windowObject: window
+      })
+    ).resolves.toEqual({ status: 'failure' });
     expect(warning).not.toHaveBeenCalled();
   });
 
-  it('schedules bounded refresh attempts and skips missing documents', () => {
-    const refresh = vi.fn(async () => undefined);
-    const setTimeout = vi.fn((callback: TimerHandler, delay?: number) => {
-      void delay;
-      if (typeof callback === 'function') callback();
-      return 1;
-    });
+  it('coalesces many refresh triggers into one shared successful retry stream', async () => {
+    vi.useFakeTimers();
+    const setTimeout = vi.spyOn(window, 'setTimeout');
+    const refresh = vi.fn(async () => successfulRefresh([firstCell], 'shared-version'));
 
-    scheduleGeneratedManifestRefresh({
-      refresh,
-      windowObject: { setTimeout } as unknown as Window
-    });
+    for (let index = 0; index < 24; index += 1) {
+      disposeRefresh = scheduleGeneratedManifestRefresh({ refresh, windowObject: window });
+    }
 
-    expect(setTimeout.mock.calls.map(([, delay]) => delay)).toEqual([0, 250, 1_000, 2_500, 5_000]);
-    expect(refresh).toHaveBeenCalledTimes(5);
+    expect(vi.getTimerCount()).toBe(5);
+    expect(setTimeout.mock.calls.slice(-5).map(([, delay]) => delay)).toEqual([0, 250, 1_000, 2_500, 5_000]);
+
+    await vi.advanceTimersByTimeAsync(0);
+    expect(refresh).toHaveBeenCalledOnce();
+    expect(getManifestSnapshot()).toEqual({ cells: [firstCell], version: 'shared-version' });
+
+    await vi.runAllTimersAsync();
+    expect(refresh).toHaveBeenCalledOnce();
+  });
+
+  it('aborts obsolete generations and rejects their late responses', async () => {
+    vi.useFakeTimers();
+    const obsolete = createDeferred<TestManifestRefreshResult>();
+    const current = createDeferred<TestManifestRefreshResult>();
+    const refresh = vi
+      .fn<TestManifestRefresh>()
+      .mockImplementationOnce(() => obsolete.promise)
+      .mockImplementationOnce(() => current.promise);
+
+    disposeRefresh = scheduleGeneratedManifestRefresh({ refresh, windowObject: window });
+    await vi.advanceTimersByTimeAsync(0);
+    const obsoleteSignal = refresh.mock.calls[0]?.[0]?.signal;
+
+    scheduleGeneratedManifestRefresh({ refresh, windowObject: window });
+    disposeRefresh = scheduleGeneratedManifestRefresh({ refresh, windowObject: window });
+    expect(obsoleteSignal?.aborted).toBe(true);
+    expect(vi.getTimerCount()).toBe(5);
+
+    await vi.advanceTimersByTimeAsync(0);
+    expect(refresh).toHaveBeenCalledTimes(2);
+
+    current.resolve(successfulRefresh([secondCell], 'current-version'));
+    await flushMicrotasks();
+    expect(getManifestSnapshot()).toEqual({ cells: [secondCell], version: 'current-version' });
+
+    obsolete.resolve(successfulRefresh([firstCell], 'obsolete-version'));
+    await flushMicrotasks();
+    expect(getManifestSnapshot()).toEqual({ cells: [secondCell], version: 'current-version' });
+  });
+
+  it('runs one attempt at a time within a generation and coalesces elapsed retries', async () => {
+    vi.useFakeTimers();
+    const firstAttempt = createDeferred<TestManifestRefreshResult>();
+    const secondAttempt = createDeferred<TestManifestRefreshResult>();
+    const refresh = vi
+      .fn<TestManifestRefresh>()
+      .mockImplementationOnce(() => firstAttempt.promise)
+      .mockImplementationOnce(() => secondAttempt.promise);
+
+    disposeRefresh = scheduleGeneratedManifestRefresh({ refresh, windowObject: window });
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(refresh).toHaveBeenCalledOnce();
+
+    firstAttempt.resolve({ status: 'failure' });
+    await flushMicrotasks();
+    expect(refresh).toHaveBeenCalledTimes(2);
+
+    secondAttempt.resolve(successfulRefresh([firstCell], 'retry-version'));
+    await flushMicrotasks();
+    expect(getManifestSnapshot()).toEqual({ cells: [firstCell], version: 'retry-version' });
+  });
+
+  it('retries a failed attempt at the next delay and cancels later retries after success', async () => {
+    vi.useFakeTimers();
+    const listener = vi.fn();
+    const unsubscribe = subscribeManifest(listener);
+    const refresh = vi
+      .fn<TestManifestRefresh>()
+      .mockResolvedValueOnce({ status: 'failure' })
+      .mockResolvedValueOnce(successfulRefresh([firstCell], 'recovered-version'));
+
+    disposeRefresh = scheduleGeneratedManifestRefresh({ refresh, windowObject: window });
+    await vi.advanceTimersByTimeAsync(0);
+    expect(refresh).toHaveBeenCalledOnce();
+    expect(listener).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(250);
+    expect(refresh).toHaveBeenCalledTimes(2);
+    expect(listener).toHaveBeenCalledOnce();
+
+    await vi.runAllTimersAsync();
+    expect(refresh).toHaveBeenCalledTimes(2);
+    unsubscribe();
+  });
+
+  it('clears pending retries and aborts in-flight work when disposed', async () => {
+    vi.useFakeTimers();
+    const attempt = createDeferred<TestManifestRefreshResult>();
+    const refresh = vi.fn<TestManifestRefresh>(() => attempt.promise);
+
+    disposeRefresh = scheduleGeneratedManifestRefresh({ refresh, windowObject: window });
+    await vi.advanceTimersByTimeAsync(0);
+    const signal = refresh.mock.calls[0]?.[0]?.signal;
+
+    disposeRefresh();
+    expect(signal?.aborted).toBe(true);
+    await vi.runAllTimersAsync();
+    expect(refresh).toHaveBeenCalledOnce();
+
+    attempt.resolve(successfulRefresh([firstCell], 'disposed-version'));
+    await flushMicrotasks();
+    expect(getManifestSnapshot()).toEqual({ cells: [], version: 'test-runtime-version' });
+  });
+
+  it('skips missing documents when synchronizing rendered source blocks', () => {
     expect(() => syncRenderedSourceBlocks(undefined)).not.toThrow();
     expect(freshManifestUrl(() => 456)).toMatch(/oxiquill-fresh=456-\d+$/u);
   });
@@ -132,4 +249,29 @@ function makeCell(id: string, sourceHtml: string): CellManifest {
     timeoutMs: 1_000,
     title: id
   };
+}
+
+type TestManifestRefreshResult = ReturnType<typeof successfulRefresh> | { status: 'failure' };
+type TestManifestRefresh = (options?: { signal?: AbortSignal }) => Promise<TestManifestRefreshResult>;
+
+function successfulRefresh(cells: readonly CellManifest[], version: string) {
+  return {
+    snapshot: { cells, version },
+    status: 'success' as const
+  };
+}
+
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+
+  return { promise, resolve };
+}
+
+async function flushMicrotasks(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
 }

--- a/tests/unit/python-worker.test.ts
+++ b/tests/unit/python-worker.test.ts
@@ -116,7 +116,7 @@ describe('python worker asset URLs', () => {
     });
   });
 
-  it('loads and initializes Pyodide once for repeated requests', async () => {
+  it('loads and initializes Pyodide once for concurrent and repeated requests', async () => {
     const pyodide = { runPythonAsync: vi.fn(async () => undefined) };
     const loadPyodide = vi.fn(async () => pyodide);
     const importModule = vi.fn(async () => ({ loadPyodide: loadPyodide as never }));
@@ -126,8 +126,11 @@ describe('python worker asset URLs', () => {
       moduleUrl: '/runtime/pyodide.mjs'
     });
 
-    await expect(loadRuntime()).resolves.toBe(pyodide);
-    await expect(loadRuntime()).resolves.toBe(pyodide);
+    const first = loadRuntime();
+    const second = loadRuntime();
+    expect(first).toBe(second);
+    await expect(first).resolves.toBe(pyodide);
+    expect(loadRuntime()).toBe(first);
     expect(importModule).toHaveBeenCalledOnce();
     expect(importModule).toHaveBeenCalledWith('/runtime/pyodide.mjs');
     expect(loadPyodide).toHaveBeenCalledOnce();
@@ -135,6 +138,83 @@ describe('python worker asset URLs', () => {
     expect(pyodide.runPythonAsync).toHaveBeenCalledOnce();
     expect(pyodide.runPythonAsync).toHaveBeenCalledWith(pythonDisplaySupportCode);
   });
+
+  it('retries both import and initialization after a shared module-import failure', async () => {
+    const importFailure = new Error('module import failed');
+    const pyodide = { runPythonAsync: vi.fn(async () => undefined) };
+    const loadPyodide = vi.fn(async () => pyodide);
+    const importModule = vi
+      .fn()
+      .mockRejectedValueOnce(importFailure)
+      .mockResolvedValueOnce({ loadPyodide: loadPyodide as never });
+    const loadRuntime = createPythonRuntimeLoader({
+      importModule,
+      indexUrl: '/runtime/',
+      moduleUrl: '/runtime/pyodide.mjs'
+    });
+
+    const first = loadRuntime();
+    const second = loadRuntime();
+    expect(first).toBe(second);
+    const failedCalls = await Promise.allSettled([first, second]);
+    expect(failedCalls).toEqual([
+      { reason: importFailure, status: 'rejected' },
+      { reason: importFailure, status: 'rejected' }
+    ]);
+
+    const recovered = loadRuntime();
+    await expect(recovered).resolves.toBe(pyodide);
+    expect(loadRuntime()).toBe(recovered);
+    expect(importModule).toHaveBeenCalledTimes(2);
+    expect(loadPyodide).toHaveBeenCalledOnce();
+  });
+
+  it.each(['runtime loading', 'display support'] as const)(
+    'reuses the imported module while retrying failed %s on later explicit requests',
+    async (failureStage) => {
+      const firstFailure = new Error(`first ${failureStage} failure`);
+      const secondFailure = new Error(`second ${failureStage} failure`);
+      const readyPyodide = { runPythonAsync: vi.fn(async () => undefined) };
+      const loadPyodide =
+        failureStage === 'runtime loading'
+          ? vi
+              .fn()
+              .mockRejectedValueOnce(firstFailure)
+              .mockRejectedValueOnce(secondFailure)
+              .mockResolvedValue(readyPyodide)
+          : vi
+              .fn()
+              .mockResolvedValueOnce({ runPythonAsync: vi.fn().mockRejectedValue(firstFailure) })
+              .mockResolvedValueOnce({ runPythonAsync: vi.fn().mockRejectedValue(secondFailure) })
+              .mockResolvedValue(readyPyodide);
+      const importModule = vi.fn(async () => ({ loadPyodide: loadPyodide as never }));
+      const loadRuntime = createPythonRuntimeLoader({
+        importModule,
+        indexUrl: '/runtime/',
+        moduleUrl: '/runtime/pyodide.mjs'
+      });
+
+      const first = loadRuntime();
+      const second = loadRuntime();
+      expect(first).toBe(second);
+      const failedCalls = await Promise.allSettled([first, second]);
+      expect(failedCalls).toEqual([
+        { reason: firstFailure, status: 'rejected' },
+        { reason: firstFailure, status: 'rejected' }
+      ]);
+      expect(loadPyodide).toHaveBeenCalledOnce();
+
+      await expect(loadRuntime()).rejects.toBe(secondFailure);
+      expect(loadPyodide).toHaveBeenCalledTimes(2);
+
+      const recovered = loadRuntime();
+      await expect(recovered).resolves.toBe(readyPyodide);
+      expect(loadRuntime()).toBe(recovered);
+      expect(importModule).toHaveBeenCalledOnce();
+      expect(loadPyodide).toHaveBeenCalledTimes(3);
+      expect(readyPyodide.runPythonAsync).toHaveBeenCalledOnce();
+    }
+  );
 
   it('loads blob modules, reports HTTP failures, and always revokes temporary URLs', async () => {
     const unavailable = vi.fn(async () => ({ ok: false, status: 503, statusText: 'Unavailable' }) as Response);

--- a/tests/unit/rust-worker.test.ts
+++ b/tests/unit/rust-worker.test.ts
@@ -4,6 +4,8 @@ import { outputArtifactLimits, utf8ByteLength } from '../../packages/oxiquill/sr
 import { initializeRustWasm, run_rust_cell } from './mocks/virtual-runtime';
 
 type MessageListener = (event: MessageEvent<RuntimeWorkerRequest>) => void;
+type CreateRustRuntimeLoader =
+  typeof import('../../packages/oxiquill/src/lib/doc-runtime/rust-worker').createRustRuntimeLoader;
 
 const worker = {
   listener: undefined as MessageListener | undefined,
@@ -12,10 +14,11 @@ const worker = {
   }),
   postMessage: vi.fn<(response: RuntimeWorkerResponse) => void>()
 };
+let createRustRuntimeLoader: CreateRustRuntimeLoader;
 
 beforeAll(async () => {
   vi.stubGlobal('self', worker);
-  await import('../../packages/oxiquill/src/lib/doc-runtime/rust-worker');
+  ({ createRustRuntimeLoader } = await import('../../packages/oxiquill/src/lib/doc-runtime/rust-worker'));
 });
 
 beforeEach(() => {
@@ -92,8 +95,53 @@ describe('Rust runtime worker', () => {
   });
 });
 
+describe('Rust runtime loader', () => {
+  it('shares each attempt, retries only on later calls, and retains successful initialization', async () => {
+    const firstAttempt = createDeferred();
+    const firstFailure = new Error('first initialization failed');
+    const secondFailure = new Error('second initialization failed');
+    const init = vi
+      .fn<() => Promise<unknown>>()
+      .mockImplementationOnce(() => firstAttempt.promise)
+      .mockRejectedValueOnce(secondFailure)
+      .mockResolvedValueOnce(undefined);
+    const ensureRuntime = createRustRuntimeLoader({ init });
+
+    const first = ensureRuntime();
+    const second = ensureRuntime();
+    expect(first).toBe(second);
+    expect(init).toHaveBeenCalledOnce();
+
+    firstAttempt.reject(firstFailure);
+    const failedCalls = await Promise.allSettled([first, second]);
+    expect(failedCalls).toEqual([
+      { reason: firstFailure, status: 'rejected' },
+      { reason: firstFailure, status: 'rejected' }
+    ]);
+
+    await expect(ensureRuntime()).rejects.toBe(secondFailure);
+    expect(init).toHaveBeenCalledTimes(2);
+
+    const recovered = ensureRuntime();
+    await expect(recovered).resolves.toBeUndefined();
+    expect(ensureRuntime()).toBe(recovered);
+    expect(init).toHaveBeenCalledTimes(3);
+  });
+});
+
 async function flushMicrotasks(): Promise<void> {
   await Promise.resolve();
   await Promise.resolve();
   await Promise.resolve();
+}
+
+function createDeferred() {
+  let reject!: (reason: Error) => void;
+  let resolve!: () => void;
+  const promise = new Promise<void>((resolvePromise, rejectPromise) => {
+    reject = rejectPromise;
+    resolve = resolvePromise;
+  });
+
+  return { promise, reject, resolve };
 }

--- a/tests/unit/virtual-modules.test.mjs
+++ b/tests/unit/virtual-modules.test.mjs
@@ -60,6 +60,7 @@ describe('oxiquill virtual modules', () => {
       event: 'oxiquill:manifest-changed',
       data: { module: 'cells' }
     });
+    expect(hot.send).toHaveBeenCalledTimes(1);
     expect(plugin.hotUpdate.call(context, { file: pathFromUrl(paths.runtimeVersionPath) })).toEqual([versionNode]);
     expect(plugin.hotUpdate.call(context, { file: pathFromUrl(paths.cellsJsonPath) })).toEqual([singleCellNode]);
     expect(plugin.hotUpdate.call(context, { file: rustWasmFile(paths) })).toEqual([rustNode]);
@@ -127,7 +128,7 @@ describe('oxiquill virtual modules', () => {
     }
   });
 
-  it('watches generated files without forcing full-page reloads', () => {
+  it('registers generated files without installing a duplicate raw change sender', () => {
     const { paths, plugin } = createPlugin();
     const hot = { send: vi.fn() };
     const server = {
@@ -151,16 +152,9 @@ describe('oxiquill virtual modules', () => {
       pathFromUrl(paths.cellsJsonPath),
       rustWasmFile(paths)
     ]);
-    expect(server.watcher.on).toHaveBeenCalledWith('change', expect.any(Function));
+    expect(server.watcher.on).not.toHaveBeenCalled();
     expect(server.middlewares.use).toHaveBeenCalledOnce();
-
-    const changeHandler = server.watcher.on.mock.calls[0][1];
-    changeHandler(pathFromUrl(paths.cellsModulePath));
-    expect(hot.send).toHaveBeenCalledWith({
-      type: 'custom',
-      event: 'oxiquill:manifest-changed',
-      data: { module: 'cells' }
-    });
+    expect(hot.send).not.toHaveBeenCalled();
     expect(hot.send).not.toHaveBeenCalledWith(expect.objectContaining({ type: 'full-reload' }));
   });
 


### PR DESCRIPTION
## Summary

- coalesce generated-manifest refreshes behind a generation-aware coordinator that aborts obsolete requests and ignores stale results
- remove the duplicate raw watcher HMR event so manifest updates have one authoritative trigger
- let Python, Rust, and Haskell runtimes recover from transient initialization failures without breaking single-flight loading or successful-result caching
- add regression coverage for retries, concurrent callers, cache cleanup, and Haskell fingerprint races

## Validation

- pnpm test:unit:coverage
- pnpm wasm:dev
- pnpm test:wasm
- pnpm test:haskell
- pnpm lint
- pnpm check
- pnpm build
- Chromium end-to-end suite: 24 passed
- pnpm test: all non-WebKit stages passed locally; WebKit could not launch because its host shared libraries are unavailable in this environment

Closes #109
Closes #110