### PR TITLE
Fix runtime validation and generation boundaries

### DIFF
--- a/examples/docs-site/content/docs/features/interactive-cells.mdx
+++ b/examples/docs-site/content/docs/features/interactive-cells.mdx
@@ -64,7 +64,7 @@ Every input accepts only fields relevant to its type. Common fields are `type`, 
 
 | Type               | Value and constraints                                                                                  |
 | ------------------ | ------------------------------------------------------------------------------------------------------ |
-| `range`, `number`  | Finite number; `step > 0`, `min <= max`, and the default must be within bounds.                        |
+| `range`, `number`  | Finite number; `step > 0`, `min <= max`, and the default must be within bounds and on the step grid.   |
 | `integer`          | Signed 32-bit integer from `-2147483648` through `2147483647`; bounds and step use the same domain.    |
 | `text`, `textarea` | String value.                                                                                          |
 | `checkbox`         | Boolean value.                                                                                         |
@@ -73,6 +73,8 @@ Every input accepts only fields relevant to its type. Common fields are `type`, 
 `type` defaults to `text`, and `label` defaults to the input name. `description` is an optional non-empty string associated with the control for assistive technology. Default values are `false` for checkbox, `0` for numeric inputs, and an empty string for text inputs. Numeric-only fields are rejected on non-numeric controls, and `options` is rejected outside `select` and `radio`.
 
 The signed 32-bit integer domain is exactly representable by JavaScript and maps consistently to Rust `i32`, Haskell `Int`, and Python `int`. Authoring rejects an integer `value`, `min`, `max`, or `step` outside that domain. Browser controls apply the same domain before constructing a worker request, including for `integer: true` numeric inputs.
+
+Numeric defaults must align with the same step grid enforced by browser controls. The effective step is `step` when provided and `1` otherwise. The grid starts at `min` when provided; without `min`, the declared or default numeric `value` is the base. Oxiquill rejects a misaligned default during authoring instead of rounding or clamping it.
 
 Number and integer controls keep their raw edit text separate from committed runtime values. Empty, incomplete, non-finite, out-of-range, and step-mismatched text remains visible but cannot update cell inputs. The Run button is disabled while any control is invalid, and reactive execution resumes exactly once with the latest complete value set after validity returns. Range labels derive their displayed precision from `step`.
 

--- a/examples/docs-site/content/docs/features/interactive-cells.mdx
+++ b/examples/docs-site/content/docs/features/interactive-cells.mdx
@@ -21,7 +21,7 @@ Only these top-level fields are accepted; unknown fields are errors:
 | `inputs`     | Mapping from lowercase cross-language identifiers matching `^[a-z][a-z0-9_]*$` to input specs. Not allowed with `autorun`. | `{}`     |
 | `packages`   | Unique non-empty Pyodide package names; Python only.                                                                       | `[]`     |
 | `crates`     | Unique non-empty helper package names from direct children of `cratesDir`; Rust only.                                      | `[]`     |
-| `timeoutMs`  | Positive integer milliseconds.                                                                                             | `30000`  |
+| `timeoutMs`  | Integer milliseconds from `1` through `2147483647`, inclusive.                                                             | `30000`  |
 | `showSource` | Boolean controlling initial source visibility.                                                                             | `true`   |
 
 The source must contain non-metadata code. Malformed YAML, a wrong scalar/collection type, duplicate normalized ID/binding/function, unknown package/crate, or language-mismatched dependency field fails before output is written. Diagnostics include page path, fence start line, cell ID when available, and the exact field path.

--- a/examples/docs-site/content/docs/features/media.mdx
+++ b/examples/docs-site/content/docs/features/media.mdx
@@ -3,7 +3,7 @@ title: Media
 description: Embed PNG, JPEG, PDF, and similar static files in MDX notes.
 ---
 
-Use `public/media` for static files that should be served as-is. MDX pages can reference those files with `/media/...` URLs, so authors do not need imports for common images or PDFs.
+Use `public/media` for static files that should be served as-is. MDX pages can reference those files with root-relative `/media/...` URLs, so authors do not need imports for common images or PDFs. Always use that source form: do not include Astro's configured `base`, because Oxiquill adds it during the Markdown transform.
 
 ## Image Files
 
@@ -40,6 +40,6 @@ For PDFs, include both an embedded frame and a normal link. The frame lets reade
 ## Placement Rules
 
 - Put public files under `public/media`.
-- Reference them with absolute `/media/...` URLs.
+- Reference them with root-relative `/media/...` URLs; never add Astro's configured `base` manually.
 - Keep generated media out of the docs tree unless the file itself is the intended source asset.
 - Use stable sample files so tests and screenshots remain deterministic.

--- a/examples/docs-site/content/docs/guides/authoring.mdx
+++ b/examples/docs-site/content/docs/guides/authoring.mdx
@@ -141,7 +141,7 @@ Keep Mermaid source in repository-owned MDX. Do not pass untrusted external inpu
 
 ## Add Media
 
