### PR TITLE
Harden doc runtime authoring and Haskell preamble parsing

### DIFF
--- a/examples/docs-site/content/docs/features/interactive-cells.mdx
+++ b/examples/docs-site/content/docs/features/interactive-cells.mdx
@@ -190,11 +190,15 @@ Haskell cells use `--|` metadata comments. Input values become Haskell variables
 --|   factor: { type: integer, label: factor, min: 1, max: 5, step: 1, value: 3 }
 --|   label: { type: text, label: label, value: sample }
 --|   include_squares: { type: checkbox, label: include squares, value: true }
-import Data.List (intercalate)
+{- Imports may use normal multiline Haskell layout. -}
+import Data.List
+  ( intercalate
+  , sort
+  )
 
 let base = [1 .. 4 :: Int]
 let scaled = map (* factor) base
-let displayed = if include_squares then map (\value -> value * value) scaled else scaled
+let displayed = sort (if include_squares then map (\value -> value * value) scaled else scaled)
 
 putStrLn (label ++ ": " ++ intercalate ", " (map show displayed))
 putStrLn ("total = " ++ show (sum displayed))

--- a/examples/docs-site/content/docs/features/interactive-cells.mdx
+++ b/examples/docs-site/content/docs/features/interactive-cells.mdx
@@ -16,7 +16,7 @@ Only these top-level fields are accepted; unknown fields are errors:
 | Field        | Type and rule                                                                                                              | Default  |
 | ------------ | -------------------------------------------------------------------------------------------------------------------------- | -------- |
 | `id`         | Required lowercase kebab-case matching `^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$`; unique within the page and after route scoping.  | —        |
-| `title`      | String shown in the cell header.                                                                                           | `id`     |
+| `title`      | Non-empty string shown in the cell header; explicit values are trimmed.                                                    | `id`     |
 | `run`        | `button`, `reactive`, or `autorun`.                                                                                        | `button` |
 | `inputs`     | Mapping from lowercase cross-language identifiers matching `^[a-z][a-z0-9_]*$` to input specs. Not allowed with `autorun`. | `{}`     |
 | `packages`   | Unique non-empty Pyodide package names; Python only.                                                                       | `[]`     |

--- a/examples/docs-site/content/docs/guides/authoring.mdx
+++ b/examples/docs-site/content/docs/guides/authoring.mdx
@@ -97,7 +97,7 @@ Use standard-library modules only. Haskell cells do not support external package
 Common metadata fields:
 
 - `id`: required lowercase kebab-case page-local cell identifier.
-- `title`: string heading shown in the cell UI; defaults to `id`.
+- `title`: non-empty string heading shown in the cell UI; explicit values are trimmed and omission defaults to `id`.
 - `run`: `button`, `reactive`, or `autorun`; defaults to `button`.
 - `inputs`: mapping of lowercase cross-language identifiers to input definitions; forbidden for `autorun`.
 - `crates`: Rust helper crates; Rust only.

--- a/examples/docs-site/content/docs/ja/features/interactive-cells.mdx
+++ b/examples/docs-site/content/docs/ja/features/interactive-cells.mdx
@@ -190,11 +190,15 @@ Haskell セルは `--|` metadata comment を使います。input value は Haske
 --|   factor: { type: integer, label: factor, min: 1, max: 5, step: 1, value: 3 }
 --|   label: { type: text, label: label, value: sample }
 --|   include_squares: { type: checkbox, label: include squares, value: true }
-import Data.List (intercalate)
+{- Imports may use normal multiline Haskell layout. -}
+import Data.List
+  ( intercalate
+  , sort
+  )
 
 let base = [1 .. 4 :: Int]
 let scaled = map (* factor) base
-let displayed = if include_squares then map (\value -> value * value) scaled else scaled
+let displayed = sort (if include_squares then map (\value -> value * value) scaled else scaled)
 
 putStrLn (label ++ ": " ++ intercalate ", " (map show displayed))
 putStrLn ("total = " ++ show (sum displayed))

--- a/examples/docs-site/content/docs/ja/features/interactive-cells.mdx
+++ b/examples/docs-site/content/docs/ja/features/interactive-cells.mdx
@@ -16,7 +16,7 @@ interactive fence は `rust`、`python`、`haskell`（Markdown の `{.rust}` for
 | Field        | Type と rule                                                                                                          | Default  |
 | ------------ | --------------------------------------------------------------------------------------------------------------------- | -------- |
 | `id`         | 必須の lowercase kebab-case `^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$`。page 内と route scope 後で unique。                    | —        |
-| `title`      | cell header に表示する string。                                                                                       | `id`     |
+| `title`      | cell header に表示する non-empty string。明示した値は前後の空白を除去。                                               | `id`     |
 | `run`        | `button`、`reactive`、`autorun`。                                                                                     | `button` |
 | `inputs`     | `^[a-z][a-z0-9_]*$` に一致する lowercase cross-language identifier から input spec への mapping。`autorun` では禁止。 | `{}`     |
 | `packages`   | unique non-empty Pyodide package name。Python 専用。                                                                  | `[]`     |

--- a/examples/docs-site/content/docs/ja/guides/authoring.mdx
+++ b/examples/docs-site/content/docs/ja/guides/authoring.mdx
@@ -97,7 +97,7 @@ standard library module だけを使います。Haskell セルでは外部 packa
 主な metadata field:
 
 - `id`: 必須の lowercase kebab-case ページ内 cell ID。
-- `title`: cell UI に表示される string の見出し。default は `id`。
+- `title`: cell UI に表示される non-empty string の見出し。明示した値は前後の空白を除去し、省略時は `id` を使います。
 - `run`: `button`、`reactive`、`autorun`。default は `button`。
 - `inputs`: lowercase cross-language identifier から input definition への mapping。`autorun` では指定できません。
 - `crates`: Rust helper crate。Rust のみ。

