### PR TITLE
Fix runtime error normalization and helper input tracking

### DIFF
--- a/packages/oxiquill/src/components/doc-runtime/ArtifactErrorBoundary.tsx
+++ b/packages/oxiquill/src/components/doc-runtime/ArtifactErrorBoundary.tsx
@@ -10,24 +10,24 @@ interface ArtifactErrorBoundaryProps {
 }
 
 interface ArtifactErrorBoundaryState {
-  error?: string;
+  error: string | undefined;
 }
 
 export default class ArtifactErrorBoundary extends Component<ArtifactErrorBoundaryProps, ArtifactErrorBoundaryState> {
-  state: ArtifactErrorBoundaryState = {};
+  state: ArtifactErrorBoundaryState = { error: undefined };
 
   componentDidCatch(error: unknown): void {
     this.setState({ error: boundedErrorMessage(error) });
   }
 
   componentDidUpdate(previousProps: ArtifactErrorBoundaryProps): void {
-    if (previousProps.resetKey !== this.props.resetKey && this.state.error) {
+    if (previousProps.resetKey !== this.props.resetKey && this.state.error !== undefined) {
       this.setState({ error: undefined });
     }
   }
 
   render({ children, index, labels }: ArtifactErrorBoundaryProps, { error }: ArtifactErrorBoundaryState) {
-    if (error) {
+    if (error !== undefined) {
       return <ArtifactError message={labels.artifactRenderError(index + 1, error)} />;
     }
     return children;

--- a/packages/oxiquill/src/components/doc-runtime/CellOutput.tsx
+++ b/packages/oxiquill/src/components/doc-runtime/CellOutput.tsx
@@ -49,7 +49,7 @@ export function CellOutput({
       <p class="doc-visually-hidden" aria-atomic="true" aria-live="polite" role="status">
         {liveMessage}
       </p>
-      {error ? (
+      {error !== undefined ? (
         <p class="error-state" role="alert">
           {labels.executionErrorLabel} <span>{labels.diagnosticDetail(error)}</span>
         </p>

--- a/packages/oxiquill/src/components/doc-runtime/MermaidDiagram.tsx
+++ b/packages/oxiquill/src/components/doc-runtime/MermaidDiagram.tsx
@@ -1,5 +1,6 @@
 import type { MermaidConfig } from 'mermaid';
 import { useEffect, useMemo, useRef, useState } from 'preact/hooks';
+import { boundedErrorMessage } from '../../lib/doc-runtime/output-limits.mjs';
 import { labelsForLanguage, type MermaidDiagramKind } from '../../lib/doc-runtime/runtime-localization.js';
 
 interface MermaidDiagramProps {
@@ -7,7 +8,8 @@ interface MermaidDiagramProps {
   source: string;
 }
 
-type RenderState = 'idle' | 'rendering' | 'ready' | 'error';
+type RenderState =
+  { status: 'idle' } | { status: 'rendering' } | { status: 'ready' } | { message: string; status: 'error' };
 type MermaidColorScheme = 'light' | 'dark';
 type MermaidApi = (typeof import('mermaid'))['default'];
 
@@ -16,8 +18,7 @@ let mermaidReady: Promise<MermaidApi> | undefined;
 
 export default function MermaidDiagram({ diagramId, source }: MermaidDiagramProps) {
   const container = useRef<HTMLDivElement>(null);
-  const [error, setError] = useState<string>();
-  const [state, setState] = useState<RenderState>('idle');
+  const [state, setState] = useState<RenderState>({ status: 'idle' });
   const [colorScheme, setColorScheme] = useState<MermaidColorScheme>(() => getMermaidColorScheme());
   const renderId = useMemo(() => `doc-${diagramId}`, [diagramId]);
   const labels = useMemo(() => labelsForLanguage(globalThis.document?.documentElement.lang), []);
@@ -45,8 +46,7 @@ export default function MermaidDiagram({ diagramId, source }: MermaidDiagramProp
     let cancelled = false;
 
     async function renderDiagram(renderElement: HTMLDivElement) {
-      setState('rendering');
-      setError(undefined);
+      setState({ status: 'rendering' });
       renderElement.replaceChildren();
 
       try {
@@ -60,13 +60,11 @@ export default function MermaidDiagram({ diagramId, source }: MermaidDiagramProp
         renderElement.innerHTML = svg;
         hideRenderedSvgFromAccessibility(renderElement);
         bindFunctions?.(renderElement);
-        setState('ready');
+        setState({ status: 'ready' });
       } catch (caught) {
         if (cancelled) return;
 
-        const message = caught instanceof Error ? caught.message : String(caught);
-        setError(message);
-        setState('error');
+        setState({ message: boundedErrorMessage(caught), status: 'error' });
       }
     }
 
@@ -83,7 +81,7 @@ export default function MermaidDiagram({ diagramId, source }: MermaidDiagramProp
       class="mermaid-diagram"
       aria-labelledby={ids.title}
       aria-describedby={ids.description}
-      data-state={state}
+      data-state={state.status}
       data-testid="mermaid-diagram"
     >
       <span id={ids.title} class="doc-visually-hidden">
@@ -99,13 +97,13 @@ export default function MermaidDiagram({ diagramId, source }: MermaidDiagramProp
         aria-labelledby={ids.title}
         role="img"
       />
-      {state === 'idle' || state === 'rendering' ? (
+      {state.status === 'idle' || state.status === 'rendering' ? (
         <figcaption class="empty-state" role="status">
           {labels.mermaidLoading}
         </figcaption>
-      ) : error ? (
+      ) : state.status === 'error' ? (
         <figcaption class="error-state" role="alert">
-          {labels.mermaidError(error)}
+          {labels.mermaidError(state.message)}
         </figcaption>
       ) : null}
     </figure>

--- a/packages/oxiquill/src/components/doc-runtime/OutputRenderer.tsx
+++ b/packages/oxiquill/src/components/doc-runtime/OutputRenderer.tsx
@@ -4,6 +4,7 @@ import type {
   ValidatedJsonArtifact,
   ValidatedOutputArtifact
 } from '../../lib/doc-runtime/output-artifact-validation.js';
+import { boundedErrorMessage } from '../../lib/doc-runtime/output-limits.mjs';
 import type { RuntimeLabels } from '../../lib/doc-runtime/runtime-localization.js';
 import { labelsForLanguage } from '../../lib/doc-runtime/runtime-localization.js';
 import type { ComponentChildren } from 'preact';
@@ -113,7 +114,7 @@ export function LazyChartOutput({
         if (!cancelled) {
           setState({
             status: 'error',
-            message: caught instanceof Error ? caught.message : String(caught)
+            message: boundedErrorMessage(caught)
           });
         }
       });

--- a/packages/oxiquill/src/components/doc-runtime/TableOutput.tsx
+++ b/packages/oxiquill/src/components/doc-runtime/TableOutput.tsx
@@ -1,4 +1,5 @@
 import { useLayoutEffect, useMemo, useRef, useState } from 'preact/hooks';
+import { boundedErrorMessage } from '../../lib/doc-runtime/output-limits.mjs';
 import { labelsForLanguage, type RuntimeLabels } from '../../lib/doc-runtime/runtime-localization.js';
 import type { TableArtifact, TableColumn } from '../../lib/doc-runtime/types.js';
 
@@ -96,7 +97,7 @@ export default function TableOutput({
       if (resultGenerationRef.current === resultGeneration) {
         setCopyStatus({
           kind: 'error',
-          message: labels.copyCsvError(error instanceof Error ? error.message : String(error))
+          message: labels.copyCsvError(boundedErrorMessage(error))
         });
       }
     }
@@ -241,7 +242,7 @@ export function tableToCsv(
       ].join('\n')
     };
   } catch (error) {
-    return { ok: false, error: error instanceof Error ? error.message : String(error) };
+    return { ok: false, error: boundedErrorMessage(error) };
   }
 }
 

--- a/packages/oxiquill/src/components/doc-runtime/useInteractiveCellRun.ts
+++ b/packages/oxiquill/src/components/doc-runtime/useInteractiveCellRun.ts
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'preact/hooks';
 import { initialValues } from '../../lib/doc-runtime/interactive-cell-model.js';
 import { createLatestRequestScheduler, createRunOnceCache } from '../../lib/doc-runtime/interactive-cell-scheduler.js';
+import { boundedErrorMessage } from '../../lib/doc-runtime/output-limits.mjs';
 import { runInteractiveCell } from '../../lib/doc-runtime/runtime-client.js';
 import type { NormalizedCellExecutionResult } from '../../lib/doc-runtime/output-artifacts.js';
 import type { CellManifest, InputValues } from '../../lib/doc-runtime/types.js';
@@ -44,7 +45,7 @@ export function useInteractiveCellRun(cell: CellManifest, runtimeVersion: string
       setExecution({ status: 'idle' });
     },
     onError: (caught) => {
-      setExecution({ error: caught instanceof Error ? caught.message : String(caught), status: 'error' });
+      setExecution({ error: boundedErrorMessage(caught), status: 'error' });
     },
     onResult: (result) => {
       setExecution({ result, status: 'success' });

--- a/packages/oxiquill/src/generator/doc-runtime-service.mjs
+++ b/packages/oxiquill/src/generator/doc-runtime-service.mjs
@@ -18,6 +18,7 @@ import {
 } from './doc-runtime-core.mjs';
 import { throwInteractiveCellDiagnostics, validateCellDependencies } from '../lib/doc-runtime/cell-authoring.mjs';
 import { defaultFileSystem, listFiles, writeIfChanged } from './doc-runtime/file-system.mjs';
+import { listAuthoredHelperInputFiles } from './doc-runtime/helper-inputs.mjs';
 import { listHelperCrates } from './doc-runtime/helper-crate-service.mjs';
 import { normalizePath } from './doc-runtime/path-utils.mjs';
 import {
@@ -31,7 +32,7 @@ import {
   generateRuntimeVersionModule,
   summarizeCells
 } from './doc-runtime/runtime-summary.mjs';
-import { hashText, stableFingerprint } from './doc-runtime/hashing.mjs';
+import { hashBytes, hashText, stableFingerprint } from './doc-runtime/hashing.mjs';
 import { createRuntimePlan } from './doc-runtime/runtime-plan.mjs';
 import {
   createRuntimeOwnedOutputs,
@@ -563,35 +564,14 @@ function recordedFilesExist(files, directory, fileSystem) {
 }
 
 async function fingerprintHelperSources({ fileSystem, paths }) {
-  const files = await listSelectedFiles(paths.cratesDir, { fileSystem });
+  const files = await listAuthoredHelperInputFiles(paths.cratesDir, { fileSystem });
   const entries = await Promise.all(
-    files.map(async (filePath) => ({
-      content: await fileSystem.readFile(filePath, 'utf8'),
-      path: normalizePath(path.relative(paths.cratesDir, filePath))
+    files.map(async ({ filePath, path: relativePath }) => ({
+      digest: hashBytes(await fileSystem.readFile(filePath)),
+      path: relativePath
     }))
   );
   return stableFingerprint(entries);
-}
-
-async function listSelectedFiles(directory, { fileSystem }) {
-  let entries;
-  try {
-    entries = await fileSystem.readdir(directory, { withFileTypes: true });
-  } catch (error) {
-    if (error?.code === 'ENOENT') return [];
-    throw error;
-  }
-
-  const nested = await Promise.all(
-    entries
-      .filter((entry) => entry.name !== 'target' && entry.name !== '.git')
-      .map(async (entry) => {
-        const entryPath = path.join(directory, entry.name);
-        if (entry.isDirectory()) return listSelectedFiles(entryPath, { fileSystem });
-        return entry.isFile() && /(?:\.rs|\.toml|Cargo\.lock)$/u.test(entry.name) ? [entryPath] : [];
-      })
-  );
-  return nested.flat().sort();
 }
 
 export async function collectCells({ fileSystem = defaultFileSystem, helperCrates, highlighter, paths }) {

--- a/packages/oxiquill/src/generator/doc-runtime-watch-core.mjs
+++ b/packages/oxiquill/src/generator/doc-runtime-watch-core.mjs
@@ -1,5 +1,8 @@
 import path from 'node:path';
 import { pathFromUrl, relativePathFromUrl } from '../config/paths.mjs';
+import { isAuthoredHelperInputPath, isExcludedHelperInputPath } from './doc-runtime/helper-inputs.mjs';
+
+const runtimeWatchFileEvents = new Set(['add', 'change', 'unlink']);
 
 export function classifyChangedPath(filePath, paths) {
   const normalized = normalizePath(filePath);
@@ -16,6 +19,17 @@ export function createRuntimeWatchPaths(paths) {
   if (!paths) return ['content/docs', 'crates'];
 
   return [pathFromUrl(paths.docsDir), pathFromUrl(paths.cratesDir)];
+}
+
+export function isExcludedCratePath(filePath, paths) {
+  const normalized = normalizePath(filePath);
+  const cratesDir = paths ? relativePathFromUrl(paths.workspaceRoot, paths.cratesDir) : 'crates';
+  const relativePath = relativePathWithin(normalized, cratesDir);
+  return relativePath !== undefined && isExcludedHelperInputPath(relativePath);
+}
+
+export function isRuntimeWatchFileEvent(event) {
+  return runtimeWatchFileEvents.has(event);
 }
 
 export function shouldSyncRuntime(changeKinds) {
@@ -83,6 +97,11 @@ function isDocsPath(filePath, docsDir) {
 }
 
 function isCratePath(filePath, cratesDir) {
-  const prefix = normalizePath(cratesDir).replace(/\/$/u, '');
-  return filePath.startsWith(`${prefix}/`) && /\.(rs|toml)$/u.test(filePath);
+  const relativePath = relativePathWithin(filePath, cratesDir);
+  return relativePath !== undefined && isAuthoredHelperInputPath(relativePath);
+}
+
+function relativePathWithin(filePath, directory) {
+  const prefix = normalizePath(directory).replace(/\/$/u, '');
+  return filePath.startsWith(`${prefix}/`) ? filePath.slice(prefix.length + 1) : undefined;
 }

--- a/packages/oxiquill/src/generator/doc-runtime/helper-inputs.mjs
+++ b/packages/oxiquill/src/generator/doc-runtime/helper-inputs.mjs
@@ -1,0 +1,43 @@
+import path from 'node:path';
+import { pathFromUrl } from '../../config/paths.mjs';
+import { normalizePath } from './path-utils.mjs';
+
+const excludedHelperInputSegments = new Set(['target', '.git', '.hg', '.svn']);
+
+export function isAuthoredHelperInputPath(filePath) {
+  const segments = normalizePath(filePath).split('/').filter(Boolean);
+  return segments.length > 0 && !segments.some((segment) => excludedHelperInputSegments.has(segment));
+}
+
+export function isExcludedHelperInputPath(filePath) {
+  return normalizePath(filePath)
+    .split('/')
+    .some((segment) => excludedHelperInputSegments.has(segment));
+}
+
+export async function listAuthoredHelperInputFiles(directory, { fileSystem }) {
+  const root = pathFromUrl(directory);
+  return listNestedHelperInputFiles(root, '', { fileSystem });
+}
+
+async function listNestedHelperInputFiles(directory, relativeDirectory, { fileSystem }) {
+  let entries;
+  try {
+    entries = await fileSystem.readdir(directory, { withFileTypes: true });
+  } catch (error) {
+    if (error?.code === 'ENOENT') return [];
+    throw error;
+  }
+
+  const nested = await Promise.all(
+    entries.map(async (entry) => {
+      const relativePath = normalizePath(path.join(relativeDirectory, entry.name));
+      if (!isAuthoredHelperInputPath(relativePath)) return [];
+
+      const filePath = path.join(directory, entry.name);
+      if (entry.isDirectory()) return listNestedHelperInputFiles(filePath, relativePath, { fileSystem });
+      return entry.isFile() ? [{ filePath, path: relativePath }] : [];
+    })
+  );
+  return nested.flat().sort((left, right) => (left.path < right.path ? -1 : left.path > right.path ? 1 : 0));
+}

--- a/packages/oxiquill/src/generator/watch-doc-runtime.mjs
+++ b/packages/oxiquill/src/generator/watch-doc-runtime.mjs
@@ -10,6 +10,8 @@ import {
   createRuntimeWatchPaths,
   createSerialTaskQueue,
   describeChangeKinds,
+  isExcludedCratePath,
+  isRuntimeWatchFileEvent,
   mergeChangeKinds,
   shouldSyncRuntime,
   toWatchEventRelativePath
@@ -94,10 +96,13 @@ export async function watchDocRuntime({ projectConfig, serviceOverrides = {}, sk
   // Chokidar v4 does not expand globs, so watch stable roots and classify events ourselves.
   const watcher = services.watch(createRuntimeWatchPaths(paths), {
     cwd: workspaceRoot,
+    ignored: (filePath) => isExcludedCratePath(toWatchEventRelativePath(workspaceRoot, filePath), paths),
     ignoreInitial: true
   });
 
-  watcher.on('all', (_event, filePath) => {
+  watcher.on('all', (event, filePath) => {
+    if (!isRuntimeWatchFileEvent(event)) return;
+
     const kind = classifyChangedPath(toWatchEventRelativePath(workspaceRoot, filePath), paths);
     if (kind === 'other') return;
 
@@ -106,7 +111,7 @@ export async function watchDocRuntime({ projectConfig, serviceOverrides = {}, sk
   });
 
   watcher.on('ready', () => {
-    console.log('[runtime] watching MDX, Rust, and Haskell cell sources');
+    console.log('[runtime] watching documentation and helper-crate inputs');
   });
 
   if (!skipInitial) {

--- a/packages/oxiquill/src/lib/doc-runtime/execution-cancellation.ts
+++ b/packages/oxiquill/src/lib/doc-runtime/execution-cancellation.ts
@@ -6,8 +6,12 @@ export class ExecutionCancellationError extends Error {
 }
 
 export function isExecutionCancellation(error: unknown): boolean {
-  return (
-    error instanceof ExecutionCancellationError ||
-    (typeof error === 'object' && error !== null && 'name' in error && error.name === 'AbortError')
-  );
+  try {
+    return (
+      error instanceof ExecutionCancellationError ||
+      (typeof error === 'object' && error !== null && 'name' in error && error.name === 'AbortError')
+    );
+  } catch {
+    return false;
+  }
 }

--- a/packages/oxiquill/src/lib/doc-runtime/output-limits.mjs
+++ b/packages/oxiquill/src/lib/doc-runtime/output-limits.mjs
@@ -15,6 +15,7 @@ export const outputArtifactLimits = Object.freeze({
 });
 
 const utf8Encoder = new TextEncoder();
+const unknownErrorMessage = 'Unknown error.';
 
 export function utf8ByteLength(value) {
   return utf8Encoder.encode(value).byteLength;
@@ -42,8 +43,16 @@ export function truncateUtf8(value, maxBytes) {
 }
 
 export function boundedErrorMessage(value) {
-  const message = value instanceof Error ? value.message : String(value);
-  return truncateUtf8(message, outputArtifactLimits.bytesPerError).value;
+  let message;
+  try {
+    const extracted = value instanceof Error ? value.message : value;
+    message = typeof extracted === 'string' ? extracted : String(extracted);
+  } catch {
+    message = unknownErrorMessage;
+  }
+
+  const normalized = message.trim() === '' ? unknownErrorMessage : message;
+  return truncateUtf8(normalized, outputArtifactLimits.bytesPerError).value;
 }
 
 export function createBoundedTextAccumulator(maxBytes = outputArtifactLimits.bytesPerStream, separator = '') {

--- a/packages/oxiquill/src/lib/doc-runtime/runtime-client.ts
+++ b/packages/oxiquill/src/lib/doc-runtime/runtime-client.ts
@@ -242,9 +242,13 @@ function isRuntimeWorkerResponse(value: unknown): value is RuntimeWorkerResponse
 
 function toError(value: unknown): Error {
   const message = boundedErrorMessage(value);
-  return value instanceof Error && value.name === 'AbortError'
-    ? new ExecutionCancellationError(message)
-    : new Error(message);
+  try {
+    return value instanceof Error && value.name === 'AbortError'
+      ? new ExecutionCancellationError(message)
+      : new Error(message);
+  } catch {
+    return new Error(message);
+  }
 }
 
 function inputArgument(input: CellManifest['inputs'][number], inputs: InputValues): string {

--- a/tests/unit/components.test.tsx
+++ b/tests/unit/components.test.tsx
@@ -48,6 +48,8 @@ vi.mock('../../packages/oxiquill/src/lib/doc-runtime/runtime-client', () => ({
 
 await import('./mocks/mermaid');
 const { default: InteractiveCell } = await import('../../packages/oxiquill/src/components/doc-runtime/InteractiveCell');
+const { default: ArtifactErrorBoundary } =
+  await import('../../packages/oxiquill/src/components/doc-runtime/ArtifactErrorBoundary');
 const {
   default: MermaidDiagram,
   getMermaidColorScheme,
@@ -476,12 +478,14 @@ describe('InteractiveCell', () => {
 
   it('coerces non-Error failures to strings', async () => {
     setManifestCells([makeCell()]);
-    mocks.runInteractiveCell.mockRejectedValue('string failure');
+    mocks.runInteractiveCell.mockRejectedValueOnce('string failure').mockRejectedValueOnce(Object.create(null));
 
     render(<InteractiveCell cellId="cell-one" />);
     fireEvent.click(screen.getByRole('button', { name: 'Run' }));
 
     await waitFor(() => expect(screen.getByText('string failure')).toBeVisible());
+    fireEvent.click(screen.getByRole('button', { name: 'Run' }));
+    await waitFor(() => expect(screen.getByRole('alert')).toHaveTextContent('Cell execution failed: Unknown error.'));
   });
 
   it('announces localized timeout failures as an alert', async () => {
@@ -756,6 +760,63 @@ describe('InteractiveCell', () => {
   });
 });
 
+describe('ArtifactErrorBoundary', () => {
+  function TestArtifact({ fail }: { fail: boolean }) {
+    if (fail) throw new Error();
+    return <p>replacement artifact</p>;
+  }
+
+  it('renders empty-message failures and resets even a legacy empty error state', async () => {
+    const firstResetKey = {};
+    const secondResetKey = {};
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    let boundary: InstanceType<typeof ArtifactErrorBoundary> | undefined;
+
+    try {
+      const { rerender } = render(
+        <ArtifactErrorBoundary
+          ref={(instance) => {
+            boundary = instance ?? undefined;
+          }}
+          index={0}
+          labels={labelsForLanguage('en')}
+          resetKey={firstResetKey}
+        >
+          <TestArtifact fail />
+        </ArtifactErrorBoundary>
+      );
+
+      await waitFor(() =>
+        expect(screen.getByRole('alert')).toHaveTextContent('Artifact 1 failed to render: Unknown error.')
+      );
+      rerender(
+        <ArtifactErrorBoundary
+          ref={(instance) => {
+            boundary = instance ?? undefined;
+          }}
+          index={0}
+          labels={labelsForLanguage('en')}
+          resetKey={firstResetKey}
+        >
+          <TestArtifact fail={false} />
+        </ArtifactErrorBoundary>
+      );
+      act(() => boundary?.setState({ error: '' }));
+      expect(screen.getByRole('alert')).toHaveTextContent('Artifact 1 failed to render:');
+
+      rerender(
+        <ArtifactErrorBoundary index={0} labels={labelsForLanguage('en')} resetKey={secondResetKey}>
+          <TestArtifact fail={false} />
+        </ArtifactErrorBoundary>
+      );
+      await waitFor(() => expect(screen.getByText('replacement artifact')).toBeVisible());
+      expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+});
+
 describe('MermaidDiagram', () => {
   it('falls back to the light Mermaid palette without a document', () => {
     vi.stubGlobal('document', undefined);
@@ -886,13 +947,21 @@ describe('MermaidDiagram', () => {
   });
 
   it('renders Mermaid errors from Error and non-Error values', async () => {
-    mocks.mermaidRender.mockRejectedValueOnce(new Error('bad diagram')).mockRejectedValueOnce('string diagram error');
+    mocks.mermaidRender
+      .mockRejectedValueOnce(new Error('bad diagram'))
+      .mockRejectedValueOnce('string diagram error')
+      .mockRejectedValueOnce(new Error());
 
     const { rerender } = render(<MermaidDiagram diagramId="bad" source="bad" />);
     await waitFor(() => expect(screen.getByRole('alert')).toHaveTextContent('bad diagram'));
 
     rerender(<MermaidDiagram diagramId="bad" source="still bad" />);
     await waitFor(() => expect(screen.getByRole('alert')).toHaveTextContent('string diagram error'));
+
+    rerender(<MermaidDiagram diagramId="bad" source="empty error" />);
+    await waitFor(() =>
+      expect(screen.getByRole('alert')).toHaveTextContent('Mermaid diagram could not be rendered: Unknown error.')
+    );
   });
 
   it('ignores resolved or rejected Mermaid renders after unmount', async () => {
@@ -965,6 +1034,14 @@ describe('lazy chart renderer', () => {
     await Promise.resolve();
 
     expect(screen.queryByTestId('doc-plot')).not.toBeInTheDocument();
+  });
+
+  it('normalizes an unstringifiable chart import failure', async () => {
+    render(<LazyChartOutput spec={spec} load={() => Promise.reject(Object.create(null))} />);
+
+    await waitFor(() =>
+      expect(screen.getByRole('alert')).toHaveTextContent('Chart renderer could not be loaded: Unknown error.')
+    );
   });
 
   it('retries a transient chart-module load failure', async () => {
@@ -1517,7 +1594,10 @@ describe('TableOutput', () => {
   });
 
   it('surfaces clipboard and CSV conversion failures', async () => {
-    const writeText = vi.fn().mockRejectedValue(new Error('permission denied'));
+    const writeText = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('permission denied'))
+      .mockRejectedValueOnce(Object.create(null));
     Object.defineProperty(globalThis.navigator, 'clipboard', {
       configurable: true,
       value: { writeText }
@@ -1534,6 +1614,9 @@ describe('TableOutput', () => {
 
     fireEvent.click(screen.getByTestId('table-copy-csv'));
     await waitFor(() => expect(screen.getByRole('alert')).toHaveTextContent('permission denied'));
+
+    fireEvent.click(screen.getByTestId('table-copy-csv'));
+    await waitFor(() => expect(screen.getByRole('alert')).toHaveTextContent('Unable to copy CSV: Unknown error.'));
 
     rerender(
       <TableOutput

--- a/tests/unit/doc-runtime-service.test.mjs
+++ b/tests/unit/doc-runtime-service.test.mjs
@@ -229,6 +229,42 @@ const runtimeSyncOptions = Object.freeze({
   runtimeInputs
 });
 
+function createRustRuntimeHarness(helperFiles) {
+  const paths = createDocRuntimePaths('/repo');
+  const fileSystem = createMemoryFileSystem({
+    '/repo/content/docs/index.mdx': '```rust\n//| id: rust\n//| crates: []\nprintln!("ok");\n```',
+    ...helperFiles
+  });
+  const buildRust = vi.fn(async ({ paths: runtimePaths }) => {
+    await Promise.all([
+      fileSystem.writeFile(path.join(runtimePaths.rustWasmPublicDir, 'doc_rust_cells.js'), 'generated js'),
+      fileSystem.writeFile(path.join(runtimePaths.rustWasmPublicDir, 'doc_rust_cells_bg.wasm'), 'generated wasm')
+    ]);
+  });
+  const syncRustSupport = async ({ fileSystem: runtimeFileSystem, paths: runtimePaths }) => {
+    await Promise.all(
+      ['Cargo.lock', 'LICENSE-MIT', 'LICENSE-APACHE'].map((fileName) =>
+        runtimeFileSystem.writeFile(path.join(runtimePaths.rustCellsDir, fileName), fileName)
+      )
+    );
+  };
+  const options = {
+    ...runtimeSyncOptions,
+    buildHaskell: vi.fn(),
+    buildRust,
+    fileSystem,
+    helperCrates: new Map(),
+    highlighter,
+    mode: 'build',
+    paths,
+    syncLicenses: async () => false,
+    syncPyodide: vi.fn(),
+    syncRustSupport
+  };
+
+  return { buildRust, fileSystem, paths, sync: () => syncDocRuntime(options) };
+}
+
 function pyodidePackage(name, fileName, content, depends = []) {
   return {
     depends,
@@ -942,6 +978,90 @@ describe('doc runtime service', () => {
       rustChanged: false
     });
     expect(fileSystem.writes).toEqual([]);
+  });
+
+  it('rebuilds Rust when authored text and extensionless helper inputs change', async () => {
+    const { buildRust, fileSystem, sync } = createRustRuntimeHarness({
+      '/repo/crates/Cargo.lock': 'lock one',
+      '/repo/crates/doc-rust/build.rs': 'fn main() {}',
+      '/repo/crates/doc-rust/help': 'help one'
+    });
+
+    await sync();
+    expect(buildRust).toHaveBeenCalledTimes(1);
+    await expect(sync()).resolves.toMatchObject({ plan: { languages: { rust: { public: 'keep' } } } });
+
+    await fileSystem.writeFile('/repo/crates/doc-rust/help', 'help two');
+    await expect(sync()).resolves.toMatchObject({ plan: { languages: { rust: { public: 'build' } } } });
+
+    await fileSystem.writeFile('/repo/crates/doc-rust/template.html', '<p>template</p>');
+    await expect(sync()).resolves.toMatchObject({ plan: { languages: { rust: { public: 'build' } } } });
+
+    await fileSystem.rm('/repo/crates/doc-rust/help');
+    await expect(sync()).resolves.toMatchObject({ plan: { languages: { rust: { public: 'build' } } } });
+
+    await fileSystem.writeFile('/repo/crates/Cargo.lock', 'lock two');
+    await expect(sync()).resolves.toMatchObject({ plan: { languages: { rust: { public: 'build' } } } });
+
+    await fileSystem.writeFile('/repo/crates/doc-rust/build.rs', 'fn main() { println!("changed"); }');
+    await expect(sync()).resolves.toMatchObject({ plan: { languages: { rust: { public: 'build' } } } });
+    expect(buildRust).toHaveBeenCalledTimes(6);
+  });
+
+  it('fingerprints binary helper inputs byte-for-byte', async () => {
+    const { buildRust, fileSystem, sync } = createRustRuntimeHarness({
+      '/repo/crates/doc-rust/logo.bin': Buffer.from([0x80])
+    });
+
+    await sync();
+    await fileSystem.writeFile('/repo/crates/doc-rust/logo.bin', Buffer.from([0x81]));
+    await expect(sync()).resolves.toMatchObject({ plan: { languages: { rust: { public: 'build' } } } });
+    expect(buildRust).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps helper fingerprints stable across directory entry order', async () => {
+    const { buildRust, fileSystem, sync } = createRustRuntimeHarness({
+      '/repo/crates/doc-rust/alpha.txt': 'alpha',
+      '/repo/crates/doc-rust/nested/beta.bin': Buffer.from([0, 1, 2])
+    });
+    const readdir = fileSystem.readdir;
+    let reverseHelperEntries = false;
+    fileSystem.readdir = async (directory, options) => {
+      const entries = await readdir(directory, options);
+      return reverseHelperEntries && memoryPath(directory).startsWith('/repo/crates') ? entries.reverse() : entries;
+    };
+
+    await sync();
+    reverseHelperEntries = true;
+    await expect(sync()).resolves.toMatchObject({ plan: { languages: { rust: { public: 'keep' } } } });
+    expect(buildRust).toHaveBeenCalledOnce();
+  });
+
+  it('ignores Cargo output and nested VCS metadata in helper fingerprints', async () => {
+    const ignoredFiles = {
+      '/repo/crates/doc-rust/target/debug/generated.rs': 'generated one',
+      '/repo/crates/doc-rust/target/debug/build.toml': 'generated one',
+      '/repo/crates/doc-rust/target/debug/logo.bin': Buffer.from([1]),
+      '/repo/crates/doc-rust/nested/.git/config': 'git one',
+      '/repo/crates/doc-rust/nested/.hg/store': 'hg one',
+      '/repo/crates/doc-rust/nested/.svn/entries': 'svn one'
+    };
+    const { buildRust, fileSystem, sync } = createRustRuntimeHarness({
+      '/repo/crates/doc-rust/src/lib.rs': 'pub fn helper() {}',
+      ...ignoredFiles
+    });
+
+    await sync();
+    for (const [filePath, content] of Object.entries(ignoredFiles)) {
+      const changed = Buffer.isBuffer(content) ? Buffer.from([2]) : `${content} changed`;
+      await fileSystem.writeFile(filePath, changed);
+    }
+    await expect(sync()).resolves.toMatchObject({ plan: { languages: { rust: { public: 'keep' } } } });
+    expect(buildRust).toHaveBeenCalledOnce();
+
+    await fileSystem.writeFile('/repo/crates/doc-rust/src/lib.rs', 'pub fn helper() { println!("changed"); }');
+    await expect(sync()).resolves.toMatchObject({ plan: { languages: { rust: { public: 'build' } } } });
+    expect(buildRust).toHaveBeenCalledTimes(2);
   });
 
   it('keeps a zero-cell project free of language runtimes and tool invocations', async () => {

--- a/tests/unit/doc-runtime-watch-core.test.mjs
+++ b/tests/unit/doc-runtime-watch-core.test.mjs
@@ -1,3 +1,4 @@
+import path from 'node:path';
 import { describe, expect, it } from 'vitest';
 import { createOxiquillPaths } from '../../packages/oxiquill/src/config/paths.mjs';
 import {
@@ -5,6 +6,8 @@ import {
   createRuntimeWatchPaths,
   createSerialTaskQueue,
   describeChangeKinds,
+  isExcludedCratePath,
+  isRuntimeWatchFileEvent,
   mergeChangeKinds,
   shouldSyncRuntime,
   toRelativePath,
@@ -15,11 +18,30 @@ describe('doc runtime watch core', () => {
   it('classifies paths that affect runtime generation', () => {
     expect(classifyChangedPath('content/docs/index.mdx')).toBe('docs');
     expect(classifyChangedPath('content/docs/page.md')).toBe('docs');
+    expect(classifyChangedPath('content/docs/data.json')).toBe('other');
     expect(classifyChangedPath('crates/doc-rust/src/lib.rs')).toBe('crate');
     expect(classifyChangedPath('crates/doc-rust/Cargo.toml')).toBe('crate');
     expect(classifyChangedPath('crates/Cargo.toml')).toBe('crate');
+    expect(classifyChangedPath('crates/Cargo.lock')).toBe('crate');
+    expect(classifyChangedPath('crates/doc-rust/build.rs')).toBe('crate');
+    expect(classifyChangedPath('crates/doc-rust/help')).toBe('crate');
+    expect(classifyChangedPath('crates/doc-rust/logo.bin')).toBe('crate');
+    expect(classifyChangedPath('crates/doc-rust/target/debug/generated.rs')).toBe('other');
+    expect(classifyChangedPath('crates/doc-rust/target/debug/build.toml')).toBe('other');
+    expect(classifyChangedPath('crates/doc-rust/target/debug/logo.bin')).toBe('other');
+    expect(classifyChangedPath('crates/doc-rust/nested/.git/config')).toBe('other');
+    expect(classifyChangedPath('crates/doc-rust/nested/.hg/store')).toBe('other');
+    expect(classifyChangedPath('crates/doc-rust/nested/.svn/entries')).toBe('other');
     expect(classifyChangedPath('Cargo.toml')).toBe('other');
     expect(classifyChangedPath('src/styles/custom.css')).toBe('other');
+  });
+
+  it('accepts only file change events from the runtime watcher', () => {
+    expect(isRuntimeWatchFileEvent('add')).toBe(true);
+    expect(isRuntimeWatchFileEvent('change')).toBe(true);
+    expect(isRuntimeWatchFileEvent('unlink')).toBe(true);
+    expect(isRuntimeWatchFileEvent('addDir')).toBe(false);
+    expect(isRuntimeWatchFileEvent('unlinkDir')).toBe(false);
   });
 
   it('merges, describes, and filters change kinds', () => {
@@ -53,8 +75,26 @@ describe('doc runtime watch core', () => {
 
     expect(createRuntimeWatchPaths(paths)).toEqual([paths.docsDir, paths.cratesDir]);
     expect(classifyChangedPath('written docs/guide.mdx', paths)).toBe('docs');
-    expect(classifyChangedPath('helper crates/example/src/lib.rs', paths)).toBe('crate');
+    expect(classifyChangedPath('helper crates/example/assets/logo.bin', paths)).toBe('crate');
+    expect(classifyChangedPath('helper crates/example/target/generated.rs', paths)).toBe('other');
     expect(classifyChangedPath('content/docs/guide.mdx', paths)).toBe('other');
+  });
+
+  it('classifies absolute configured crate roots outside the workspace', () => {
+    const paths = createOxiquillPaths({
+      cratesDir: path.resolve('/shared/helper crates'),
+      workspaceRoot: path.resolve('/repo')
+    });
+    const assetPath = toWatchEventRelativePath(paths.workspaceRoot, path.join(paths.cratesDir, 'assets/logo.bin'));
+    const targetPath = toWatchEventRelativePath(
+      paths.workspaceRoot,
+      path.join(paths.cratesDir, 'example/target/debug/generated.rs')
+    );
+
+    expect(classifyChangedPath(assetPath, paths)).toBe('crate');
+    expect(classifyChangedPath(targetPath, paths)).toBe('other');
+    expect(isExcludedCratePath(assetPath, paths)).toBe(false);
+    expect(isExcludedCratePath(targetPath, paths)).toBe(true);
   });
 
   it('serializes tasks and coalesces pending enqueues', async () => {

--- a/tests/unit/haskell-worker.test.ts
+++ b/tests/unit/haskell-worker.test.ts
@@ -82,6 +82,16 @@ describe('haskell worker helpers', () => {
     });
     await failingHandler(request);
     expect(failureResponses).toEqual([{ requestId: 4, ok: false, error: 'runtime unavailable' }]);
+
+    const unstringifiableResponses: RuntimeWorkerResponse[] = [];
+    const unstringifiableHandler = createHaskellWorkerRequestHandler({
+      loadModule: async () => {
+        throw Object.create(null);
+      },
+      postMessage: (response) => unstringifiableResponses.push(response)
+    });
+    await unstringifiableHandler(request);
+    expect(unstringifiableResponses).toEqual([{ requestId: 4, ok: false, error: 'Unknown error.' }]);
   });
 
   it('caches modules by expected fingerprint and rejects stale status before loading wasm', async () => {

--- a/tests/unit/interactive-cell-scheduler.test.ts
+++ b/tests/unit/interactive-cell-scheduler.test.ts
@@ -3,6 +3,7 @@ import {
   createLatestRequestScheduler,
   createRunOnceCache
 } from '../../packages/oxiquill/src/lib/doc-runtime/interactive-cell-scheduler';
+import { isExecutionCancellation } from '../../packages/oxiquill/src/lib/doc-runtime/execution-cancellation';
 
 function createDeferred<Result>() {
   let reject!: (reason: Error) => void;
@@ -137,6 +138,13 @@ describe('interactive cell request scheduler', () => {
 
     scheduler.schedule('request');
     await vi.waitFor(() => expect(onCancelled).toHaveBeenCalledOnce());
+  });
+
+  it('treats an uninspectable thrown value as a regular failure', () => {
+    const revoked = Proxy.revocable({}, {});
+    revoked.revoke();
+
+    expect(isExecutionCancellation(revoked.proxy)).toBe(false);
   });
 
   it('shares successful and failed executions by key', async () => {

--- a/tests/unit/output-limits.test.ts
+++ b/tests/unit/output-limits.test.ts
@@ -34,6 +34,43 @@ describe('producer output limits', () => {
     expect(oversized.endsWith('…')).toBe(true);
   });
 
+  it('returns a stable bounded fallback for missing and unstringifiable errors', () => {
+    const errorWithThrowingMessage = new Error('hidden');
+    Object.defineProperty(errorWithThrowingMessage, 'message', {
+      get: () => {
+        throw new Error('message getter failed');
+      }
+    });
+    const revoked = Proxy.revocable({}, {});
+    revoked.revoke();
+
+    const missingMessages = [
+      new Error(),
+      new Error('   '),
+      '',
+      ' \n\t ',
+      Object.create(null),
+      {
+        toString: () => {
+          throw new Error('toString failed');
+        }
+      },
+      {
+        [Symbol.toPrimitive]: () => {
+          throw new Error('primitive conversion failed');
+        }
+      },
+      errorWithThrowingMessage,
+      revoked.proxy
+    ];
+
+    for (const value of missingMessages) {
+      const normalized = boundedErrorMessage(value);
+      expect(normalized).toBe('Unknown error.');
+      expect(utf8ByteLength(normalized)).toBeLessThanOrEqual(outputArtifactLimits.bytesPerError);
+    }
+  });
+
   it('normalizes aliases from bounded outputs and caps complete worker responses', () => {
     const rawAlias = 'x'.repeat(outputArtifactLimits.workerResponseBytes + 1);
     const boundedAlias = boundWorkerResult({

--- a/tests/unit/python-worker.test.ts
+++ b/tests/unit/python-worker.test.ts
@@ -328,6 +328,16 @@ describe('python worker request handling', () => {
     await evaluationHandler(pythonRequest({ packages: [] }));
     expect(globals.destroy).toHaveBeenCalledOnce();
     expect(evaluationResponses).toEqual([{ requestId: 7, ok: false, error: 'evaluation failed' }]);
+
+    const unstringifiableResponses: RuntimeWorkerResponse[] = [];
+    const unstringifiableHandler = createPythonWorkerRequestHandler({
+      ensurePyodide: async () => {
+        throw Object.create(null);
+      },
+      postMessage: (response) => unstringifiableResponses.push(response)
+    });
+    await unstringifiableHandler(pythonRequest());
+    expect(unstringifiableResponses).toEqual([{ requestId: 7, ok: false, error: 'Unknown error.' }]);
   });
 });
 

--- a/tests/unit/runtime-client.test.ts
+++ b/tests/unit/runtime-client.test.ts
@@ -516,4 +516,19 @@ describe('runtime client', () => {
 
     await expect(runner.runInteractiveCell(makeCell('rust'), {})).rejects.toThrow('worker construction failed');
   });
+
+  it('normalizes uninspectable worker failures without escaping error handling', async () => {
+    const revoked = Proxy.revocable({}, {});
+    revoked.revoke();
+    const worker = new FakeWorker();
+    worker.postMessageFailure = revoked.proxy;
+    const runner = createInteractiveCellRunner({
+      clearTimeout,
+      createWorker: () => worker as unknown as Worker,
+      setTimeout
+    });
+
+    await expect(runner.runInteractiveCell(makeCell('rust'), {})).rejects.toThrow('Unknown error.');
+    expect(worker.terminated).toBe(true);
+  });
 });

--- a/tests/unit/rust-worker.test.ts
+++ b/tests/unit/rust-worker.test.ts
@@ -93,6 +93,20 @@ describe('Rust runtime worker', () => {
       expect(utf8ByteLength(response.error)).toBeLessThanOrEqual(outputArtifactLimits.bytesPerError);
     }
   });
+
+  it('posts one fallback response for an unstringifiable thrown value', async () => {
+    run_rust_cell.mockImplementationOnce(() => {
+      throw Object.create(null);
+    });
+
+    worker.listener?.({
+      data: { requestId: 6, cellId: 'unstringifiable-error', inputs: {} }
+    } as MessageEvent<RuntimeWorkerRequest>);
+    await flushMicrotasks();
+
+    expect(worker.postMessage).toHaveBeenCalledOnce();
+    expect(worker.postMessage).toHaveBeenCalledWith({ requestId: 6, ok: false, error: 'Unknown error.' });
+  });
 });
 
 describe('Rust runtime loader', () => {

--- a/tests/unit/watch-doc-runtime.test.mjs
+++ b/tests/unit/watch-doc-runtime.test.mjs
@@ -35,10 +35,14 @@ describe('runtime watcher entrypoint', () => {
       fields: ['cacheDir', 'publicAssetsDir'],
       paths
     });
-    expect(services.watch).toHaveBeenCalledWith(expect.arrayContaining([expect.any(String)]), {
-      cwd: workspaceRoot,
-      ignoreInitial: true
-    });
+    expect(services.watch).toHaveBeenCalledWith(
+      expect.arrayContaining([expect.any(String)]),
+      expect.objectContaining({
+        cwd: workspaceRoot,
+        ignored: expect.any(Function),
+        ignoreInitial: true
+      })
+    );
     expect(handlers.has('all')).toBe(true);
     expect(handlers.has('ready')).toBe(true);
     expect(services.createDocRuntimeContext).not.toHaveBeenCalled();
@@ -63,7 +67,7 @@ describe('runtime watcher entrypoint', () => {
       })
     );
     expect(warning).toHaveBeenCalledWith('[runtime] Haskell/WASI runtime unavailable: compiler failed');
-    expect(log).toHaveBeenCalledWith('[runtime] watching MDX, Rust, and Haskell cell sources');
+    expect(log).toHaveBeenCalledWith('[runtime] watching documentation and helper-crate inputs');
     expect(log).not.toHaveBeenCalledWith(expect.stringContaining('baseline ready'));
   });
 
@@ -130,6 +134,32 @@ describe('runtime watcher entrypoint', () => {
     );
     expect(log).toHaveBeenCalledWith('[runtime] rebuilt Rust/Wasm cells');
     expect(log).toHaveBeenCalledWith('[runtime] rebuilt Haskell/WASI cells');
+  });
+
+  it('rebuilds for helper data-file add, change, and unlink events while ignoring generated paths', async () => {
+    const { handlers, services } = createServices({
+      syncDocRuntime: vi.fn(async () => runtimeSummary({ rustPlan: 'build' }))
+    });
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    await main(['--skip-initial'], services);
+    const watchOptions = services.watch.mock.calls[0][1];
+    const assetPath = path.join(workspaceRoot, 'crates/doc-rust/assets/help.txt');
+    const targetPath = path.join(workspaceRoot, 'crates/doc-rust/target/debug/generated.rs');
+    expect(watchOptions.ignored(assetPath)).toBe(false);
+    expect(watchOptions.ignored(targetPath)).toBe(true);
+
+    for (const event of ['add', 'change', 'unlink']) {
+      const expectedCallCount = services.syncDocRuntime.mock.calls.length + 1;
+      handlers.get('all')(event, assetPath);
+      await waitForCallCount(services.syncDocRuntime, expectedCallCount);
+      expect(services.syncDocRuntime).toHaveBeenLastCalledWith(expect.objectContaining({ forceRustBuild: true }));
+    }
+
+    handlers.get('all')('addDir', path.dirname(assetPath));
+    handlers.get('all')('change', targetPath);
+    await flushMicrotasks();
+    expect(services.syncDocRuntime).toHaveBeenCalledTimes(3);
   });
 });
 


### PR DESCRIPTION
## Summary

- make runtime error normalization total for arbitrary thrown values and render empty diagnostics consistently
- apply the shared normalization path across interactive cells, rich-output components, runtime clients, and workers
- fingerprint every authored helper-crate input byte-for-byte while excluding Cargo output and VCS metadata
- make the runtime watcher rebuild on added, changed, or removed helper inputs regardless of file extension
- add regression coverage for hostile error values, binary helper inputs, deterministic ordering, and watcher behavior

## Validation

- `pnpm test`
- 556 unit tests passed, 1 skipped
- 70 end-to-end tests passed, 2 expected skips
- Rust, Wasm, Haskell, package, documentation, and npm/pnpm consumer checks passed

Closes #111
Closes #112