-Put unprocessed static files such as PNG, JPEG, and PDF files in `public/media`. Reference them from MDX with `/media/...` URLs.
+Put unprocessed static files such as PNG, JPEG, and PDF files in `public/media`. Reference them from MDX with root-relative `/media/...` URLs. Do not include Astro's configured `base`; Oxiquill adds it during the Markdown transform.
 
 ```md
 ![Sample image](/media/examples/sample.png)

--- a/examples/docs-site/content/docs/guides/authoring.mdx
+++ b/examples/docs-site/content/docs/guides/authoring.mdx
@@ -109,6 +109,8 @@ These are the only top-level fields. Dependency arrays must contain unique non-e
 
 Integer metadata uses one portable signed 32-bit domain: `-2147483648` through `2147483647`. This limit applies to `value`, `min`, `max`, and `step` so generated Rust, Haskell, and Python bindings receive the same exact integer.
 
+Numeric defaults must also align with the input's step grid. The effective step is the declared `step` or `1`; the base is `min` when present and otherwise the declared or default numeric `value`. Misaligned defaults fail authoring and are never rounded or clamped.
+
 ## Add Math
 
 Inline math uses `$...$`, and block math uses `$$...$$`.

--- a/examples/docs-site/content/docs/guides/authoring.mdx
+++ b/examples/docs-site/content/docs/guides/authoring.mdx
@@ -102,7 +102,7 @@ Common metadata fields:
 - `inputs`: mapping of lowercase cross-language identifiers to input definitions; forbidden for `autorun`.
 - `crates`: Rust helper crates; Rust only.
 - `packages`: Pyodide packages; Python only.
-- `timeoutMs`: positive integer timeout in milliseconds; defaults to `30000`.
+- `timeoutMs`: integer timeout from `1` through `2147483647` milliseconds, inclusive; defaults to `30000`.
 - `showSource`: boolean source visibility; defaults to `true`.
 
 These are the only top-level fields. Dependency arrays must contain unique non-empty strings. Supported input types are `range`, `number`, `integer`, `text`, `textarea`, `checkbox`, `select`, and `radio`. See [Interactive Cells](../../features/interactive-cells/) for the exact input fields, defaults, constraints, and option schema.

--- a/examples/docs-site/content/docs/guides/project-configuration.mdx
+++ b/examples/docs-site/content/docs/guides/project-configuration.mdx
@@ -131,7 +131,7 @@ Runtime fingerprints contain semantic build inputs rather than machine-local pat
 
 ## Base Paths and Public Assets
 
-Set Astro's `base` when publishing below a subpath. Oxiquill applies it to interactive-cell manifests, language runtimes, diagrams, and `/media/...` references. Keep authored public URLs root-relative; the Markdown transform adds the configured base exactly once.
+Set Astro's `base` when publishing below a subpath. Oxiquill applies it to interactive-cell manifests, language runtimes, diagrams, and `/media/...` references. Keep every authored public URL in root-relative `/media/...` form, even when `base` itself is `/media` or starts the same way. Do not add the configured base manually; the normal Markdown pass prefixes the authored URL.
 
 Generated runtime files belong under `.oxiquill` and `public/oxiquill`; the verified download cache belongs under `.cache/oxiquill/downloads/v1`; and the final static site belongs under Astro's `outDir` (normally `dist`). Generated directories and their ownership markers must not be edited directly. The download cache may be retained across builds and reconstructed outputs, but its files are verified before every use.
 

--- a/examples/docs-site/content/docs/guides/troubleshooting.mdx
+++ b/examples/docs-site/content/docs/guides/troubleshooting.mdx
@@ -53,7 +53,7 @@ Clean preflights all three targets before deleting any of them. A diagnostic for
 
 ## Worker Timeouts and Browser Failures
 
-A cell defaults to a 30,000 ms timeout unless `timeoutMs` specifies another positive integer. A timeout terminates the failed language worker, rejects requests owned by it, and creates a fresh worker for later runs. Reduce the workload or choose a justified larger timeout; do not use timeout as a security sandbox.
+A cell defaults to a 30,000 ms timeout. `timeoutMs` can select an integer from 1 through 2,147,483,647 ms, inclusive. A timeout terminates the failed language worker, rejects requests owned by it, and creates a fresh worker for later runs. Reduce the workload or choose a justified larger timeout; do not use timeout as a security sandbox.
 
 For browser failures, verify the site was rebuilt, the expected files exist below `public/oxiquill`, the deployment preserves `.wasm` and JavaScript assets, and the configured base path matches the deployed URL. Test in a supported current Chromium, Firefox, or WebKit browser.
 

--- a/examples/docs-site/content/docs/ja/features/interactive-cells.mdx
+++ b/examples/docs-site/content/docs/ja/features/interactive-cells.mdx
@@ -21,7 +21,7 @@ interactive fence は `rust`、`python`、`haskell`（Markdown の `{.rust}` for
 | `inputs`     | `^[a-z][a-z0-9_]*$` に一致する lowercase cross-language identifier から input spec への mapping。`autorun` では禁止。 | `{}`     |
 | `packages`   | unique non-empty Pyodide package name。Python 専用。                                                                  | `[]`     |
 | `crates`     | `cratesDir` 直下の helper package name の unique non-empty list。Rust 専用。                                          | `[]`     |
-| `timeoutMs`  | positive integer millisecond。                                                                                        | `30000`  |
+| `timeoutMs`  | `1` 以上 `2147483647` 以下の integer millisecond。                                                                    | `30000`  |
 | `showSource` | initial source visibility を指定する boolean。                                                                        | `true`   |
 
 source には metadata 以外の code が必要です。malformed YAML、wrong scalar/collection type、duplicate normalized ID/binding/function、unknown package/crate、language-mismatched dependency field は output を書く前に失敗します。diagnostic は page path、fence start line、可能なら cell ID、正確な field path を含みます。

--- a/examples/docs-site/content/docs/ja/features/interactive-cells.mdx
+++ b/examples/docs-site/content/docs/ja/features/interactive-cells.mdx
@@ -64,7 +64,7 @@ reactive run が supersede されると、その worker request を active に c
 
 | Type               | Value と constraint                                                                               |
 | ------------------ | ------------------------------------------------------------------------------------------------- |
-| `range`, `number`  | finite number。`step > 0`、`min <= max`、default が bound 内。                                    |
+| `range`, `number`  | finite number。`step > 0`、`min <= max`、default が bound 内かつ step grid 上。                   |
 | `integer`          | `-2147483648` 以上 `2147483647` 以下の signed 32-bit integer。bound/step も同じ domain。          |
 | `text`, `textarea` | string value。                                                                                    |
 | `checkbox`         | boolean value。                                                                                   |
@@ -73,6 +73,8 @@ reactive run が supersede されると、その worker request を active に c
 `type` の default は `text`、`label` の default は input name です。`description` は control と assistive technology 向けに関連付ける optional non-empty string です。default value は checkbox が `false`、numeric input が `0`、text input が空 string です。numeric 専用 field は non-numeric control で拒否され、`options` は `select`/`radio` 以外では使えません。
 
 signed 32-bit integer domain は JavaScript で正確に表現でき、Rust `i32`、Haskell `Int`、Python `int` に同じ値として渡されます。domain 外の integer `value`、`min`、`max`、`step` は authoring 時に拒否されます。browser control と worker request も、`integer: true` の numeric input を含めて同じ domain を適用します。
+
+numeric default は browser control と同じ step grid に揃える必要があります。effective step は `step` があればその値、なければ `1` です。grid の base は `min` があればその値、なければ明示または default の numeric `value` です。Oxiquill は不一致の default を丸めたり clamp したりせず、authoring 時に拒否します。
 
 number/integer control は raw edit text と committed runtime value を分離します。空、入力途中、non-finite、range 外、step 不一致の text は表示を保ちますが cell input を更新しません。どれか一つでも invalid なら Run button は disabled になり、reactive execution は validity が戻った後に最新の complete value set を一度だけ実行します。range label の表示精度は `step` から決まります。
 

--- a/examples/docs-site/content/docs/ja/features/media.mdx
+++ b/examples/docs-site/content/docs/ja/features/media.mdx
@@ -3,7 +3,7 @@ title: メディア
 description: PNG、JPEG、PDF などの静的 file を MDX ノートに埋め込みます。
 ---
 
-そのまま配信したい静的 file は `public/media` に置きます。MDX ページからは `/media/...` URL で参照できるため、一般的な画像や PDF に import は不要です。
+そのまま配信したい静的 file は `public/media` に置きます。MDX ページからは root-relative の `/media/...` URL で参照できるため、一般的な画像や PDF に import は不要です。source では常にこの形式を使い、Astro の configured `base` を含めないでください。Oxiquill が Markdown transform 中に追加します。
 
 ## 画像 file
 
@@ -40,6 +40,6 @@ PDF には embedded frame と通常 link の両方を置きます。frame でペ
 ## 配置 rule
 
 - public file は `public/media` に置きます。
-- `/media/...` の absolute URL で参照します。
+- root-relative の `/media/...` URL で参照し、Astro の configured `base` は手動で追加しません。
 - file 自体が source asset でない限り、生成 media を docs tree に置かないでください。
 - test や screenshot が安定するよう、sample file は stable にします。

--- a/examples/docs-site/content/docs/ja/guides/authoring.mdx
+++ b/examples/docs-site/content/docs/ja/guides/authoring.mdx
@@ -109,6 +109,8 @@ top-level ではこれらの field だけを指定できます。dependency arra
 
 integer metadata の portable domain は `-2147483648` 以上 `2147483647` 以下の signed 32-bit です。この制限は `value`、`min`、`max`、`step` に適用され、generated Rust/Haskell/Python binding に同じ正確な integer を渡します。
 
+numeric default は input の step grid にも揃える必要があります。effective step は明示した `step`、または `1` です。base は `min` があればその値、なければ明示または default の numeric `value` です。不一致の default は丸めたり clamp したりせず、authoring 時に拒否されます。
+
 ## 数式を追加する
 
 inline math は `$...$`、block math は `$$...$$` で書きます。

--- a/examples/docs-site/content/docs/ja/guides/authoring.mdx
+++ b/examples/docs-site/content/docs/ja/guides/authoring.mdx
@@ -141,7 +141,7 @@ Mermaid source は repository-owned MDX に置きます。信頼できない外�
 
 ## メディアを追加する
 
-PNG、JPEG、PDF など処理せずに配信したい静的 file は `public/media` に置きます。MDX からは `/media/...` URL で参照します。
+PNG、JPEG、PDF など処理せずに配信したい静的 file は `public/media` に置きます。MDX からは root-relative の `/media/...` URL で参照します。Astro の configured `base` は含めず、Oxiquill の Markdown transform に追加させます。
 
 ```md
 ![Sample image](/media/examples/sample.png)