--- a/packages/oxiquill/src/generator/doc-runtime/haskell-codegen.mjs
+++ b/packages/oxiquill/src/generator/doc-runtime/haskell-codegen.mjs
@@ -64,33 +64,35 @@ ${body}
 export function splitHaskellCellSource(cellOrSource) {
   const source = typeof cellOrSource === 'string' ? cellOrSource : cellOrSource.source;
   const cell = typeof cellOrSource === 'string' ? undefined : cellOrSource;
-  assertSupportedHaskellSource(source, cell);
+  const tokens = assertSupportedHaskellSource(source, cell);
 
   const pragmas = [];
   const imports = [];
-  const body = [];
-  let isPreamble = true;
+  let tokenIndex = 0;
 
-  for (const line of source.split('\n')) {
-    const trimmed = line.trim();
-
-    if (isPreamble && trimmed === '') continue;
-    if (isPreamble && /^--(?!\|)/u.test(trimmed)) continue;
-    if (isPreamble && /^\{-#\s+LANGUAGE\b/u.test(trimmed)) {
-      pragmas.push(trimmed);
+  while (tokenIndex < tokens.length) {
+    const token = tokens[tokenIndex];
+    if (isLanguagePragma(token)) {
+      pragmas.push(source.slice(token.start, token.end).trim());
+      tokenIndex += 1;
       continue;
     }
-    if (isPreamble && /^import\s+/u.test(trimmed)) {
-      imports.push(trimmed);
+    if (isIdentifierToken(token, 'import')) {
+      const declaration = consumeImportDeclaration(tokens, tokenIndex, cell);
+      imports.push(source.slice(token.start, declaration.end).trim());
+      tokenIndex = declaration.nextTokenIndex;
       continue;
     }
 
-    isPreamble = false;
-    body.push(line);
+    return {
+      body: source.slice(token.start).trim(),
+      imports,
+      pragmas
+    };
   }
 
   return {
-    body: body.join('\n').trim(),
+    body: '',
     imports,
     pragmas
   };
@@ -137,11 +139,250 @@ readStringInput _ raw = pure raw`;
 }
 
 function assertSupportedHaskellSource(source, cell) {
-  const moduleMatch = source.match(/^\s*module\s+\S+\s+where\b/mu);
-  if (!moduleMatch) return;
+  const tokens = scanHaskellTokens(source, cell);
+  if (!hasModuleDeclaration(tokens)) return tokens;
 
   const context = cell ? ` "${cell.id}" in ${cell.pagePath}` : '';
   throw new Error(`Haskell cell${context} cannot declare a module; write a snippet body instead.`);
+}
+
+function scanHaskellTokens(source, cell) {
+  const tokens = [];
+  let cursor = 0;
+
+  while (cursor < source.length) {
+    const character = source[cursor];
+    if (/\s/u.test(character)) {
+      cursor += 1;
+      continue;
+    }
+    if (startsHaskellLineComment(source, cursor)) {
+      cursor = skipHaskellLineComment(source, cursor);
+      continue;
+    }
+    if (source.startsWith('{-#', cursor)) {
+      const end = source.indexOf('#-}', cursor + 3);
+      if (end === -1) throwHaskellSourceError(cell, 'has an unterminated pragma.');
+      tokens.push({ type: 'pragma', value: source.slice(cursor, end + 3), start: cursor, end: end + 3 });
+      cursor = end + 3;
+      continue;
+    }
+    if (source.startsWith('{-', cursor)) {
+      cursor = skipHaskellBlockComment(source, cursor, cell);
+      continue;
+    }
+    if (character === '"') {
+      const end = scanHaskellQuotedLiteral(source, cursor, '"', cell, 'string literal');
+      tokens.push({ type: 'string', start: cursor, end });
+      cursor = end;
+      continue;
+    }
+    if (character === "'") {
+      const end = scanHaskellQuotedLiteral(source, cursor, "'", cell, 'character literal');
+      tokens.push({ type: 'character', start: cursor, end });
+      cursor = end;
+      continue;
+    }
+    if (isHaskellIdentifierStart(character)) {
+      const start = cursor;
+      cursor += 1;
+      while (cursor < source.length && isHaskellIdentifierContinuation(source[cursor])) cursor += 1;
+      tokens.push({ type: 'identifier', value: source.slice(start, cursor), start, end: cursor });
+      continue;
+    }
+
+    tokens.push({ type: 'symbol', value: character, start: cursor, end: cursor + 1 });
+    cursor += 1;
+  }
+
+  return tokens;
+}
+
+function startsHaskellLineComment(source, start) {
+  if (!source.startsWith('--', start)) return false;
+
+  let cursor = start + 2;
+  while (source[cursor] === '-') cursor += 1;
+  return cursor >= source.length || !isHaskellSymbol(source[cursor]);
+}
+
+function skipHaskellLineComment(source, start) {
+  const end = source.indexOf('\n', start + 2);
+  return end === -1 ? source.length : end;
+}
+
+function skipHaskellBlockComment(source, start, cell) {
+  let cursor = start + 2;
+  let depth = 1;
+
+  while (cursor < source.length) {
+    if (source.startsWith('{-', cursor)) {
+      depth += 1;
+      cursor += 2;
+      continue;
+    }
+    if (source.startsWith('-}', cursor)) {
+      depth -= 1;
+      cursor += 2;
+      if (depth === 0) return cursor;
+      continue;
+    }
+    cursor += 1;
+  }
+
+  throwHaskellSourceError(cell, 'has an unterminated block comment.');
+}
+
+function scanHaskellQuotedLiteral(source, start, quote, cell, description) {
+  let cursor = start + 1;
+
+  while (cursor < source.length) {
+    if (source[cursor] === quote) return cursor + 1;
+    if (source[cursor] === '\n' || source[cursor] === '\r') {
+      throwHaskellSourceError(cell, `has an unterminated ${description}.`);
+    }
+    if (source[cursor] === '\\') {
+      if (quote === '"' && /\s/u.test(source[cursor + 1] ?? '')) {
+        cursor += 1;
+        while (cursor < source.length && /\s/u.test(source[cursor])) cursor += 1;
+        if (source[cursor] !== '\\') throwHaskellSourceError(cell, `has an unterminated ${description}.`);
+        cursor += 1;
+        continue;
+      }
+      cursor += 2;
+      continue;
+    }
+    cursor += 1;
+  }
+
+  throwHaskellSourceError(cell, `has an unterminated ${description}.`);
+}
+
+function consumeImportDeclaration(tokens, start, cell) {
+  let cursor = start + 1;
+  const consumeIdentifier = (value) => {
+    if (!isIdentifierToken(tokens[cursor], value)) return false;
+    cursor += 1;
+    return true;
+  };
+
+  if (isSourcePragma(tokens[cursor])) cursor += 1;
+  consumeIdentifier('safe');
+  consumeIdentifier('qualified');
+  if (tokens[cursor]?.type === 'string') cursor += 1;
+
+  cursor = consumeHaskellModuleName(tokens, cursor, cell);
+  consumeIdentifier('qualified');
+  if (consumeIdentifier('as')) cursor = consumeHaskellModuleName(tokens, cursor, cell);
+
+  const hidesImports = consumeIdentifier('hiding');
+  if (isSymbolToken(tokens[cursor], '(')) {
+    cursor = consumeBalancedImportList(tokens, cursor, cell);
+  } else if (hidesImports) {
+    throwHaskellSourceError(cell, 'has an unbalanced import list.');
+  }
+
+  if (isSymbolToken(tokens[cursor], ')')) throwHaskellSourceError(cell, 'has an unbalanced import list.');
+
+  return { end: tokens[cursor - 1].end, nextTokenIndex: cursor };
+}
+
+function consumeHaskellModuleName(tokens, start, cell) {
+  let cursor = start;
+  if (tokens[cursor]?.type !== 'identifier') throwHaskellSourceError(cell, 'has an incomplete import declaration.');
+  cursor += 1;
+
+  while (isSymbolToken(tokens[cursor], '.')) {
+    cursor += 1;
+    if (tokens[cursor]?.type !== 'identifier') {
+      throwHaskellSourceError(cell, 'has an incomplete import declaration.');
+    }
+    cursor += 1;
+  }
+
+  return cursor;
+}
+
+function consumeBalancedImportList(tokens, start, cell) {
+  let depth = 0;
+
+  for (let cursor = start; cursor < tokens.length; cursor += 1) {
+    if (isSymbolToken(tokens[cursor], '(')) depth += 1;
+    if (isSymbolToken(tokens[cursor], ')')) depth -= 1;
+    if (depth === 0) return cursor + 1;
+  }
+
+  throwHaskellSourceError(cell, 'has an unbalanced import list.');
+}
+
+function hasModuleDeclaration(tokens) {
+  const nesting = { '(': 0, '[': 0, '{': 0 };
+
+  for (let index = 0; index < tokens.length; index += 1) {
+    const token = tokens[index];
+    const isTopLevel = Object.values(nesting).every((depth) => depth === 0);
+    if (isTopLevel && isIdentifierToken(token, 'module') && matchesModuleDeclaration(tokens, index)) return true;
+
+    if (token.type !== 'symbol') continue;
+    if (Object.hasOwn(nesting, token.value)) nesting[token.value] += 1;
+    if (token.value === ')') nesting['('] = Math.max(0, nesting['('] - 1);
+    if (token.value === ']') nesting['['] = Math.max(0, nesting['['] - 1);
+    if (token.value === '}') nesting['{'] = Math.max(0, nesting['{'] - 1);
+  }
+
+  return false;
+}
+
+function matchesModuleDeclaration(tokens, start) {
+  let cursor = start + 1;
+  if (tokens[cursor]?.type !== 'identifier') return false;
+  cursor += 1;
+
+  while (isSymbolToken(tokens[cursor], '.') && tokens[cursor + 1]?.type === 'identifier') cursor += 2;
+  if (isSymbolToken(tokens[cursor], '(')) {
+    let depth = 0;
+    do {
+      if (isSymbolToken(tokens[cursor], '(')) depth += 1;
+      if (isSymbolToken(tokens[cursor], ')')) depth -= 1;
+      cursor += 1;
+    } while (cursor < tokens.length && depth > 0);
+    if (depth !== 0) return false;
+  }
+
+  return isIdentifierToken(tokens[cursor], 'where');
+}
+
+function isLanguagePragma(token) {
+  return token?.type === 'pragma' && /^\{-#\s*LANGUAGE\b/u.test(token.value);
+}
+
+function isSourcePragma(token) {
+  return token?.type === 'pragma' && /^\{-#\s*SOURCE\b/u.test(token.value);
+}
+
+function isIdentifierToken(token, value) {
+  return token?.type === 'identifier' && token.value === value;
+}
+
+function isSymbolToken(token, value) {
+  return token?.type === 'symbol' && token.value === value;
+}
+
+function isHaskellIdentifierStart(character) {
+  return /[\p{L}_]/u.test(character);
+}
+
+function isHaskellIdentifierContinuation(character) {
+  return /[\p{L}\p{M}\p{N}_']/u.test(character);
+}
+
+function isHaskellSymbol(character) {
+  return '!#$%&*+./<=>?@\\^|-~:'.includes(character);
+}
+
+function throwHaskellSourceError(cell, detail) {
+  const context = cell ? ` "${cell.id}" in ${cell.pagePath}` : '';
+  throw new Error(`Haskell cell${context} ${detail}`);
 }
 
 function haskellStringLiteral(value) {

--- a/packages/oxiquill/src/lib/doc-runtime/cell-authoring.mjs
+++ b/packages/oxiquill/src/lib/doc-runtime/cell-authoring.mjs
@@ -89,7 +89,7 @@ export function parseInteractiveCellNode(node, pagePath) {
   const context = { ...location, cellId };
   const diagnostics = unknownFieldDiagnostics(metadata, cellFields, context, '');
   const localId = normalizeLocalId(metadata.id, context, diagnostics);
-  const title = normalizeString(metadata, 'title', localId ?? '', context, diagnostics);
+  const title = normalizeTitle(metadata, localId ?? '', context, diagnostics);
   const run = normalizeRunMode(metadata, context, diagnostics);
   const timeoutMs = normalizeTimeout(metadata, context, diagnostics);
   const showSource = normalizeBoolean(metadata, 'showSource', true, context, diagnostics);
@@ -240,10 +240,17 @@ function normalizeLocalId(value, context, diagnostics) {
   return value;
 }
 
-function normalizeString(metadata, field, fallback, context, diagnostics) {
-  if (!hasOwn(metadata, field)) return fallback;
-  if (typeof metadata[field] === 'string') return metadata[field];
-  diagnostics.push(diagnostic(context, field, 'Expected a string.'));
+function normalizeTitle(metadata, fallback, context, diagnostics) {
+  if (!hasOwn(metadata, 'title')) return fallback;
+  if (typeof metadata.title !== 'string') {
+    diagnostics.push(diagnostic(context, 'title', 'Expected a string.'));
+    return fallback;
+  }
+
+  const title = metadata.title.trim();
+  if (title) return title;
+
+  diagnostics.push(diagnostic(context, 'title', 'Expected a non-empty string.'));
   return fallback;
 }
 

--- a/packages/oxiquill/src/lib/doc-runtime/remark-interactive-cells.mjs
+++ b/packages/oxiquill/src/lib/doc-runtime/remark-interactive-cells.mjs
@@ -4,7 +4,12 @@ import {
   throwInteractiveCellDiagnostics,
   uniqueCellIdDiagnostics
 } from './cell-authoring.mjs';
-import { identifierAttribute, visit } from './remark-mdx-helpers.mjs';
+import {
+  allocateMdxIdentifier,
+  collectReservedMdxIdentifiers,
+  identifierAttribute,
+  visit
+} from './remark-mdx-helpers.mjs';
 
 export default function remarkInteractiveCells({ root = process.cwd() } = {}) {
   return (tree, file) => {
@@ -21,14 +26,20 @@ export default function remarkInteractiveCells({ root = process.cwd() } = {}) {
     throwInteractiveCellDiagnostics(diagnostics);
     throwInteractiveCellDiagnostics(uniqueCellIdDiagnostics(cells.map(({ cell }) => cell)));
 
+    const reservedIdentifiers = collectReservedMdxIdentifiers(tree);
+    const componentIdentifier = allocateMdxIdentifier(reservedIdentifiers, '__OxiquillInteractiveCell');
+    const cellIdentifiers = cells.map((_, index) =>
+      allocateMdxIdentifier(reservedIdentifiers, interactiveCellIdentifier(index))
+    );
+
     cells.forEach(({ cell, node }, index) => {
       Object.assign(node, {
         type: 'mdxJsxFlowElement',
-        name: 'InteractiveCell',
+        name: componentIdentifier,
         attributes: [
           { type: 'mdxJsxAttribute', name: 'client:visible', value: null },
           { type: 'mdxJsxAttribute', name: 'cellId', value: cell.id },
-          identifierAttribute('cell', interactiveCellIdentifier(index))
+          identifierAttribute('cell', cellIdentifiers[index])
         ],
         children: []
       });
@@ -39,19 +50,20 @@ export default function remarkInteractiveCells({ root = process.cwd() } = {}) {
     });
 
     if (cells.length > 0 && Array.isArray(tree.children)) {
-      tree.children.unshift(createInteractiveCellImports(cells.map(({ cell }) => cell.id)));
+      tree.children.unshift(
+        createInteractiveCellImports(
+          componentIdentifier,
+          cells.map(({ cell }, index) => ({ cellId: cell.id, identifier: cellIdentifiers[index] }))
+        )
+      );
     }
   };
 }
 
-function createInteractiveCellImports(cellIds) {
-  const componentImport = createImportDeclaration('InteractiveCell', 'oxiquill/runtime/InteractiveCell', true);
-  const cellImports = cellIds.map((cellId, index) =>
-    createImportDeclaration(
-      interactiveCellIdentifier(index),
-      `virtual:oxiquill/cell?cellId=${encodeURIComponent(cellId)}`,
-      false
-    )
+function createInteractiveCellImports(componentIdentifier, cells) {
+  const componentImport = createImportDeclaration(componentIdentifier, 'oxiquill/runtime/InteractiveCell', true);
+  const cellImports = cells.map(({ cellId, identifier }) =>
+    createImportDeclaration(identifier, `virtual:oxiquill/cell?cellId=${encodeURIComponent(cellId)}`, false)
   );
   const declarations = [componentImport, ...cellImports];
 

--- a/packages/oxiquill/src/lib/doc-runtime/remark-mdx-helpers.mjs
+++ b/packages/oxiquill/src/lib/doc-runtime/remark-mdx-helpers.mjs
@@ -14,6 +14,35 @@ export function visit(node, callback) {
   }
 }
 
+export function collectReservedMdxIdentifiers(tree) {
+  const identifiers = new Set();
+
+  visit(tree, (node) => {
+    if (!node || typeof node !== 'object') return;
+
+    if (/^mdxJsx(?:Flow|Text)Element$/u.test(node.type) && typeof node.name === 'string') {
+      identifiers.add(node.name.split('.', 1)[0]);
+    }
+
+    collectEstreeIdentifiers(node.data?.estree, identifiers, new Set());
+  });
+
+  return identifiers;
+}
+
+export function allocateMdxIdentifier(reservedIdentifiers, preferredName) {
+  let suffix = 0;
+  let candidate = preferredName;
+
+  while (reservedIdentifiers.has(candidate)) {
+    suffix += 1;
+    candidate = `${preferredName}${suffix}`;
+  }
+
+  reservedIdentifiers.add(candidate);
+  return candidate;
+}
+
 export function relativeImport(fromFile, toFile, fallback) {
   if (!fromFile) return fallback;
 
@@ -92,4 +121,19 @@ export function identifierAttribute(name, identifier) {
       }
     }
   };
+}
+
+function collectEstreeIdentifiers(value, identifiers, visited) {
+  if (!value || typeof value !== 'object' || visited.has(value)) return;
+  visited.add(value);
+
+  if (value.type === 'Identifier' && typeof value.name === 'string') identifiers.add(value.name);
+
+  for (const child of Object.values(value)) {
+    if (Array.isArray(child)) {
+      child.forEach((entry) => collectEstreeIdentifiers(entry, identifiers, visited));
+    } else {
+      collectEstreeIdentifiers(child, identifiers, visited);
+    }
+  }
 }

--- a/packages/oxiquill/src/lib/doc-runtime/remark-mermaid-diagrams.mjs
+++ b/packages/oxiquill/src/lib/doc-runtime/remark-mermaid-diagrams.mjs
@@ -1,25 +1,35 @@
-import { createDefaultImport, expressionAttribute, visit } from './remark-mdx-helpers.mjs';
+import {
+  allocateMdxIdentifier,
+  collectReservedMdxIdentifiers,
+  createDefaultImport,
+  expressionAttribute,
+  visit
+} from './remark-mdx-helpers.mjs';
 
 const mermaidLanguage = 'mermaid';
 
 export default function remarkMermaidDiagrams() {
   return (tree) => {
-    let needsImport = false;
-    let diagramIndex = 0;
+    const diagrams = [];
 
     visit(tree, (node) => {
       if (!node || node.type !== 'code' || normalizeLanguage(node.lang) !== mermaidLanguage) return;
 
-      needsImport = true;
-      diagramIndex += 1;
+      diagrams.push(node);
+    });
 
+    if (diagrams.length === 0) return;
+
+    const componentIdentifier = allocateMdxIdentifier(collectReservedMdxIdentifiers(tree), '__OxiquillMermaidDiagram');
+
+    diagrams.forEach((node, index) => {
       Object.assign(node, {
         type: 'mdxJsxFlowElement',
-        name: 'MermaidDiagram',
+        name: componentIdentifier,
         attributes: [
           { type: 'mdxJsxAttribute', name: 'client:load', value: null },
           expressionAttribute('source', node.value ?? ''),
-          { type: 'mdxJsxAttribute', name: 'diagramId', value: `mermaid-${diagramIndex}` }
+          { type: 'mdxJsxAttribute', name: 'diagramId', value: `mermaid-${index + 1}` }
         ],
         children: []
       });
@@ -29,8 +39,8 @@ export default function remarkMermaidDiagrams() {
       delete node.value;
     });
 
-    if (needsImport && Array.isArray(tree.children)) {
-      tree.children.unshift(createDefaultImport('MermaidDiagram', 'oxiquill/runtime/MermaidDiagram'));
+    if (Array.isArray(tree.children)) {
+      tree.children.unshift(createDefaultImport(componentIdentifier, 'oxiquill/runtime/MermaidDiagram'));
     }
   };
 }

--- a/tests/unit/astro-config.test.mjs
+++ b/tests/unit/astro-config.test.mjs
@@ -1,5 +1,6 @@
 // @vitest-environment node
 
+import { createRequire } from 'node:module';
 import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -23,6 +24,9 @@ const { defineOxiquillConfig: definePackageConfig, oxiquillIntegration } =
   await import('../../packages/oxiquill/src/astro/index.ts');
 const { readOxiquillMetadata } = await import('../../packages/oxiquill/src/config/metadata.mjs');
 const { canonicalPath } = await import('../../packages/oxiquill/src/config/paths.mjs');
+const requireFromPackage = createRequire(path.resolve(process.cwd(), 'packages/oxiquill/package.json'));
+const requireFromStarlight = createRequire(requireFromPackage.resolve('@astrojs/starlight'));
+const { default: astroMdx } = await import(pathToFileURL(requireFromStarlight.resolve('@astrojs/mdx')).href);
 const linkedConsumerRoot = new URL('../fixtures/linked-consumer/', import.meta.url);
 const tempRoot = pathToFileURL(canonicalPath(os.tmpdir()));
 const preactExportSpecifiers = [
@@ -106,6 +110,30 @@ async function resolveWithVite(update, ids) {
   } finally {
     await server.close();
   }
+}
+
+async function compileMdxWithAstro(update, source, filePath) {
+  const integration = astroMdx();
+  const config = {
+    markdown: update.markdown,
+    srcDir: new URL('./src/', linkedConsumerRoot)
+  };
+  let vitePlugins;
+
+  await integration.hooks['astro:config:setup']({
+    addContentEntryType: vi.fn(),
+    addPageExtension: vi.fn(),
+    addRenderer: vi.fn(),
+    config,
+    updateConfig: (value) => {
+      vitePlugins = value.vite.plugins;
+    }
+  });
+  integration.hooks['astro:config:done']({ config, logger: { warn: vi.fn() } });
+
+  const plugin = vitePlugins.find(({ name }) => name === '@mdx-js/rolldown');
+  plugin.configResolved({ build: { sourcemap: false }, plugins: [] });
+  return plugin.transform.handler(source, filePath);
 }
 
 describe('defineOxiquillConfig', () => {
@@ -196,6 +224,32 @@ describe('defineOxiquillConfig', () => {
     expect(rehypePlugins.map(pluginName)).toEqual(['rehypeKatex', 'rehypePlugin']);
     expect(update.markdown).not.toHaveProperty('remarkPlugins');
     expect(update.markdown).not.toHaveProperty('rehypePlugins');
+  });
+
+  it('compiles MDX whose author bindings collide with every preferred runtime alias', async () => {
+    const config = defineOxiquillConfig({ sidebar: [], title: 'Docs' });
+    const update = runConfigSetup(config);
+    const rendered = await compileMdxWithAstro(
+      update,
+      `export const __OxiquillInteractiveCell = () => null;
+export const __OxiquillMermaidDiagram = () => null;
+export const __oxiquillCell0 = {};
+
+\`\`\`rust
+//| id: collision
+println!("ok");
+\`\`\`
+
+\`\`\`mermaid
+flowchart LR
+  A --> B
+\`\`\``,
+      path.join(fileURLToPath(linkedConsumerRoot), 'content', 'docs', 'collision.mdx')
+    );
+
+    expect(rendered.code).toContain('__OxiquillInteractiveCell1');
+    expect(rendered.code).toContain('__OxiquillMermaidDiagram1');
+    expect(rendered.code).toContain('__oxiquillCell01');
   });
 
   it('renders overlapping public media bases through the configured Markdown processor', async () => {

--- a/tests/unit/components.test.tsx
+++ b/tests/unit/components.test.tsx
@@ -193,7 +193,8 @@ describe('InteractiveCell', () => {
     render(<InteractiveCell cellId="cell-one" cell={makeCell()} />);
 
     expect(screen.getByTestId('cell-cell-one')).toBeVisible();
-    expect(screen.getByText('Cell one')).toBeVisible();
+    expect(screen.getByRole('heading', { name: 'Cell one' })).toBeVisible();
+    expect(screen.getByRole('region', { name: 'Output for Cell one' })).toBeVisible();
   });
 
   it('renders controls, toggles source, runs button cells, and displays all output types', async () => {

--- a/tests/unit/doc-runtime-core.test.mjs
+++ b/tests/unit/doc-runtime-core.test.mjs
@@ -344,6 +344,48 @@ describe('doc runtime core', () => {
     );
   });
 
+  it.each([
+    ['empty', '""', 'Expected a non-empty string.'],
+    ['whitespace-only', '"   "', 'Expected a non-empty string.'],
+    ['non-string', '12', 'Expected a string.']
+  ])('rejects an explicitly %s title with a title diagnostic', (_name, title, message) => {
+    const source = ['```rust', '//| id: titled-cell', `//| title: ${title}`, 'println!("ok");', '```'].join('\n');
+    const parsed = parseCellsFromMarkdown(source, 'content/docs/page.mdx');
+
+    expect(parsed.cells).toEqual([]);
+    expect(parsed.diagnostics).toContainEqual(
+      expect.objectContaining({
+        pagePath: 'content/docs/page.mdx',
+        fenceStartLine: 1,
+        cellId: 'titled-cell',
+        fieldPath: 'title',
+        message
+      })
+    );
+  });
+
+  it('trims explicit titles and keeps the local id fallback for omitted titles', () => {
+    const source = [
+      '```rust',
+      '//| id: explicit-title',
+      '//| title: "  Example cell  "',
+      'println!("explicit");',
+      '```',
+      '',
+      '```python',
+      '#| id: omitted-title',
+      'print("omitted")',
+      '```'
+    ].join('\n');
+    const parsed = parseCellsFromMarkdown(source, 'content/docs/page.mdx');
+
+    expect(parsed.diagnostics).toEqual([]);
+    expect(parsed.cells).toMatchObject([
+      { localId: 'explicit-title', title: 'Example cell' },
+      { localId: 'omitted-title', title: 'omitted-title' }
+    ]);
+  });
+
   it.each([1, 2_147_483_647])('accepts the timeout boundary %s', (timeoutMs) => {
     const source = ['```python', '#| id: timeout-boundary', `#| timeoutMs: ${timeoutMs}`, 'print("ok")', '```'].join(
       '\n'

--- a/tests/unit/doc-runtime-core.test.mjs
+++ b/tests/unit/doc-runtime-core.test.mjs
@@ -66,6 +66,17 @@ const runtimeInputs = {
   }
 };
 
+function makeHaskellCell(source, overrides = {}) {
+  return {
+    id: 'haskell-cell',
+    pagePath: 'content/docs/page.mdx',
+    language: 'haskell',
+    source,
+    inputs: [],
+    ...overrides
+  };
+}
+
 describe('doc runtime core', () => {
   it('creates stable page-scoped authoring ids', () => {
     expect(pageIdFromPath('content/docs/ja/notes/example.mdx')).toBe('ja__notes__example');
@@ -839,6 +850,91 @@ describe('doc runtime core', () => {
     expect(() => splitHaskellCellSource({ ...haskellCell, source: 'module Example where\nmain = pure ()' })).toThrow(
       'cannot declare a module'
     );
+  });
+
+  it('extracts multiline Haskell pragmas and imports through nested preamble comments', () => {
+    const source = [
+      '{- explain the preamble {- including a nested comment -} -}',
+      'import Data.List',
+      '  ( intercalate',
+      '  -- keep comments inside a declaration valid',
+      '  , sort',
+      '  )',
+      '{- interstitial {- nested -} comment -}',
+      '{-# LANGUAGE',
+      '  ScopedTypeVariables',
+      '#-}',
+      'putStrLn (intercalate "," (sort values))'
+    ].join('\n');
+
+    expect(splitHaskellCellSource(makeHaskellCell(source))).toEqual({
+      pragmas: ['{-# LANGUAGE\n  ScopedTypeVariables\n#-}'],
+      imports: ['import Data.List\n  ( intercalate\n  -- keep comments inside a declaration valid\n  , sort\n  )'],
+      body: 'putStrLn (intercalate "," (sort values))'
+    });
+  });
+
+  it('extracts qualified, import-as, and hiding forms split across lines', () => {
+    const source = [
+      'import qualified',
+      '  Data.Map.Strict',
+      '  as',
+      '  Map',
+      '  hiding',
+      '  ( map',
+      '  , null',
+      '  )',
+      'print (Map.size values)'
+    ].join('\n');
+
+    expect(splitHaskellCellSource(makeHaskellCell(source))).toEqual({
+      pragmas: [],
+      imports: [
+        ['import qualified', '  Data.Map.Strict', '  as', '  Map', '  hiding', '  ( map', '  , null', '  )'].join('\n')
+      ],
+      body: 'print (Map.size values)'
+    });
+  });
+
+  it('ignores module declaration text in comments, strings, and character literals', () => {
+    const source = ['{- module Commented where -}', 'putStrLn "module Example where"', "print 'm'"].join('\n');
+
+    expect(splitHaskellCellSource(makeHaskellCell(source)).body).toBe(
+      ['putStrLn "module Example where"', "print 'm'"].join('\n')
+    );
+  });
+
+  it('rejects a real Haskell module declaration with cell and page context', () => {
+    const cell = makeHaskellCell('module Example (main) where\nmain = pure ()', {
+      id: 'module-cell',
+      pagePath: 'content/docs/module.mdx'
+    });
+
+    expect(() => splitHaskellCellSource(cell)).toThrow(
+      'Haskell cell "module-cell" in content/docs/module.mdx cannot declare a module; write a snippet body instead.'
+    );
+  });
+
+  it('preserves imports and pragma-looking text after the first body token', () => {
+    const body = ['putStrLn "start"', 'import Data.List (sort)', '{-# LANGUAGE LambdaCase #-}'].join('\n');
+
+    expect(splitHaskellCellSource(makeHaskellCell(body))).toEqual({ body, imports: [], pragmas: [] });
+  });
+
+  it.each([
+    ['block comment', '{- unfinished', 'unterminated block comment'],
+    ['pragma', '{-# LANGUAGE LambdaCase', 'unterminated pragma'],
+    ['string literal', 'putStrLn "unfinished', 'unterminated string literal'],
+    ['character literal', "print 'x", 'unterminated character literal'],
+    ['import list', 'import Data.List (sort', 'unbalanced import list']
+  ])('reports an unterminated Haskell %s with cell context', (_name, source, message) => {
+    expect(() => splitHaskellCellSource(makeHaskellCell(source))).toThrow(
+      `Haskell cell "haskell-cell" in content/docs/page.mdx has an ${message}.`
+    );
+  });
+
+  it('keeps the empty Haskell body fallback after lifting declarations', () => {
+    expect(generateHaskellFunction(makeHaskellCell('import Data.List (sort)'))).toContain('    pure ()');
   });
 
   it('detects Rust output capabilities from source tokens', () => {

--- a/tests/unit/remark-plugins.test.mjs
+++ b/tests/unit/remark-plugins.test.mjs
@@ -24,7 +24,7 @@ describe('remark interactive cells', () => {
       path: '/repo/content/docs/page.mdx'
     });
 
-    expect(tree.children[0].value).toContain('import InteractiveCell');
+    expect(tree.children[0].value).toContain('import __OxiquillInteractiveCell');
     expect(tree.children[0].value).toContain(
       'import { cell as __oxiquillCell0 } from "virtual:oxiquill/cell?cellId=page__rust-one";'
     );
@@ -36,7 +36,7 @@ describe('remark interactive cells', () => {
     });
     expect(tree.children[2]).toMatchObject({
       type: 'mdxJsxFlowElement',
-      name: 'InteractiveCell',
+      name: '__OxiquillInteractiveCell',
       attributes: [
         { type: 'mdxJsxAttribute', name: 'client:visible', value: null },
         { type: 'mdxJsxAttribute', name: 'cellId', value: 'page__rust-one' },
@@ -69,7 +69,9 @@ describe('remark interactive cells', () => {
 
     remarkInteractiveCells({ root: '/repo' })(tree, {});
 
-    expect(tree.children[0].value).toContain('import InteractiveCell from "oxiquill/runtime/InteractiveCell";');
+    expect(tree.children[0].value).toContain(
+      'import __OxiquillInteractiveCell from "oxiquill/runtime/InteractiveCell";'
+    );
     expect(tree.children[0].value).toContain(
       'import { cell as __oxiquillCell0 } from "virtual:oxiquill/cell?cellId=rust-one";'
     );
@@ -107,7 +109,9 @@ describe('remark interactive cells', () => {
       path: '/repo/src/components/doc-runtime/example.mdx'
     });
 
-    expect(tree.children[0].value).toContain('import InteractiveCell from "oxiquill/runtime/InteractiveCell";');
+    expect(tree.children[0].value).toContain(
+      'import __OxiquillInteractiveCell from "oxiquill/runtime/InteractiveCell";'
+    );
   });
 
   it('leaves trees without interactive cells unchanged', () => {
@@ -199,10 +203,10 @@ describe('remark Mermaid diagrams', () => {
       path: '/repo/content/docs/page.mdx'
     });
 
-    expect(tree.children[0].value).toContain('import MermaidDiagram');
+    expect(tree.children[0].value).toContain('import __OxiquillMermaidDiagram');
     expect(tree.children[1]).toMatchObject({
       type: 'mdxJsxFlowElement',
-      name: 'MermaidDiagram',
+      name: '__OxiquillMermaidDiagram',
       attributes: [
         { type: 'mdxJsxAttribute', name: 'client:load', value: null },
         {
@@ -235,7 +239,7 @@ describe('remark Mermaid diagrams', () => {
 
     remarkMermaidDiagrams({ root: '/repo' })(tree, {});
 
-    expect(tree.children[0].value).toBe("import MermaidDiagram from 'oxiquill/runtime/MermaidDiagram';");
+    expect(tree.children[0].value).toBe("import __OxiquillMermaidDiagram from 'oxiquill/runtime/MermaidDiagram';");
   });
 
   it('keeps package-stable Mermaid imports for non-docs files', () => {
@@ -248,7 +252,7 @@ describe('remark Mermaid diagrams', () => {
       path: '/repo/src/components/doc-runtime/example.mdx'
     });
 
-    expect(tree.children[0].value).toBe("import MermaidDiagram from 'oxiquill/runtime/MermaidDiagram';");
+    expect(tree.children[0].value).toBe("import __OxiquillMermaidDiagram from 'oxiquill/runtime/MermaidDiagram';");
   });
 
   it('leaves trees without Mermaid diagrams unchanged', () => {
@@ -262,6 +266,138 @@ describe('remark Mermaid diagrams', () => {
     });
 
     expect(tree.children).toHaveLength(1);
+  });
+});
+
+describe('remark runtime binding allocation', () => {
+  it('allocates distinct component aliases when preferred names are already imported', () => {
+    const tree = parseMdxTree(`import __OxiquillInteractiveCell from './InteractiveCell.astro';
+import __OxiquillMermaidDiagram from './MermaidDiagram.astro';
+
+\`\`\`rust
+//| id: rust-one
+println!("ok");
+\`\`\`
+
+\`\`\`mermaid
+flowchart LR
+  A --> B
+\`\`\``);
+
+    applyRuntimeRemarkPlugins(tree);
+
+    expect(runtimeImportLocal(tree, 'oxiquill/runtime/InteractiveCell')).toBe('__OxiquillInteractiveCell1');
+    expect(runtimeImportLocal(tree, 'oxiquill/runtime/MermaidDiagram')).toBe('__OxiquillMermaidDiagram1');
+  });
+
+  it('reserves variable, function, and class declarations', () => {
+    const tree = parseMdxTree(`export const __OxiquillInteractiveCell = null;
+export function __OxiquillMermaidDiagram() {}
+export class __oxiquillCell0 {}
+
+\`\`\`python
+#| id: python-one
+print("ok")
+\`\`\`
+
+\`\`\`mermaid
+flowchart LR
+  A --> B
+\`\`\``);
+
+    applyRuntimeRemarkPlugins(tree);
+
+    expect(runtimeImportLocal(tree, 'oxiquill/runtime/InteractiveCell')).toBe('__OxiquillInteractiveCell1');
+    expect(runtimeImportLocal(tree, 'oxiquill/runtime/MermaidDiagram')).toBe('__OxiquillMermaidDiagram1');
+    expect(cellImportLocals(tree)).toEqual(['__oxiquillCell01']);
+  });
+
+  it('reserves destructured names and fills free preferred numeric names deterministically', () => {
+    const tree = parseMdxTree(`export const { __oxiquillCell0, __oxiquillCell01, __oxiquillCell2 } = bindings;
+
+\`\`\`rust
+//| id: cell-zero
+println!("zero");
+\`\`\`
+
+\`\`\`python
+#| id: cell-one
+print("one")
+\`\`\`
+
+\`\`\`haskell
+--| id: cell-two
+putStrLn "two"
+\`\`\``);
+
+    remarkInteractiveCells({ root: '/repo' })(tree, { path: '/repo/content/docs/page.mdx' });
+
+    expect(cellImportLocals(tree)).toEqual(['__oxiquillCell02', '__oxiquillCell1', '__oxiquillCell21']);
+  });
+
+  it('reserves simple and root JSX component identifiers', () => {
+    const tree = parseMdxTree(`<__OxiquillInteractiveCell />
+
+<__OxiquillMermaidDiagram.Part />
+
+\`\`\`rust
+//| id: rust-one
+println!("ok");
+\`\`\`
+
+\`\`\`mermaid
+flowchart LR
+  A --> B
+\`\`\`
+
+\`\`\`mermaid
+flowchart LR
+  B --> C
+\`\`\``);
+
+    applyRuntimeRemarkPlugins(tree);
+
+    expect(runtimeImportLocal(tree, 'oxiquill/runtime/InteractiveCell')).toBe('__OxiquillInteractiveCell1');
+    expect(runtimeImportLocal(tree, 'oxiquill/runtime/MermaidDiagram')).toBe('__OxiquillMermaidDiagram1');
+    expect(transformedElements(tree, 'client:load').map(({ name }) => name)).toEqual([
+      '__OxiquillMermaidDiagram1',
+      '__OxiquillMermaidDiagram1'
+    ]);
+  });
+
+  it('produces identical trees and keeps textual ESM, ESTree, JSX, and expressions aligned', () => {
+    const source = `export const __OxiquillInteractiveCell = null;
+export const __OxiquillMermaidDiagram = null;
+export const __oxiquillCell0 = null;
+
+\`\`\`rust
+//| id: rust-one
+println!("ok");
+\`\`\`
+
+\`\`\`python
+#| id: python-one
+print("ok")
+\`\`\`
+
+\`\`\`mermaid
+flowchart LR
+  A --> B
+\`\`\`
+
+\`\`\`mermaid
+sequenceDiagram
+  A->>B: hi
+\`\`\``;
+    const first = parseMdxTree(source);
+    const second = parseMdxTree(source);
+
+    applyRuntimeRemarkPlugins(first);
+    applyRuntimeRemarkPlugins(second);
+
+    expect(first).toEqual(second);
+    expectInjectedBindingsAgree(first, 'oxiquill/runtime/InteractiveCell', 'client:visible');
+    expectInjectedBindingsAgree(first, 'oxiquill/runtime/MermaidDiagram', 'client:load');
   });
 });
 
@@ -353,3 +489,59 @@ describe('remark public asset base', () => {
     expect(tree.children[2].attributes[1].value).toBe('/media/media/docs/guide.pdf');
   });
 });
+
+function parseMdxTree(source) {
+  const parsed = parseCellsFromMarkdown(source, 'content/docs/page.mdx');
+  expect(parsed.diagnostics).toEqual([]);
+  return parsed.tree;
+}
+
+function applyRuntimeRemarkPlugins(tree) {
+  remarkInteractiveCells({ root: '/repo' })(tree, { path: '/repo/content/docs/page.mdx' });
+  remarkMermaidDiagrams()(tree);
+}
+
+function runtimeImportNode(tree, source) {
+  return tree.children.find((node) =>
+    node?.data?.estree?.body?.some(
+      (declaration) => declaration.type === 'ImportDeclaration' && declaration.source.value === source
+    )
+  );
+}
+
+function runtimeImportLocal(tree, source) {
+  const declaration = runtimeImportNode(tree, source).data.estree.body.find(
+    (candidate) => candidate.type === 'ImportDeclaration' && candidate.source.value === source
+  );
+  return declaration.specifiers[0].local.name;
+}
+
+function cellImportLocals(tree) {
+  return runtimeImportNode(tree, 'oxiquill/runtime/InteractiveCell')
+    .data.estree.body.filter((declaration) => declaration.source.value.startsWith('virtual:oxiquill/cell?'))
+    .map((declaration) => declaration.specifiers[0].local.name);
+}
+
+function transformedElements(tree, clientDirective) {
+  return tree.children.filter(
+    (node) =>
+      node?.type === 'mdxJsxFlowElement' && node.attributes.some((attribute) => attribute.name === clientDirective)
+  );
+}
+
+function expectInjectedBindingsAgree(tree, componentSource, clientDirective) {
+  const importNode = runtimeImportNode(tree, componentSource);
+  const localNames = importNode.data.estree.body.map((declaration) => declaration.specifiers[0].local.name);
+
+  localNames.forEach((name) => expect(importNode.value).toContain(name));
+
+  const elements = transformedElements(tree, clientDirective);
+  elements.forEach((element, index) => {
+    expect(element.name).toBe(localNames[0]);
+    if (clientDirective !== 'client:visible') return;
+
+    const expression = element.attributes.find((attribute) => attribute.name === 'cell').value;
+    expect(expression.value).toBe(localNames[index + 1]);
+    expect(expression.data.estree.body[0].expression.name).toBe(localNames[index + 1]);
+  });
+}


### PR DESCRIPTION
## Summary

- allocate deterministic, collision-free MDX bindings for injected interactive-cell and Mermaid runtime components
- reject explicitly blank interactive-cell titles while preserving trimmed titles and the existing omitted-title fallback
- replace line-based Haskell preamble extraction with a lexical scanner that supports multiline pragmas, imports, nested comments, and contextual malformed-source errors
- extend unit, integration, accessibility, runtime, and bilingual documentation coverage for all three changes

## Validation

- `pnpm lint`
- `pnpm check`
- `pnpm build`
- `pnpm test:unit:coverage` (614 passed, 1 skipped)
- `pnpm test:wasm`
- `pnpm test:haskell`
- `pnpm test:docs`
- `pnpm test:package`
- `pnpm test:consumer:npm`
- `pnpm test:consumer:pnpm`
- `pnpm test:packed-browser`
- `pnpm test:e2e` (70 passed, 2 skipped)

Closes #117
Closes #118
Closes #119