--- a/examples/docs-site/content/docs/ja/guides/authoring.mdx
+++ b/examples/docs-site/content/docs/ja/guides/authoring.mdx
@@ -102,7 +102,7 @@ standard library module だけを使います。Haskell セルでは外部 packa
 - `inputs`: lowercase cross-language identifier から input definition への mapping。`autorun` では指定できません。
 - `crates`: Rust helper crate。Rust のみ。
 - `packages`: Pyodide package。Python のみ。
-- `timeoutMs`: 正の integer で指定する millisecond timeout。default は `30000`。
+- `timeoutMs`: `1` 以上 `2147483647` 以下の integer で指定する millisecond timeout。default は `30000`。
 - `showSource`: source の初期表示を決める boolean。default は `true`。
 
 top-level ではこれらの field だけを指定できます。dependency array は重複のない空でない string で構成します。対応 input type は `range`、`number`、`integer`、`text`、`textarea`、`checkbox`、`select`、`radio` です。input field、default、constraint、option schema の正確な仕様は[実行可能セル](../../features/interactive-cells/)を参照してください。

--- a/examples/docs-site/content/docs/ja/guides/project-configuration.mdx
+++ b/examples/docs-site/content/docs/ja/guides/project-configuration.mdx
@@ -131,7 +131,7 @@ runtime fingerprint には machine-local path ではなく semantic build input 
 
 ## Base path と public asset
 
-subpath 配下へ公開するときは Astro の `base` を設定します。Oxiquill は interactive-cell manifest、language runtime、diagram、`/media/...` reference に適用します。authoring では public URL を root-relative のまま記述し、Markdown transform が base を一度だけ追加します。
+subpath 配下へ公開するときは Astro の `base` を設定します。Oxiquill は interactive-cell manifest、language runtime、diagram、`/media/...` reference に適用します。`base` 自体が `/media` または同じ prefix で始まる場合も、authoring ではすべての public URL を root-relative の `/media/...` 形式で記述します。configured base は手動で追加せず、通常の Markdown pass に authored URL を prefix させます。
 
 生成 runtime は `.oxiquill` と `public/oxiquill`、verified download cache は `.cache/oxiquill/downloads/v1`、最終 static site は Astro の `outDir`（通常 `dist`）に置かれます。生成 directory と ownership marker を直接編集しないでください。download cache は build や output 再生成をまたいで保持できますが、file は利用前に毎回検証されます。
 

--- a/examples/docs-site/content/docs/ja/guides/troubleshooting.mdx
+++ b/examples/docs-site/content/docs/ja/guides/troubleshooting.mdx
@@ -53,7 +53,7 @@ clean は削除前に3つの target をすべて preflight します。そのた
 
 ## Worker timeout と browser failure
 
-cell timeout の default は 30,000 ms で、`timeoutMs` には別の positive integer を指定できます。timeout 時は failed language worker を終了し、その worker が持つ request を reject して、次回用に fresh worker を作ります。workload を減らすか妥当な長い timeout を選び、security sandbox として使わないでください。
+cell timeout の default は 30,000 ms です。`timeoutMs` には 1 以上 2,147,483,647 以下の integer millisecond を指定できます。timeout 時は failed language worker を終了し、その worker が持つ request を reject して、次回用に fresh worker を作ります。workload を減らすか妥当な長い timeout を選び、security sandbox として使わないでください。
 
 browser failure では site rebuild、`public/oxiquill` 下の expected file、deployment が `.wasm`/JavaScript asset を保持すること、configured base path と deploy URL の一致を確認します。supported current Chromium、Firefox、WebKit で test してください。
 

--- a/packages/oxiquill/src/generator/doc-runtime/rust-codegen/cargo.mjs
+++ b/packages/oxiquill/src/generator/doc-runtime/rust-codegen/cargo.mjs
@@ -42,5 +42,5 @@ export function generateRustDependency(crateName, helperCrates) {
     throw new Error(`Cannot generate dependency for unknown Rust crate "${crateName}".`);
   }
 
-  return `${crateName} = { path = ${JSON.stringify(crateInfo.relativePath)} }`;
+  return `${JSON.stringify(crateName)} = { path = ${JSON.stringify(crateInfo.relativePath)} }`;
 }

--- a/packages/oxiquill/src/lib/doc-runtime/cell-authoring.mjs
+++ b/packages/oxiquill/src/lib/doc-runtime/cell-authoring.mjs
@@ -1,5 +1,6 @@
 import YAML from 'yaml';
 import { scopedCellId } from './authoring-ids.mjs';
+import { numericStepGrid } from './numeric-step.mjs';
 import { isPortableInteger, PORTABLE_INTEGER_MAX, PORTABLE_INTEGER_MIN } from './portable-integer.mjs';
 
 export const inputTypes = ['range', 'number', 'integer', 'text', 'textarea', 'checkbox', 'select', 'radio'];
@@ -329,7 +330,13 @@ function normalizeInput(name, value, context, diagnostics) {
   const step = normalizeInputNumber(value, 'step', type, inputPath, context, diagnostics);
   const options = normalizeOptions(value, type, inputPath, context, diagnostics);
 
-  validateNumericConstraints({ integer, max, min, step, type, value: inputValue }, inputPath, context, diagnostics);
+  validateNumericConstraints(
+    { integer, max, min, step, type, value: inputValue },
+    value,
+    inputPath,
+    context,
+    diagnostics
+  );
   validateOptionDefault(type, inputValue, options, inputPath, context, diagnostics);
 
   return {
@@ -462,20 +469,32 @@ function normalizeNonEmptyOptionString(value, fieldPath, context, diagnostics) {
   return undefined;
 }
 
-function validateNumericConstraints(input, inputPath, context, diagnostics) {
+function validateNumericConstraints(input, metadata, inputPath, context, diagnostics) {
   if (!isNumericInput(input.type)) return;
-  if (input.step !== undefined && input.step <= 0) {
+  const hasValidFields = ['value', 'min', 'max', 'step'].every(
+    (field) => !hasOwn(metadata, field) || (typeof metadata[field] === 'number' && Number.isFinite(metadata[field]))
+  );
+  const hasValidIntegerFlag = !hasOwn(metadata, 'integer') || typeof metadata.integer === 'boolean';
+  const hasValidStep = input.step === undefined || input.step > 0;
+  const hasOrderedBounds = input.min === undefined || input.max === undefined || input.min <= input.max;
+  const isWithinMinimum = input.min === undefined || input.value >= input.min;
+  const isWithinMaximum = input.max === undefined || input.value <= input.max;
+  const integerFieldsArePortable =
+    !input.integer ||
+    ['value', 'min', 'max', 'step'].every((field) => input[field] === undefined || isPortableInteger(input[field]));
+
+  if (!hasValidStep) {
     diagnostics.push(diagnostic(context, `${inputPath}.step`, 'Expected a number greater than zero.'));
   }
-  if (input.min !== undefined && input.max !== undefined && input.min > input.max) {
+  if (!hasOrderedBounds) {
     diagnostics.push(diagnostic(context, `${inputPath}.min`, 'Expected min to be less than or equal to max.'));
   }
-  if (input.min !== undefined && input.value < input.min) {
+  if (!isWithinMinimum) {
     diagnostics.push(
       diagnostic(context, `${inputPath}.value`, 'Expected the default value to be greater than or equal to min.')
     );
   }
-  if (input.max !== undefined && input.value > input.max) {
+  if (!isWithinMaximum) {
     diagnostics.push(
       diagnostic(context, `${inputPath}.value`, 'Expected the default value to be less than or equal to max.')
     );
@@ -491,6 +510,26 @@ function validateNumericConstraints(input, inputPath, context, diagnostics) {
           )
         );
       }
+    }
+  }
+  if (
+    hasValidFields &&
+    hasValidIntegerFlag &&
+    hasValidStep &&
+    hasOrderedBounds &&
+    isWithinMinimum &&
+    isWithinMaximum &&
+    integerFieldsArePortable
+  ) {
+    const grid = numericStepGrid(input, input.value);
+    if (grid.stepMismatch) {
+      diagnostics.push(
+        diagnostic(
+          context,
+          `${inputPath}.value`,
+          `Expected the default value to align with effective step ${JSON.stringify(grid.effectiveStep)} from base ${JSON.stringify(grid.base)}.`
+        )
+      );
     }
   }
 }

--- a/packages/oxiquill/src/lib/doc-runtime/cell-authoring.mjs
+++ b/packages/oxiquill/src/lib/doc-runtime/cell-authoring.mjs
@@ -35,6 +35,7 @@ const optionFields = new Set(['label', 'value']);
 const localIdPattern = /^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$/u;
 const inputNamePattern = /^[a-z][a-z0-9_]*$/u;
 const anyOptionPattern = /^\s*(?:\/\/\/?\||#\||--\|)/u;
+const MAX_CELL_TIMEOUT_MS = 2_147_483_647;
 const optionPatterns = {
   haskell: /^\s*--\|\s?(.*)$/u,
   python: /^\s*#\|\s?(.*)$/u,
@@ -263,8 +264,12 @@ function normalizeRunMode(metadata, context, diagnostics) {
 function normalizeTimeout(metadata, context, diagnostics) {
   if (!hasOwn(metadata, 'timeoutMs')) return 30_000;
   const value = metadata.timeoutMs;
-  if (typeof value === 'number' && Number.isFinite(value) && Number.isInteger(value) && value > 0) return value;
-  diagnostics.push(diagnostic(context, 'timeoutMs', 'Expected a positive finite integer.'));
+  if (typeof value === 'number' && Number.isSafeInteger(value) && value >= 1 && value <= MAX_CELL_TIMEOUT_MS) {
+    return value;
+  }
+  diagnostics.push(
+    diagnostic(context, 'timeoutMs', `Expected an integer from 1 through ${MAX_CELL_TIMEOUT_MS} milliseconds.`)
+  );
   return 30_000;
 }
 

--- a/packages/oxiquill/src/lib/doc-runtime/interactive-input-validation.ts
+++ b/packages/oxiquill/src/lib/doc-runtime/interactive-input-validation.ts
@@ -1,4 +1,5 @@
 import type { CellManifest, InputSpec, InputValues } from './types.js';
+import { effectiveNumericStep, numericStepGrid } from './numeric-step.mjs';
 import { isPortableInteger, PORTABLE_INTEGER_MAX, PORTABLE_INTEGER_MIN } from './portable-integer.mjs';
 
 export type NumericInputValidation =
@@ -22,7 +23,7 @@ export function validateNumericInputValue(input: InputSpec, value: unknown): Num
   const maximum = effectiveMaximum(input);
   if (minimum !== undefined && value < minimum) return 'rangeUnderflow';
   if (maximum !== undefined && value > maximum) return 'rangeOverflow';
-  if (hasStepMismatch(input, value)) return 'stepMismatch';
+  if (numericStepGrid(input, value).stepMismatch) return 'stepMismatch';
   return undefined;
 }
 
@@ -65,7 +66,7 @@ export function effectiveMaximum(input: InputSpec): number | undefined {
 }
 
 export function effectiveStep(input: InputSpec): number {
-  return input.step ?? 1;
+  return effectiveNumericStep(input);
 }
 
 export function stepNumericInputValue(input: InputSpec, value: number, direction: -1 | 1): number {
@@ -83,14 +84,6 @@ export function isIntegerInput(input: InputSpec): boolean {
 
 export function isNumericInput(input: InputSpec): boolean {
   return input.type === 'range' || input.type === 'number' || input.type === 'integer';
-}
-
-function hasStepMismatch(input: InputSpec, value: number): boolean {
-  const step = effectiveStep(input);
-  const base = input.min ?? (typeof input.value === 'number' ? input.value : 0);
-  const steps = (value - base) / step;
-  const tolerance = Number.EPSILON * Math.max(1, Math.abs(steps)) * 8;
-  return Math.abs(steps - Math.round(steps)) > tolerance;
 }
 
 function decimalPlaces(value: number): number {

--- a/packages/oxiquill/src/lib/doc-runtime/numeric-step.mjs
+++ b/packages/oxiquill/src/lib/doc-runtime/numeric-step.mjs
@@ -1,0 +1,29 @@
+/**
+ * @typedef {{ min?: number, step?: number, value?: unknown }} NumericStepInput
+ */
+
+/**
+ * @param {NumericStepInput} input
+ * @returns {number}
+ */
+export function effectiveNumericStep(input) {
+  return input.step ?? 1;
+}
+
+/**
+ * @param {NumericStepInput} input
+ * @param {number} value
+ * @returns {{ base: number, effectiveStep: number, stepMismatch: boolean }}
+ */
+export function numericStepGrid(input, value) {
+  const effectiveStep = effectiveNumericStep(input);
+  const base = input.min ?? (typeof input.value === 'number' ? input.value : 0);
+  const steps = (value - base) / effectiveStep;
+  const tolerance = Number.EPSILON * Math.max(1, Math.abs(steps)) * 8;
+
+  return {
+    base,
+    effectiveStep,
+    stepMismatch: Math.abs(steps - Math.round(steps)) > tolerance
+  };
+}

--- a/packages/oxiquill/src/lib/doc-runtime/remark-public-asset-base.mjs
+++ b/packages/oxiquill/src/lib/doc-runtime/remark-public-asset-base.mjs
@@ -26,12 +26,13 @@ export default function remarkPublicAssetBase({ base = '' } = {}) {
 }
 
 export function withPublicAssetBase(url, base) {
-  if (!shouldPrefixPublicAsset(url, base)) return url;
-  return `${base}${url}`;
+  const normalizedBase = normalizeBase(base);
+  if (!normalizedBase || !shouldPrefixPublicAsset(url)) return url;
+  return `${normalizedBase}${url}`;
 }
 
-function shouldPrefixPublicAsset(url, base) {
-  return publicAssetPrefixes.some((prefix) => url.startsWith(prefix)) && !url.startsWith(`${base}/`);
+function shouldPrefixPublicAsset(url) {
+  return publicAssetPrefixes.some((prefix) => url.startsWith(prefix));
 }
 
 function isUrlAttribute(attribute) {

--- a/tests/unit/astro-config.test.mjs
+++ b/tests/unit/astro-config.test.mjs
@@ -203,7 +203,7 @@ describe('defineOxiquillConfig', () => {
     const update = runConfigSetup(config);
     const renderer = await update.markdown.processor.createRenderer(update.markdown);
     const rendered = await renderer.render('![Sample](/media/examples/sample.png)\n\n[Guide](/media/docs/guide.pdf)', {
-      fileURL: new URL('file:///repo/content/docs/page.md')
+      fileURL: pathToFileURL(path.join(os.tmpdir(), 'oxiquill-render-fixture', 'content', 'docs', 'page.md'))
     });
 
     expect(rendered.code).toContain('src="/media/media/examples/sample.png"');

--- a/tests/unit/astro-config.test.mjs
+++ b/tests/unit/astro-config.test.mjs
@@ -198,6 +198,18 @@ describe('defineOxiquillConfig', () => {
     expect(update.markdown).not.toHaveProperty('rehypePlugins');
   });
 
+  it('renders overlapping public media bases through the configured Markdown processor', async () => {
+    const config = defineOxiquillConfig({ base: '/media', sidebar: [], title: 'Docs' });
+    const update = runConfigSetup(config);
+    const renderer = await update.markdown.processor.createRenderer(update.markdown);
+    const rendered = await renderer.render('![Sample](/media/examples/sample.png)\n\n[Guide](/media/docs/guide.pdf)', {
+      fileURL: new URL('file:///repo/content/docs/page.md')
+    });
+
+    expect(rendered.code).toContain('src="/media/media/examples/sample.png"');
+    expect(rendered.code).toContain('href="/media/media/docs/guide.pdf"');
+  });
+
   it.each([
     ['disabled highlighting', false],
     ['Prism highlighting', 'prism'],

--- a/tests/unit/doc-runtime-core.test.mjs
+++ b/tests/unit/doc-runtime-core.test.mjs
@@ -339,6 +339,41 @@ describe('doc runtime core', () => {
     );
   });
 
+  it.each([1, 2_147_483_647])('accepts the timeout boundary %s', (timeoutMs) => {
+    const source = ['```python', '#| id: timeout-boundary', `#| timeoutMs: ${timeoutMs}`, 'print("ok")', '```'].join(
+      '\n'
+    );
+    const parsed = parseCellsFromMarkdown(source, 'content/docs/page.mdx');
+
+    expect(parsed.diagnostics).toEqual([]);
+    expect(parsed.cells[0].timeoutMs).toBe(timeoutMs);
+  });
+
+  it.each(['0', '-1', '1.5', '.nan', '.inf', '-.inf', '2147483648', '9007199254740991', '9007199254740992'])(
+    'rejects timeoutMs %s outside the supported timer range',
+    (timeoutMs) => {
+      const source = ['```python', '#| id: invalid-timeout', `#| timeoutMs: ${timeoutMs}`, 'print("ok")', '```'].join(
+        '\n'
+      );
+      const parsed = parseCellsFromMarkdown(source, 'content/docs/page.mdx');
+
+      expect(parsed.cells).toEqual([]);
+      expect(parsed.diagnostics).toContainEqual(
+        expect.objectContaining({
+          fieldPath: 'timeoutMs',
+          message: 'Expected an integer from 1 through 2147483647 milliseconds.'
+        })
+      );
+    }
+  );
+
+  it('defaults timeoutMs to 30000 when the field is omitted', () => {
+    const parsed = parseCellsFromMarkdown('```python\n#| id: default-timeout\nprint("ok")\n```', 'page.mdx');
+
+    expect(parsed.diagnostics).toEqual([]);
+    expect(parsed.cells[0].timeoutMs).toBe(30_000);
+  });
+
   it.each([
     ['button', 'number'],
     ['reactive', 'number'],

--- a/tests/unit/doc-runtime-core.test.mjs
+++ b/tests/unit/doc-runtime-core.test.mjs
@@ -1,3 +1,5 @@
+import { createRequire } from 'node:module';
+import { resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import {
   pageIdFromPath,
@@ -37,6 +39,9 @@ import {
   splitHaskellCellSource,
   splitCellSource
 } from '../../packages/oxiquill/src/generator/doc-runtime-core.mjs';
+
+const requireFromPackage = createRequire(resolve(process.cwd(), 'packages/oxiquill/package.json'));
+const { parse: parseToml } = requireFromPackage('smol-toml');
 
 const highlighter = {
   codeToHtml: (source, options) => Promise.resolve(`<pre data-lang="${options.lang}">${source}</pre>`)
@@ -561,6 +566,9 @@ describe('doc runtime core', () => {
     expect(packageNameFromCargoToml('[package]\nname = "doc-rust"\n', '/repo/crates/doc-rust/Cargo.toml')).toBe(
       'doc-rust'
     );
+    expect(packageNameFromCargoToml('[package]\nname = "補助-crate٢"\n', '/repo/crates/unicode/Cargo.toml')).toBe(
+      '補助-crate٢'
+    );
     expect(() => packageNameFromCargoToml('[dependencies]\nserde = "1"\n', '/repo/crates/bad/Cargo.toml')).toThrow(
       'missing a [package] table'
     );
@@ -573,6 +581,37 @@ describe('doc runtime core', () => {
         { rustCellsDir: '/repo/.oxiquill/rust-cells' }
       )
     ).toThrow('use duplicate package name');
+  });
+
+  it('quotes and parses every generated helper-crate dependency key in deterministic order', () => {
+    const crates = new Map([
+      ['ascii', { name: 'ascii', relativePath: '../../crates/ascii' }],
+      ['hyphen-crate', { name: 'hyphen-crate', relativePath: '../../crates/hyphen' }],
+      ['under_score', { name: 'under_score', relativePath: '../../crates/underscore' }],
+      ['補助-crate٢', { name: '補助-crate٢', relativePath: '../../crates/unicode' }]
+    ]);
+    const manifest = generateRustCargoToml(
+      [{ crates: ['補助-crate٢', 'under_score', 'hyphen-crate', 'ascii'] }],
+      crates,
+      runtimeInputs
+    );
+
+    const dependencyLines = [
+      '"ascii" = { path = "../../crates/ascii" }',
+      '"hyphen-crate" = { path = "../../crates/hyphen" }',
+      '"under_score" = { path = "../../crates/underscore" }',
+      '"補助-crate٢" = { path = "../../crates/unicode" }'
+    ];
+    const dependencyPositions = dependencyLines.map((line) => manifest.indexOf(line));
+    expect(dependencyPositions.every((position) => position >= 0)).toBe(true);
+    expect(dependencyPositions).toEqual([...dependencyPositions].sort((left, right) => left - right));
+    expect(generateRustDependency('補助-crate٢', crates)).toBe('"補助-crate٢" = { path = "../../crates/unicode" }');
+
+    const parsed = parseToml(manifest);
+    expect(parsed.dependencies.ascii.path).toBe('../../crates/ascii');
+    expect(parsed.dependencies['hyphen-crate'].path).toBe('../../crates/hyphen');
+    expect(parsed.dependencies.under_score.path).toBe('../../crates/underscore');
+    expect(parsed.dependencies['補助-crate٢'].path).toBe('../../crates/unicode');
   });
 
   it('generates manifest files and Rust support code', () => {
@@ -588,9 +627,9 @@ describe('doc runtime core', () => {
     );
     expect(generateRustCargoToml([], helperCrates, runtimeInputs)).toContain('serde_json = "=1.0.150"');
     expect(generateRustCargoToml([{ crates: ['doc-rust'] }], helperCrates, runtimeInputs)).toContain(
-      'doc-rust = { path = "../../crates/doc-rust" }'
+      '"doc-rust" = { path = "../../crates/doc-rust" }'
     );
-    expect(generateRustDependency('doc-rust', helperCrates)).toContain('doc-rust');
+    expect(generateRustDependency('doc-rust', helperCrates)).toBe('"doc-rust" = { path = "../../crates/doc-rust" }');
     expect(() => generateRustDependency('missing', helperCrates)).toThrow('unknown Rust crate');
 
     expect(rustIdentifier('1-bad id')).toBe('cell_1_bad_id');

--- a/tests/unit/doc-runtime-core.test.mjs
+++ b/tests/unit/doc-runtime-core.test.mjs
@@ -339,6 +339,51 @@ describe('doc runtime core', () => {
     );
   });
 
+  it.each([
+    ['button', 'number'],
+    ['reactive', 'number'],
+    ['button', 'range'],
+    ['button', 'integer']
+  ])('rejects a step-mismatched %s %s default before manifest generation', (run, type) => {
+    const source = [
+      '```python',
+      '#| id: mismatched-default',
+      `#| run: ${run}`,
+      '#| inputs:',
+      `#|   count: { type: ${type}, min: 0, step: 2, value: 1 }`,
+      'print(count)',
+      '```'
+    ].join('\n');
+    const parsed = parseCellsFromMarkdown(source, 'content/docs/page.mdx');
+
+    expect(parsed.cells).toEqual([]);
+    expect(parsed.diagnostics).toContainEqual(
+      expect.objectContaining({
+        fieldPath: 'inputs.count.value',
+        message: 'Expected the default value to align with effective step 2 from base 0.'
+      })
+    );
+  });
+
+  it('accepts numeric defaults aligned to integer, decimal, scientific, and implicit step grids', () => {
+    const source = [
+      '```python',
+      '#| id: aligned-defaults',
+      '#| inputs:',
+      '#|   integer: { type: integer, min: 0, step: 2, value: 4 }',
+      '#|   decimal: { type: range, min: 0.1, step: 0.1, value: 0.3 }',
+      '#|   scientific: { type: number, min: 1e-7, step: 1e-7, value: 3e-7 }',
+      '#|   implicit_step: { type: number, min: 0, value: 2 }',
+      '#|   default_base: { type: number, step: 2, value: 1 }',
+      'print(integer, decimal, scientific, implicit_step, default_base)',
+      '```'
+    ].join('\n');
+    const parsed = parseCellsFromMarkdown(source, 'content/docs/page.mdx');
+
+    expect(parsed.diagnostics).toEqual([]);
+    expect(parsed.cells).toHaveLength(1);
+  });
+
   it('normalizes strict input defaults and option mappings', () => {
     const source = [
       '```python',

--- a/tests/unit/interactive-cell-model.test.ts
+++ b/tests/unit/interactive-cell-model.test.ts
@@ -8,9 +8,11 @@ import {
   localeFromLanguage,
   parseNumericInput,
   stepNumericInputValue,
+  validateNumericInputValue,
   shouldShowInputControls,
   shouldShowRunButton
 } from '../../packages/oxiquill/src/lib/doc-runtime/interactive-cell-model';
+import { numericStepGrid } from '../../packages/oxiquill/src/lib/doc-runtime/numeric-step.mjs';
 import type { InputSpec } from '../../packages/oxiquill/src/lib/doc-runtime/types';
 
 const textInput: InputSpec = {
@@ -118,6 +120,26 @@ describe('interactive cell model', () => {
     expect(parseNumericInput(numberInput, '1.25')).toEqual({ valid: false, validation: 'stepMismatch' });
     expect(parseNumericInput(numberInput, '-1.5')).toEqual({ valid: true, value: -1.5 });
   });
+
+  it.each([
+    ['aligned integer', { value: 4, min: 0, step: 2 }, 4, 0, 2, undefined],
+    ['aligned decimal', { value: 0.3, min: 0.1, step: 0.1 }, 0.3, 0.1, 0.1, undefined],
+    ['scientific notation', { value: 3e-7, min: 1e-7, step: 1e-7 }, 3e-7, 1e-7, 1e-7, undefined],
+    ['omitted step', { value: 0, min: 0 }, 2, 0, 1, undefined],
+    ['provided minimum base', { value: 1, min: 0, step: 2 }, 1, 0, 2, 'stepMismatch'],
+    ['declared default base', { value: 1, step: 2 }, 3, 1, 2, undefined],
+    ['accepted floating boundary', { value: 0.1, min: 0.1, step: 0.1 }, 0.30000000000000004, 0.1, 0.1, undefined],
+    ['rejected floating boundary', { value: 0.1, min: 0.1, step: 0.1 }, 0.300000000000001, 0.1, 0.1, 'stepMismatch']
+  ] as const)(
+    'shares the authoring step grid with runtime validation for %s',
+    (_name, overrides, candidate, base, effectiveStep, validation) => {
+      const input: InputSpec = { ...textInput, type: 'number', ...overrides };
+      const grid = numericStepGrid(input, candidate);
+
+      expect(grid).toEqual({ base, effectiveStep, stepMismatch: validation === 'stepMismatch' });
+      expect(validateNumericInputValue(input, candidate)).toBe(validation);
+    }
+  );
 
   it('enforces the portable signed 32-bit integer domain', () => {
     const integerInput: InputSpec = { ...textInput, type: 'integer', value: 0 };

--- a/tests/unit/remark-plugins.test.mjs
+++ b/tests/unit/remark-plugins.test.mjs
@@ -266,7 +266,7 @@ describe('remark Mermaid diagrams', () => {
 });
 
 describe('remark public asset base', () => {
-  it('prefixes public media URLs with the configured base path', () => {
+  it('prefixes Markdown and string-valued MDX media URLs with the configured base path', () => {
     const tree = {
       type: 'root',
       children: [
@@ -278,6 +278,12 @@ describe('remark public asset base', () => {
           name: 'iframe',
           attributes: [
             { type: 'mdxJsxAttribute', name: 'src', value: '/media/examples/sample.pdf' },
+            { type: 'mdxJsxAttribute', name: 'href', value: '/media/examples/sample.png' },
+            {
+              type: 'mdxJsxAttribute',
+              name: 'src',
+              value: { type: 'mdxJsxAttributeValueExpression', value: 'dynamicSource' }
+            },
             { type: 'mdxJsxAttribute', name: 'title', value: 'Sample PDF' }
           ],
           children: []
@@ -291,22 +297,59 @@ describe('remark public asset base', () => {
     expect(tree.children[1].url).toBe('/oxiquill/media/examples/sample.pdf');
     expect(tree.children[2].url).toBe('/features/media/');
     expect(tree.children[3].attributes[0].value).toBe('/oxiquill/media/examples/sample.pdf');
+    expect(tree.children[3].attributes[1].value).toBe('/oxiquill/media/examples/sample.png');
+    expect(tree.children[3].attributes[2].value).toEqual({
+      type: 'mdxJsxAttributeValueExpression',
+      value: 'dynamicSource'
+    });
   });
 
-  it('leaves URLs unchanged when no base path is configured', () => {
-    const tree = {
-      type: 'root',
-      children: [{ type: 'image', url: '/media/examples/sample.png' }]
-    };
+  it.each([
+    ['/media/examples/sample.png', '/media', '/media/media/examples/sample.png'],
+    ['/media/docs/guide.pdf', '/media/docs', '/media/docs/media/docs/guide.pdf'],
+    ['/media/examples/sample.png', '/oxiquill', '/oxiquill/media/examples/sample.png']
+  ])('prefixes authored media URL %s under base %s', (url, base, expected) => {
+    expect(withPublicAssetBase(url, base)).toBe(expected);
+  });
 
-    remarkPublicAssetBase()(tree);
+  it.each([undefined, '', '/'])('leaves media URLs unchanged when base is %s', (base) => {
+    const tree = { type: 'root', children: [{ type: 'image', url: '/media/examples/sample.png' }] };
+
+    remarkPublicAssetBase({ base })(tree);
 
     expect(tree.children[0].url).toBe('/media/examples/sample.png');
   });
 
-  it('does not double-prefix public media URLs', () => {
-    expect(withPublicAssetBase('/oxiquill/media/examples/sample.png', '/oxiquill')).toBe(
-      '/oxiquill/media/examples/sample.png'
-    );
+  it.each(['/features/media/', 'media/examples/sample.png', 'https://example.com/media/sample.png', '#media'])(
+    'leaves non-media URL %s unchanged',
+    (url) => {
+      expect(withPublicAssetBase(url, '/media')).toBe(url);
+    }
+  );
+
+  it('applies an overlapping base consistently to Markdown and MDX nodes', () => {
+    const tree = {
+      type: 'root',
+      children: [
+        { type: 'image', url: '/media/examples/sample.png' },
+        { type: 'link', url: '/media/docs/guide.pdf' },
+        {
+          type: 'mdxJsxFlowElement',
+          name: 'a',
+          attributes: [
+            { type: 'mdxJsxAttribute', name: 'src', value: '/media/examples/sample.png' },
+            { type: 'mdxJsxAttribute', name: 'href', value: '/media/docs/guide.pdf' }
+          ],
+          children: []
+        }
+      ]
+    };
+
+    remarkPublicAssetBase({ base: '/media' })(tree);
+
+    expect(tree.children[0].url).toBe('/media/media/examples/sample.png');
+    expect(tree.children[1].url).toBe('/media/media/docs/guide.pdf');
+    expect(tree.children[2].attributes[0].value).toBe('/media/media/examples/sample.png');
+    expect(tree.children[2].attributes[1].value).toBe('/media/media/docs/guide.pdf');
   });
 });

--- a/tests/unit/runtime-client.test.ts
+++ b/tests/unit/runtime-client.test.ts
@@ -374,6 +374,31 @@ describe('runtime client', () => {
     expect(workers[1].terminated).toBe(true);
   });
 
+  it('passes the maximum supported timeout unchanged to the timer dependency', async () => {
+    const workers: FakeWorker[] = [];
+    const scheduledTimeout = 1 as unknown as ReturnType<typeof setTimeout>;
+    const setTimer = vi.fn((handler: () => void, timeout: number) => {
+      void handler;
+      void timeout;
+      return scheduledTimeout;
+    });
+    const runner = createInteractiveCellRunner({
+      clearTimeout: vi.fn(),
+      createWorker: () => {
+        const worker = new FakeWorker();
+        workers.push(worker);
+        return worker as unknown as Worker;
+      },
+      setTimeout: setTimer
+    });
+
+    const promise = runner.runInteractiveCell(makeCell('rust', { timeoutMs: 2_147_483_647 }), {});
+
+    expect(setTimer).toHaveBeenCalledWith(expect.any(Function), 2_147_483_647);
+    workers[0].emitMessage({ requestId: 1, ok: true, result });
+    await expect(promise).resolves.toEqual(normalizedResult);
+  });
+
   it('cancels active worker requests, clears their timers, and recovers with a replacement worker', async () => {
     const workers: FakeWorker[] = [];
     const clearTimer = vi.fn(clearTimeout);


### PR DESCRIPTION
## Summary

- reject numeric defaults that do not align with their effective step grid
- constrain interactive-cell timeouts to the supported timer range
- prefix public media correctly when the configured Astro base overlaps `/media`
- quote helper-crate dependency keys in generated Cargo manifests
- add focused regression coverage and update the English and Japanese documentation

## Testing

- `pnpm lint`
- `pnpm check`
- `pnpm test:unit:coverage`
- `pnpm test:wasm`
- `pnpm test:docs`
- `BASE_PATH=/media pnpm build`
- Playwright Chromium and Firefox projects

Closes #113
Closes #114
Closes #115
Closes #116