### PR TITLE
Fix Rust cell generation and enforce runtime and documentation CI checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -242,6 +242,8 @@ jobs:
         run: pnpm exec playwright install --with-deps chromium
       - name: Exercise packed interactive cells
         run: pnpm test:packed-browser
+      - name: Run development HMR smoke
+        run: pnpm test:dev-hmr
 
   runtime:
     name: Runtime (${{ matrix.label }})

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,8 @@ jobs:
         run: pnpm audit --prod --audit-level=low
       - name: Run unit coverage
         run: pnpm test:unit:coverage
+      - name: Run documentation contract checks
+        run: pnpm test:docs
 
   rust-quality:
     name: Rust quality
@@ -295,6 +297,9 @@ jobs:
         run: pnpm install --frozen-lockfile
       - name: Run generated runtime and static build tests
         run: pnpm test:runtime
+      - name: Run browser bundle contract checks
+        if: matrix.label == 'Linux'
+        run: pnpm test:bundle
       - name: Upload Linux browser site
         if: matrix.label == 'Linux'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/examples/docs-site/content/docs/guides/validation.mdx
+++ b/examples/docs-site/content/docs/guides/validation.mdx
@@ -49,10 +49,13 @@ pnpm test:wasm
 pnpm test:haskell
 pnpm build
 pnpm test:bundle
+pnpm test:dev-hmr
 pnpm test:e2e
 ```
 
 `pnpm wasm:dev` regenerates the runtime for local development. It requires `wasm32-wasi-ghc` when Haskell cells are present, as do `pnpm build`, `pnpm check`, `pnpm wasm:build`, and `pnpm test:wasm`. `pnpm dev` and `pnpm dev:runtime` are intentionally more forgiving: they keep Astro serving and show a Haskell cell error in the browser if the Haskell compiler is missing or a Haskell compile fails. `pnpm test:wasm` verifies generated Rust cell behavior, and `pnpm test:haskell` executes the generated Haskell/WASI runtime. `pnpm test:e2e` runs the full browser suite in Chromium, Firefox, and WebKit.
+
+`pnpm test:dev-hmr` runs a standalone Chromium smoke against a temporary copy of the workspace. It installs dependencies offline from the pnpm store, builds the package, generates the initial runtime, edits an MDX cell, and verifies source and reactive output updates remain stable. Run `pnpm install --frozen-lockfile` first to populate the store; Rust/Wasm, `wasm32-wasi-ghc`, and Playwright Chromium are required. PR CI runs it once in the Linux packed-browser job, after the packed consumer smoke.
 
 Production builds write `dist/oxiquill/bundle-report.json` and fail when an emitted client or worker JavaScript chunk exceeds 650 KiB uncompressed. Run `pnpm test:bundle` after `pnpm build` to verify the budget and confirm that ECharts and Mermaid remain behind dynamic import boundaries.
 

--- a/examples/docs-site/content/docs/ja/guides/validation.mdx
+++ b/examples/docs-site/content/docs/ja/guides/validation.mdx
@@ -49,10 +49,13 @@ pnpm test:wasm
 pnpm test:haskell
 pnpm build
 pnpm test:bundle
+pnpm test:dev-hmr
 pnpm test:e2e
 ```
 
 `pnpm wasm:dev` は local development 用 runtime を再生成します。Haskell セルがある場合は `wasm32-wasi-ghc` が必要で、`pnpm build`、`pnpm check`、`pnpm wasm:build`、`pnpm test:wasm` でも同じです。`pnpm dev` と `pnpm dev:runtime` は意図的により寛容で、Haskell compiler がない、または Haskell compile に失敗しても Astro の serving を続け、browser 上の Haskell セルに error を表示します。`pnpm test:wasm` は生成 Rust cell の動作を確認し、`pnpm test:haskell` は生成 Haskell/WASI runtime を実行します。`pnpm test:e2e` は Chromium、Firefox、WebKit で full browser suite を実行します。
+
+`pnpm test:dev-hmr` はワークスペースの一時コピーで Chromium の開発スモークテストを実行します。pnpm store からのオフラインインストール、パッケージのビルド、初回 runtime 生成の後に MDX セルを編集し、ソースと reactive 出力の更新が安定することを確認します。先に `pnpm install --frozen-lockfile` で store を準備してください。Rust/Wasm、`wasm32-wasi-ghc`、Playwright Chromium が必要です。PR CI では Linux の packed-browser job で packed consumer smoke の後に1回実行します。
 
 production build は `dist/oxiquill/bundle-report.json` を生成し、出力された client または worker の JavaScript chunk が uncompressed で 650 KiB を超えると失敗します。`pnpm build` の後に `pnpm test:bundle` を実行すると、budget と ECharts/Mermaid の dynamic import boundary を検証できます。
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "lint:js": "eslint \"**/*.{js,mjs,cjs,ts,tsx,astro}\" --max-warnings=0",
     "format": "prettier \"**/*.{astro,css,js,mjs,cjs,ts,tsx,md,mdx,json,yaml,yml}\" --write",
     "format:check": "prettier \"**/*.{astro,css,js,mjs,cjs,ts,tsx,md,mdx,json,yaml,yml}\" --check",
-    "test": "pnpm verify:release-version && pnpm lint && pnpm test:coverage && pnpm doc:rust && pnpm test:cli && pnpm test:runtime && pnpm test:bundle && pnpm test:docs && pnpm test:package && pnpm test:consumer && pnpm test:packed-browser && pnpm test:e2e",
+    "test": "pnpm verify:release-version && pnpm lint && pnpm test:coverage && pnpm doc:rust && pnpm test:cli && pnpm test:runtime && pnpm test:bundle && pnpm test:docs && pnpm test:package && pnpm test:consumer && pnpm test:packed-browser && pnpm test:dev-hmr && pnpm test:e2e",
     "test:coverage": "pnpm test:rust:coverage && pnpm test:unit:coverage",
     "test:compatibility": "pnpm lint && pnpm check:types && pnpm test:unit && pnpm test:cli && pnpm test:rust && pnpm test:package",
     "test:cli": "pnpm build:package && node packages/oxiquill/dist/cli/index.mjs --help",
@@ -50,7 +50,8 @@
     "test:consumer:registry:pnpm": "node tests/package/consumer-smoke.mjs --package-manager pnpm --registry",
     "verify:release-version": "node .github/scripts/verify-release-version.mjs",
     "lint:rust": "pnpm build:package && pnpm --dir examples/docs-site lint:rust",
-    "clean": "pnpm build:package && pnpm --dir examples/docs-site clean && pnpm --dir packages/oxiquill clean"
+    "clean": "pnpm build:package && pnpm --dir examples/docs-site clean && pnpm --dir packages/oxiquill clean",
+    "test:dev-hmr": "node tests/e2e/dev-hmr-smoke.mjs"
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "0.18.5",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "test:unit": "vitest run",
     "test:unit:coverage": "vitest run --coverage",
     "doc:rust": "pnpm build:package && pnpm --dir examples/docs-site doc:rust",
-    "test:wasm": "pnpm build:package && pnpm --dir examples/docs-site test:wasm",
+    "test:wasm": "pnpm build:package && pnpm --dir examples/docs-site test:wasm && node tests/runtime/rust-codegen-smoke.mjs",
     "test:e2e": "pnpm build:package && playwright test",
     "test:bundle": "node tests/bundle/client-bundle.mjs",
     "test:docs": "pnpm build:package && node tests/docs/check-documentation.mjs",

--- a/packages/oxiquill/src/generator/doc-runtime/rust-codegen/capabilities.mjs
+++ b/packages/oxiquill/src/generator/doc-runtime/rust-codegen/capabilities.mjs
@@ -1,41 +1,46 @@
+import { scanRustMacroInvocations } from './macro-invocations.mjs';
+
 const chartTokens = [
-  'emit_line_plot!',
-  'emit_line_chart!',
-  'emit_scatter_chart!',
-  'emit_bar_chart!',
-  'emit_histogram!',
-  'emit_heatmap!'
+  'emit_line_plot',
+  'emit_line_chart',
+  'emit_scatter_chart',
+  'emit_bar_chart',
+  'emit_histogram',
+  'emit_heatmap'
 ];
 
-const imageTokens = ['emit_image_svg!', 'emit_image_png!', 'emit_svg!', 'emit_png_base64!'];
+const imageTokens = ['emit_image_svg', 'emit_image_png', 'emit_svg', 'emit_png_base64'];
 
-const tableTokens = ['emit_table!', 'emit_table_with_columns!', 'emit_records_table!'];
+const tableTokens = ['emit_table', 'emit_table_with_columns', 'emit_records_table'];
 
 const sourceFeatureDescriptors = [
-  ['legacyPlot', ['emit_line_plot!']],
-  ['lineChart', ['emit_line_chart!']],
-  ['scatterChart', ['emit_scatter_chart!']],
-  ['barChart', ['emit_bar_chart!']],
-  ['histogramChart', ['emit_histogram!']],
-  ['heatmapChart', ['emit_heatmap!']],
-  ['html', ['emit_html!']],
-  ['json', ['emit_json!']]
+  ['legacyPlot', ['emit_line_plot']],
+  ['lineChart', ['emit_line_chart']],
+  ['scatterChart', ['emit_scatter_chart']],
+  ['barChart', ['emit_bar_chart']],
+  ['histogramChart', ['emit_histogram']],
+  ['heatmapChart', ['emit_heatmap']],
+  ['html', ['emit_html']],
+  ['json', ['emit_json']]
 ];
 
-export function rustOutputCapabilities(rustCells) {
-  return rustSourceCapabilities(rustCells.map((cell) => cell.source).join('\n'));
+export function rustOutputCapabilities(
+  rustCells,
+  macroSets = rustCells.map((cell) => scanRustMacroInvocations(cell.source, cell))
+) {
+  return rustSourceCapabilities('', new Set(macroSets.flatMap((macros) => [...macros])));
 }
 
-export function rustSourceCapabilities(source) {
+export function rustSourceCapabilities(source, macros = scanRustMacroInvocations(source)) {
   return {
-    ...Object.fromEntries(sourceFeatureDescriptors.map(([key, tokens]) => [key, hasAnyToken(source, tokens)])),
-    chart: hasAnyToken(source, chartTokens),
-    image: hasAnyToken(source, imageTokens),
-    table: hasAnyToken(source, tableTokens),
-    text: hasAnyToken(source, ['emit_text!'])
+    ...Object.fromEntries(sourceFeatureDescriptors.map(([key, names]) => [key, hasAnyMacro(macros, names)])),
+    chart: hasAnyMacro(macros, chartTokens),
+    image: hasAnyMacro(macros, imageTokens),
+    table: hasAnyMacro(macros, tableTokens),
+    text: hasAnyMacro(macros, ['emit_text'])
   };
 }
 
-export function hasAnyToken(source, tokens) {
-  return tokens.some((token) => source.includes(token));
+export function hasAnyMacro(macros, names) {
+  return names.some((name) => macros.has(name));
 }

--- a/packages/oxiquill/src/generator/doc-runtime/rust-codegen/functions.mjs
+++ b/packages/oxiquill/src/generator/doc-runtime/rust-codegen/functions.mjs
@@ -5,17 +5,19 @@ import { generateRustPreludeMacros } from './macros.mjs';
 import { outputArtifactLimits } from '../../../lib/doc-runtime/output-limits.mjs';
 
 export function generateRustFunction(cell, invokedMacros = scanRustMacroInvocations(cell.source, cell)) {
-  const inputBindings = cell.inputs.map((input) => `    ${generateRustInputBinding(input)}`).join('\n');
+  const inputBindings = cell.inputs.map((input) => `        ${generateRustInputBinding(input)}`).join('\n');
   const escapedSource = indentRustSource(cell.source);
   const macros = generateRustPreludeMacros(cell.source, invokedMacros);
   const inputsParameter = cell.inputs.length > 0 ? 'inputs' : '_inputs';
 
   return `fn ${rustFunctionName(cell.id)}(${inputsParameter}: &Value) -> Result<CellOutput, String> {
-${inputBindings ? `${inputBindings}\n` : ''}    let __stdout = std::cell::RefCell::new(BoundedText::new());
+    let __stdout = std::cell::RefCell::new(BoundedText::new());
     let __outputs = std::cell::RefCell::new(OutputCollector::new());
 ${macros ? `\n${macros}\n` : ''}
 
-${escapedSource}
+    let _ = {
+${inputBindings ? `${inputBindings}\n` : ''}${escapedSource}
+    };
 
     Ok(finish_cell_output(
         __stdout.into_inner(),
@@ -84,6 +86,6 @@ function generateRustTest(cell) {
 function indentRustSource(source) {
   return source
     .split('\n')
-    .map((line) => `    ${line}`)
+    .map((line) => `        ${line}`)
     .join('\n');
 }

--- a/packages/oxiquill/src/generator/doc-runtime/rust-codegen/functions.mjs
+++ b/packages/oxiquill/src/generator/doc-runtime/rust-codegen/functions.mjs
@@ -1,12 +1,13 @@
 import { generateRustInputBinding } from '../rust-readers.mjs';
 import { rustFunctionName, rustIdentifier } from '../rust-identifiers.mjs';
+import { scanRustMacroInvocations } from './macro-invocations.mjs';
 import { generateRustPreludeMacros } from './macros.mjs';
 import { outputArtifactLimits } from '../../../lib/doc-runtime/output-limits.mjs';
 
-export function generateRustFunction(cell) {
+export function generateRustFunction(cell, invokedMacros = scanRustMacroInvocations(cell.source, cell)) {
   const inputBindings = cell.inputs.map((input) => `    ${generateRustInputBinding(input)}`).join('\n');
   const escapedSource = indentRustSource(cell.source);
-  const macros = generateRustPreludeMacros(cell.source);
+  const macros = generateRustPreludeMacros(cell.source, invokedMacros);
   const inputsParameter = cell.inputs.length > 0 ? 'inputs' : '_inputs';
 
   return `fn ${rustFunctionName(cell.id)}(${inputsParameter}: &Value) -> Result<CellOutput, String> {

--- a/packages/oxiquill/src/generator/doc-runtime/rust-codegen/lib.mjs
+++ b/packages/oxiquill/src/generator/doc-runtime/rust-codegen/lib.mjs
@@ -1,5 +1,7 @@
 import { generateRustReaders } from '../rust-readers.mjs';
 import { rustFunctionName } from '../rust-identifiers.mjs';
+import { scanRustMacroInvocations } from './macro-invocations.mjs';
+import { rustOutputCapabilities } from './capabilities.mjs';
 import { generatedBanner } from './banners.mjs';
 import { generateRustFunction, generateRustTests } from './functions.mjs';
 import { generateRustOutputTypes } from './output-types.mjs';
@@ -29,10 +31,11 @@ ${matchArms}
     serialize_cell_output(output).map_err(to_js_error)
 }`;
 
-  const functions = rustCells.map(generateRustFunction).join('\n\n');
+  const macroSets = rustCells.map((cell) => scanRustMacroInvocations(cell.source, cell));
+  const functions = rustCells.map((cell, index) => generateRustFunction(cell, macroSets[index])).join('\n\n');
   const tests = generateRustTests(rustCells);
   const readers = generateRustReaders(rustCells);
-  const outputTypes = generateRustOutputTypes(rustCells);
+  const outputTypes = generateRustOutputTypes(rustCells, rustOutputCapabilities(rustCells, macroSets));
   const serdeImport = rustCells.length === 0 ? '' : 'use serde::Serialize;\n';
   const jsErrorMessage =
     rustCells.length === 0

--- a/packages/oxiquill/src/generator/doc-runtime/rust-codegen/macro-invocations.mjs
+++ b/packages/oxiquill/src/generator/doc-runtime/rust-codegen/macro-invocations.mjs
@@ -1,0 +1,145 @@
+const identifierStart = /[_\p{XID_Start}]/u;
+const identifierContinue = /\p{XID_Continue}/u;
+const whitespace = /\p{Pattern_White_Space}/u;
+
+// A capability scan, not a parser: visit each token once without expanding macros.
+export function scanRustMacroInvocations(source, cell) {
+  const macros = new Set();
+  let identifier;
+  let index = 0;
+
+  while (index < source.length) {
+    const character = codePointAt(source, index);
+    if (whitespace.test(character)) {
+      index += character.length;
+    } else if (source.startsWith('//', index)) {
+      const newline = source.indexOf('\n', index + 2);
+      index = newline < 0 ? source.length : newline + 1;
+    } else if (source.startsWith('/*', index)) {
+      index = skipBlockComment(source, index, cell);
+    } else if (character === '"') {
+      index = skipString(source, index, cell);
+      identifier = undefined;
+    } else if (character === "'") {
+      index = skipCharacterOrLifetime(source, index, cell);
+      identifier = undefined;
+    } else if (identifierContinue.test(character)) {
+      const start = index;
+      index = identifierEnd(source, index);
+      const name = source.slice(start, index);
+      identifier = identifierStart.test(character) ? name : undefined;
+
+      if (['r', 'br', 'cr'].includes(name)) {
+        let quote = index;
+        while (source[quote] === '#') quote += 1;
+        if (source[quote] === '"') {
+          index = skipRawString(source, start, quote, quote - index, cell);
+          identifier = undefined;
+        } else if (name === 'r' && source[index] === '#' && identifierStart.test(codePointAt(source, index + 1))) {
+          const rawStart = index + 1;
+          index = identifierEnd(source, rawStart);
+          identifier = source.slice(rawStart, index);
+        }
+      } else if (name === 'b' && source[index] === "'") {
+        index = skipCharacterOrLifetime(source, index, cell, true);
+        identifier = undefined;
+      }
+    } else {
+      if (character === '!' && source[index + 1] !== '=' && identifier) macros.add(identifier);
+      identifier = undefined;
+      index += character.length;
+    }
+  }
+
+  return macros;
+}
+
+function codePointAt(source, index) {
+  const point = source.codePointAt(index);
+  return point === undefined ? '' : String.fromCodePoint(point);
+}
+
+function identifierEnd(source, start) {
+  let index = start;
+  while (index < source.length) {
+    const character = codePointAt(source, index);
+    if (!identifierContinue.test(character)) break;
+    index += character.length;
+  }
+  return index;
+}
+
+function skipBlockComment(source, start, cell) {
+  let depth = 1;
+  let index = start + 2;
+  while (index < source.length) {
+    if (source.startsWith('/*', index)) {
+      depth += 1;
+      index += 2;
+    } else if (source.startsWith('*/', index)) {
+      depth -= 1;
+      index += 2;
+      if (depth === 0) return index;
+    } else {
+      index += 1;
+    }
+  }
+  throw unterminated(source, start, 'block comment', cell);
+}
+
+function skipString(source, start, cell) {
+  let index = start + 1;
+  while (index < source.length) {
+    if (source[index] === '"') return index + 1;
+    index += source[index] === '\\' ? 2 : 1;
+  }
+  throw unterminated(source, start, 'string literal', cell);
+}
+
+function skipRawString(source, start, quote, hashes, cell) {
+  let index = quote + 1;
+  while (index < source.length) {
+    if (source[index] !== '"') {
+      index += 1;
+      continue;
+    }
+    index += 1;
+    let closingHashes = 0;
+    while (closingHashes < hashes && source[index] === '#') {
+      closingHashes += 1;
+      index += 1;
+    }
+    if (closingHashes === hashes) return index;
+  }
+  throw unterminated(source, start, 'raw string literal', cell);
+}
+
+function skipCharacterOrLifetime(source, start, cell, byte = false) {
+  let index = start + 1;
+  if (source[index] === '\\') {
+    index += 1;
+    if (source[index] === 'u' && source[index + 1] === '{') {
+      index += 2;
+      while (/[\da-fA-F_]/u.test(source[index] ?? '')) index += 1;
+      if (source[index] === '}') index += 1;
+    } else {
+      index += source[index] === 'x' ? 3 : 1;
+    }
+  } else {
+    index += codePointAt(source, index).length;
+  }
+  if (source[index] === "'") return index + 1;
+  if (!byte && identifierStart.test(codePointAt(source, start + 1))) {
+    const raw = source.startsWith('r#', start + 1) && identifierStart.test(codePointAt(source, start + 3));
+    return identifierEnd(source, start + (raw ? 3 : 1));
+  }
+  throw unterminated(source, start, byte ? 'byte character literal' : 'character literal', cell);
+}
+
+function unterminated(source, start, kind, cell) {
+  const lines = source.slice(0, start).split('\n');
+  const context = cell ? `Rust cell "${cell.id}"${cell.pagePath ? ` in ${cell.pagePath}` : ''}` : 'Rust source';
+  return new Error(
+    `${context} has an unterminated ${kind} at line ${lines.length}, column ${Array.from(lines.at(-1)).length + 1}.`
+  );
+}

--- a/packages/oxiquill/src/generator/doc-runtime/rust-codegen/macros.mjs
+++ b/packages/oxiquill/src/generator/doc-runtime/rust-codegen/macros.mjs
@@ -1,28 +1,29 @@
-import { hasAnyToken } from './capabilities.mjs';
+import { scanRustMacroInvocations } from './macro-invocations.mjs';
+import { hasAnyMacro } from './capabilities.mjs';
 
 const macroDescriptors = [
-  [['println!'], generatePrintlnMacro],
-  [['emit_text!'], generateTextMacro],
-  [['emit_json!'], generateJsonMacro],
-  [['emit_html!'], generateHtmlMacro],
-  [['emit_image_svg!', 'emit_svg!'], generateImageSvgMacro],
-  [['emit_image_png!', 'emit_png_base64!'], generateImagePngMacro],
-  [['emit_svg!'], generateSvgMacro],
-  [['emit_png_base64!'], generatePngBase64Macro],
-  [['emit_table!'], generateTableMacro],
-  [['emit_table_with_columns!'], generateTableWithColumnsMacro],
-  [['emit_records_table!'], generateRecordsTableMacro],
-  [['emit_line_chart!'], generateLineChartMacro],
-  [['emit_scatter_chart!'], generateScatterChartMacro],
-  [['emit_bar_chart!'], generateBarChartMacro],
-  [['emit_histogram!'], generateHistogramMacro],
-  [['emit_heatmap!'], generateHeatmapMacro],
-  [['emit_line_plot!'], generateLinePlotMacro]
+  [['println'], generatePrintlnMacro],
+  [['emit_text'], generateTextMacro],
+  [['emit_json'], generateJsonMacro],
+  [['emit_html'], generateHtmlMacro],
+  [['emit_image_svg', 'emit_svg'], generateImageSvgMacro],
+  [['emit_image_png', 'emit_png_base64'], generateImagePngMacro],
+  [['emit_svg'], generateSvgMacro],
+  [['emit_png_base64'], generatePngBase64Macro],
+  [['emit_table'], generateTableMacro],
+  [['emit_table_with_columns'], generateTableWithColumnsMacro],
+  [['emit_records_table'], generateRecordsTableMacro],
+  [['emit_line_chart'], generateLineChartMacro],
+  [['emit_scatter_chart'], generateScatterChartMacro],
+  [['emit_bar_chart'], generateBarChartMacro],
+  [['emit_histogram'], generateHistogramMacro],
+  [['emit_heatmap'], generateHeatmapMacro],
+  [['emit_line_plot'], generateLinePlotMacro]
 ];
 
-export function generateRustPreludeMacros(source) {
+export function generateRustPreludeMacros(source, macros = scanRustMacroInvocations(source)) {
   return macroDescriptors
-    .filter(([tokens]) => hasAnyToken(source, tokens))
+    .filter(([tokens]) => hasAnyMacro(macros, tokens))
     .map(([, generate]) => generate())
     .join('\n\n');
 }

--- a/packages/oxiquill/src/generator/doc-runtime/rust-codegen/macros.mjs
+++ b/packages/oxiquill/src/generator/doc-runtime/rust-codegen/macros.mjs
@@ -30,9 +30,10 @@ export function generateRustPreludeMacros(source, macros = scanRustMacroInvocati
 
 function generatePrintlnMacro() {
   return `    macro_rules! println {
-        () => {
-            __stdout.borrow_mut().push('\\n');
-        };
+        () => {{
+            use std::fmt::Write as _;
+            writeln!(&mut *__stdout.borrow_mut()).map_err(|error| error.to_string())?;
+        }};
         ($($arg:tt)*) => {{
             use std::fmt::Write as _;
             let mut stdout = __stdout.borrow_mut();

--- a/packages/oxiquill/src/generator/doc-runtime/rust-codegen/output-types.mjs
+++ b/packages/oxiquill/src/generator/doc-runtime/rust-codegen/output-types.mjs
@@ -2,10 +2,9 @@ import { rustOutputCapabilities } from './capabilities.mjs';
 import { generateRustChartHelpers } from './chart-helpers.mjs';
 import { outputArtifactLimits } from '../../../lib/doc-runtime/output-limits.mjs';
 
-export function generateRustOutputTypes(rustCells) {
+export function generateRustOutputTypes(rustCells, capabilities = rustOutputCapabilities(rustCells)) {
   if (rustCells.length === 0) return '';
 
-  const capabilities = rustOutputCapabilities(rustCells);
   const outputVariants = [
     `    #[serde(rename = "__oxiquill_error")]
     ProducerError(ProducerErrorArtifact),`,

--- a/tests/e2e/dev-hmr-smoke.mjs
+++ b/tests/e2e/dev-hmr-smoke.mjs
@@ -5,6 +5,7 @@ import { cpSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:f
 import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { observeProcess } from './process-output.mjs';
 
 const repoRoot = path.resolve(fileURLToPath(new URL('../..', import.meta.url)));
 const tempRoot = mkdtempSync(path.join(os.tmpdir(), 'oxiquill-dev-hmr-'));
@@ -18,20 +19,25 @@ try {
   disableDevToolbar();
   await runCommand('install', 'pnpm', ['install', '--offline', '--frozen-lockfile', '--ignore-scripts'], tempRoot);
 
+  await runCommand('build', 'pnpm', ['build:package'], tempRoot);
+
   const port = await availablePort();
   const runtime = startProcess(
     'runtime',
     process.execPath,
-    [path.join(tempRoot, 'packages/oxiquill/src/generator/watch-doc-runtime.mjs'), '--skip-initial'],
+    [path.join(tempRoot, 'packages/oxiquill/dist/generator/watch-doc-runtime.mjs')],
     tempSiteRoot
   );
-  await waitForOutput(runtime, '[runtime] watching MDX and Rust sources', 60_000);
+  await Promise.all([
+    runtime.waitForOutput(/^\[runtime\] watching .+$/mu, 60_000),
+    runtime.waitForOutput('[runtime] ready:', 300_000)
+  ]);
 
-  startProcess(
+  const astro = startProcess(
     'astro',
     process.execPath,
     [
-      path.join(tempRoot, 'packages/oxiquill/src/cli/index.mjs'),
+      path.join(tempRoot, 'packages/oxiquill/dist/cli/index.mjs'),
       'dev:astro',
       '--host',
       '127.0.0.1',
@@ -40,27 +46,34 @@ try {
     ],
     tempSiteRoot
   );
-  await waitForHttp(`http://127.0.0.1:${port}/features/interactive-cells/`, 60_000);
+  await waitForHttp(`http://127.0.0.1:${port}/features/interactive-cells/`, 60_000, [runtime, astro]);
 
   browser = await chromium.launch({
     ...(chromiumExecutablePath ? { executablePath: chromiumExecutablePath } : {}),
     args: ['--disable-setuid-sandbox', '--no-sandbox']
   });
   const page = await browser.newPage();
+  const browserErrors = [];
   page.on('console', (message) => {
     if (['error', 'warning'].includes(message.type())) {
-      console.log(`[browser:${message.type()}] ${message.text()}`);
+      const diagnostic = `${message.text()} ${JSON.stringify(message.location())}`;
+      console.log(`[browser:${message.type()}] ${diagnostic}`);
+      if (message.type() === 'error') browserErrors.push(diagnostic);
     }
   });
   page.on('pageerror', (error) => {
-    console.log(`[browser:pageerror] ${error.message}`);
+    const diagnostic = error.stack ?? error.message;
+    console.log(`[browser:pageerror] ${diagnostic}`);
+    browserErrors.push(diagnostic);
   });
   await page.goto(`http://127.0.0.1:${port}/features/interactive-cells/`);
 
   const cell = page.getByTestId('cell-features__interactive-cells__python-controls');
+  await cell.scrollIntoViewIfNeeded();
   const source = cell.getByTestId('cell-source');
   const output = cell.getByTestId('run-output');
-  await expect(source).toContainText('values = [', { timeout: 45_000 });
+  await expect(source).toContainText('values = [1, 2, 3, 4]', { timeout: 45_000 });
+  await expect(output).toContainText('SAMPLE: mean = 7.5', { timeout: 60_000 });
 
   const mdxPath = path.join(tempSiteRoot, 'content/docs/features/interactive-cells.mdx');
   const before = readFileSync(mdxPath, 'utf8');
@@ -75,20 +88,45 @@ try {
 
   const stableUntil = Date.now() + 3_000;
   while (Date.now() < stableUntil) {
+    runtime.assertRunning();
+    astro.assertRunning();
+    expect(browserErrors, 'Browser console and page errors').toEqual([]);
     await expect(source).toContainText('values = [10, 20, 30, 40]');
     await expect(output).toContainText('SAMPLE: mean = 75.0');
     await page.waitForTimeout(250);
   }
 
+  expect(browserErrors, 'Browser console and page errors').toEqual([]);
   console.log(`Dev HMR source refresh verified at http://127.0.0.1:${port}/features/interactive-cells/`);
 } finally {
-  if (browser) await browser.close();
-  await stopChildren();
-  rmSync(tempRoot, { force: true, recursive: true });
+  try {
+    if (browser) await browser.close();
+  } finally {
+    try {
+      await stopChildren();
+    } finally {
+      rmSync(tempRoot, { force: true, recursive: true, maxRetries: 10, retryDelay: 250 });
+    }
+  }
 }
 
 function copyWorkspace(sourceRoot, targetRoot) {
-  const ignored = new Set(['.astro', '.git', 'coverage', 'dist', 'node_modules', 'target', 'test-results']);
+  const ignored = new Set([
+    '.astro',
+    '.git',
+    '.cache',
+    '.oxiquill',
+    '.codex',
+    '.direnv',
+    '.agents',
+    '.serena',
+    'coverage',
+    'dist',
+    'node_modules',
+    'target',
+    'test-results',
+    'playwright-report'
+  ]);
 
   cpSync(sourceRoot, targetRoot, {
     dereference: false,
@@ -96,7 +134,10 @@ function copyWorkspace(sourceRoot, targetRoot) {
       const relativePath = path.relative(sourceRoot, sourcePath);
       if (!relativePath) return true;
 
-      return relativePath.split(path.sep).every((segment) => !ignored.has(segment));
+      const segments = relativePath.split(path.sep);
+      return segments.every(
+        (segment, index) => !ignored.has(segment) && !(segment === 'oxiquill' && segments[index - 1] === 'public')
+      );
     },
     recursive: true
   });
@@ -121,33 +162,25 @@ function startProcess(label, command, args, cwd) {
   const child = spawn(command, args, {
     cwd,
     detached: true,
-    env: { ...process.env, NODE_PATH: path.join(tempRoot, 'packages/oxiquill/node_modules') },
+    env: {
+      ...process.env,
+      // Keep Astro in our process group even when it detects an agent environment.
+      ASTRO_DEV_BACKGROUND: '0',
+      ASTRO_TELEMETRY_DISABLED: '1',
+      NODE_PATH: path.join(tempRoot, 'packages/oxiquill/node_modules')
+    },
     stdio: ['ignore', 'pipe', 'pipe']
   });
   children.add(child);
 
-  child.stdout.setEncoding('utf8');
-  child.stderr.setEncoding('utf8');
+  const observed = observeProcess(child, label);
   child.stdout.on('data', (chunk) => process.stdout.write(prefixLines(label, chunk)));
   child.stderr.on('data', (chunk) => process.stderr.write(prefixLines(label, chunk)));
-  child.on('exit', () => children.delete(child));
-
-  return child;
+  return observed;
 }
 
 async function runCommand(label, command, args, cwd) {
-  const child = startProcess(label, command, args, cwd);
-
-  await new Promise((resolve, reject) => {
-    child.on('exit', (code, signal) => {
-      if (code === 0) {
-        resolve();
-      } else {
-        reject(new Error(`${label} exited with ${signal ?? code}`));
-      }
-    });
-    child.on('error', reject);
-  });
+  await startProcess(label, command, args, cwd).waitForExit();
 }
 
 function prefixLines(label, chunk) {
@@ -158,50 +191,21 @@ function prefixLines(label, chunk) {
 }
 
 function stopProcessGroup(child, signal) {
+  if (!child.pid) return false;
   try {
     process.kill(-child.pid, signal);
+    return true;
   } catch (error) {
     if (error?.code !== 'ESRCH') throw error;
+    return false;
   }
 }
 
-async function waitForOutput(child, expected, timeoutMs) {
-  let buffered = '';
-
-  await new Promise((resolve, reject) => {
-    const timeout = setTimeout(() => {
-      cleanup();
-      reject(new Error(`Timed out waiting for output: ${expected}`));
-    }, timeoutMs);
-
-    const onData = (chunk) => {
-      buffered += String(chunk);
-      if (buffered.includes(expected)) {
-        cleanup();
-        resolve();
-      }
-    };
-    const onExit = (code, signal) => {
-      cleanup();
-      reject(new Error(`Process exited before "${expected}": ${signal ?? code}`));
-    };
-    const cleanup = () => {
-      clearTimeout(timeout);
-      child.stdout.off('data', onData);
-      child.stderr.off('data', onData);
-      child.off('exit', onExit);
-    };
-
-    child.stdout.on('data', onData);
-    child.stderr.on('data', onData);
-    child.on('exit', onExit);
-  });
-}
-
-async function waitForHttp(url, timeoutMs) {
+async function waitForHttp(url, timeoutMs, processes) {
   const startedAt = Date.now();
 
   while (Date.now() - startedAt < timeoutMs) {
+    processes.forEach((process) => process.assertRunning());
     try {
       const response = await fetch(url);
       if (response.ok) return;
@@ -234,27 +238,16 @@ async function availablePort() {
 }
 
 async function stopChildren() {
-  await Promise.all(
-    Array.from(
-      children,
-      (child) =>
-        new Promise((resolve) => {
-          if (child.exitCode !== null || child.signalCode !== null) {
-            resolve();
-            return;
-          }
-
-          const timeout = setTimeout(() => {
-            if (child.exitCode === null && child.signalCode === null) stopProcessGroup(child, 'SIGKILL');
-          }, 5_000);
-          timeout.unref();
-
-          child.once('exit', () => {
-            clearTimeout(timeout);
-            resolve();
-          });
-          stopProcessGroup(child, 'SIGTERM');
-        })
-    )
+  const results = await Promise.allSettled(
+    Array.from(children, async (child) => {
+      if (!stopProcessGroup(child, 'SIGTERM')) return;
+      const deadline = Date.now() + 5_000;
+      while (stopProcessGroup(child, 0) && Date.now() < deadline) {
+        await new Promise((resolve) => setTimeout(resolve, 50));
+      }
+      stopProcessGroup(child, 'SIGKILL');
+    })
   );
+  const failures = results.filter((result) => result.status === 'rejected').map((result) => result.reason);
+  if (failures.length) throw new AggregateError(failures, 'Could not stop dev HMR process groups');
 }

--- a/tests/e2e/process-output.mjs
+++ b/tests/e2e/process-output.mjs
@@ -1,0 +1,86 @@
+import { EventEmitter } from 'node:events';
+
+// Attach immediately after spawn so output and failures survive late waiter registration.
+export function observeProcess(child, label) {
+  const changes = new EventEmitter();
+  let output = '';
+  let failure;
+  let exited = child.exitCode !== null || child.signalCode !== null;
+  let exitStatus = child.signalCode ?? child.exitCode;
+
+  const record = (chunk) => {
+    output += String(chunk);
+    changes.emit('change');
+  };
+  child.stdout.setEncoding('utf8');
+  child.stderr.setEncoding('utf8');
+  child.stdout.on('data', record);
+  child.stderr.on('data', record);
+  child.on('error', (error) => {
+    failure = error;
+    changes.emit('change');
+  });
+  child.on('exit', (code, signal) => {
+    exited = true;
+    exitStatus = signal ?? code;
+    changes.emit('change');
+  });
+
+  const diagnostic = (message) => new Error(`${label}: ${message}\n${output.slice(-12_000)}`, { cause: failure });
+  const assertRunning = () => {
+    if (failure) throw diagnostic(`failed to start: ${failure.message}`);
+    if (exited) throw diagnostic(`exited with ${exitStatus}`);
+  };
+
+  function waitUntil(check, expected, timeoutMs) {
+    return new Promise((resolve, reject) => {
+      let timeout;
+      const cleanup = () => {
+        clearTimeout(timeout);
+        changes.off('change', inspect);
+      };
+      const inspect = () => {
+        try {
+          if (!check()) return;
+          cleanup();
+          resolve();
+        } catch (error) {
+          cleanup();
+          reject(error);
+        }
+      };
+      if (timeoutMs !== undefined) {
+        timeout = setTimeout(() => {
+          cleanup();
+          reject(diagnostic(`timed out waiting for ${expected}`));
+        }, timeoutMs);
+      }
+      changes.on('change', inspect);
+      inspect();
+    });
+  }
+
+  return {
+    assertRunning,
+    waitForOutput(expected, timeoutMs) {
+      const matches =
+        expected instanceof RegExp
+          ? () => new RegExp(expected.source, expected.flags).test(output)
+          : () => output.includes(expected);
+      return waitUntil(
+        () => {
+          assertRunning();
+          return matches();
+        },
+        String(expected),
+        timeoutMs
+      );
+    },
+    waitForExit() {
+      return waitUntil(() => {
+        if (failure || (exited && exitStatus !== 0)) assertRunning();
+        return exited;
+      }, 'successful exit');
+    }
+  };
+}

--- a/tests/fixtures/rust-codegen/content/docs/index.mdx
+++ b/tests/fixtures/rust-codegen/content/docs/index.mdx
@@ -8,3 +8,46 @@ println /* trivia */ ! ("spaced output");
 emit_json ! (&serde_json::json!({ "ok": true }));
 emit_svg /* wrapper dependency */ ! (r#"<svg xmlns="http://www.w3.org/2000/svg"/>"#);
 ```
+
+```rust
+//| id: colliding-locals
+fn author_label() -> &'static str { "author value" }
+macro_rules! author_number { () => { 42 }; }
+let __stdout = author_label();
+let __outputs = author_number!();
+for value in [__outputs] {
+    println!("{__stdout}:{value}");
+}
+println!();
+emit_json!(&serde_json::json!({ "label": __stdout, "number": __outputs }));
+Ok::<_, String>(123)
+```
+
+```rust
+//| id: inputs-and-question-mark
+//| inputs:
+//|   label: { type: text, label: label, value: input }
+//|   fail: { type: checkbox, label: fail, value: false }
+fn author_number(fail: bool) -> Result<i32, String> {
+    if fail { Err("question mark failure".to_owned()) } else { Ok(42) }
+}
+let __stdout = label;
+let __outputs = author_number(fail)?;
+println!("{__stdout}:{__outputs}");
+emit_text!(format!("{__stdout}:{__outputs}"));
+```
+
+```rust
+//| id: early-return
+//| inputs:
+//|   early: { type: checkbox, label: early return, value: false }
+if early {
+    return Ok(CellOutput {
+        stdout: "early return".to_owned(),
+        plots: Vec::new(),
+        value: serde_json::Value::Null,
+        outputs: Vec::new(),
+    });
+}
+println!("normal return");
+```

--- a/tests/fixtures/rust-codegen/content/docs/index.mdx
+++ b/tests/fixtures/rust-codegen/content/docs/index.mdx
@@ -1,0 +1,10 @@
+---
+title: Rust code generation regressions
+---
+
+```rust
+//| id: spaced-macros
+println /* trivia */ ! ("spaced output");
+emit_json ! (&serde_json::json!({ "ok": true }));
+emit_svg /* wrapper dependency */ ! (r#"<svg xmlns="http://www.w3.org/2000/svg"/>"#);
+```

--- a/tests/runtime/rust-codegen-smoke.mjs
+++ b/tests/runtime/rust-codegen-smoke.mjs
@@ -19,15 +19,44 @@ try {
   const runtime = await import(pathToFileURL(path.join(paths.rustWasmPublicDir, 'doc_rust_cells.js')).href);
   runtime.initSync({ module: await readFile(path.join(paths.rustWasmPublicDir, 'doc_rust_cells_bg.wasm')) });
   const manifest = JSON.parse(await readFile(paths.cellsJsonPath, 'utf8'));
-  const cell = manifest.find((entry) => entry.id.endsWith('__spaced-macros'));
-  assert.ok(cell, 'spaced invocation fixture must be generated');
-  const output = JSON.parse(runtime.run_rust_cell(cell.id, '{}'));
+  const run = (name, inputs = {}) => {
+    const cell = manifest.find((entry) => entry.id.endsWith(`__${name}`));
+    assert.ok(cell, `${name} fixture must be generated`);
+    return JSON.parse(runtime.run_rust_cell(cell.id, JSON.stringify(inputs)));
+  };
+  const output = run('spaced-macros');
   assert.equal(output.stdout, 'spaced output\n');
   assert.deepEqual(output.outputs.find((artifact) => artifact.kind === 'json')?.value, { ok: true });
   assert.equal(
     output.outputs.find((artifact) => artifact.kind === 'image')?.data,
     '<svg xmlns="http://www.w3.org/2000/svg"/>'
   );
+
+  const collision = run('colliding-locals');
+  assert.equal(collision.stdout, 'author value:42\n\n');
+  assert.deepEqual(collision.outputs, [
+    { kind: 'text', stream: 'stdout', content: 'author value:42\n\n', truncated: false },
+    { kind: 'json', value: { label: 'author value', number: 42 }, truncated: false }
+  ]);
+  const inputs = run('inputs-and-question-mark', { label: 'custom input', fail: false });
+  assert.equal(inputs.stdout, 'custom input:42\n');
+  assert.deepEqual(inputs.outputs.at(-1), {
+    kind: 'text',
+    stream: 'display',
+    content: 'custom input:42',
+    truncated: false
+  });
+  assert.throws(
+    () => run('inputs-and-question-mark', { label: 'input', fail: true }),
+    (error) => error === 'question mark failure'
+  );
+  assert.equal(run('early-return', { early: false }).stdout, 'normal return\n');
+  assert.deepEqual(run('early-return', { early: true }), {
+    stdout: 'early return',
+    plots: [],
+    value: null,
+    outputs: []
+  });
   console.log('Generated Rust/Wasm code generation regressions passed.');
 } finally {
   await rm(workspaceRoot, { recursive: true, force: true });

--- a/tests/runtime/rust-codegen-smoke.mjs
+++ b/tests/runtime/rust-codegen-smoke.mjs
@@ -1,0 +1,34 @@
+import assert from 'node:assert/strict';
+import { cp, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { runCli } from '../../packages/oxiquill/dist/cli/commands.mjs';
+import { createOxiquillPaths } from '../../packages/oxiquill/dist/config/paths.mjs';
+
+const workspaceRoot = await mkdtemp(path.join(tmpdir(), 'oxiquill-rust-codegen-'));
+const paths = createOxiquillPaths({ workspaceRoot });
+
+try {
+  await cp(new URL('../fixtures/rust-codegen/', import.meta.url), workspaceRoot, { recursive: true });
+  await writeFile(path.join(workspaceRoot, 'package.json'), JSON.stringify({ private: true, type: 'module' }));
+  await runCli(['test-wasm'], {
+    cwd: workspaceRoot,
+    loadProjectConfig: async () => ({ astroConfigArgs: [], cwd: workspaceRoot, paths })
+  });
+  const runtime = await import(pathToFileURL(path.join(paths.rustWasmPublicDir, 'doc_rust_cells.js')).href);
+  runtime.initSync({ module: await readFile(path.join(paths.rustWasmPublicDir, 'doc_rust_cells_bg.wasm')) });
+  const manifest = JSON.parse(await readFile(paths.cellsJsonPath, 'utf8'));
+  const cell = manifest.find((entry) => entry.id.endsWith('__spaced-macros'));
+  assert.ok(cell, 'spaced invocation fixture must be generated');
+  const output = JSON.parse(runtime.run_rust_cell(cell.id, '{}'));
+  assert.equal(output.stdout, 'spaced output\n');
+  assert.deepEqual(output.outputs.find((artifact) => artifact.kind === 'json')?.value, { ok: true });
+  assert.equal(
+    output.outputs.find((artifact) => artifact.kind === 'image')?.data,
+    '<svg xmlns="http://www.w3.org/2000/svg"/>'
+  );
+  console.log('Generated Rust/Wasm code generation regressions passed.');
+} finally {
+  await rm(workspaceRoot, { recursive: true, force: true });
+}

--- a/tests/unit/doc-runtime-core.test.mjs
+++ b/tests/unit/doc-runtime-core.test.mjs
@@ -181,6 +181,32 @@ describe('Rust macro invocation scanning', () => {
   });
 });
 
+describe('Rust cell author scope', () => {
+  it('keeps inputs and author bindings inside a discarded block after macro definitions', () => {
+    const source =
+      'let __stdout = label;\nlet __outputs = 42;\nprintln!("{__stdout}:{__outputs}");\nemit_text!(__stdout);\n42';
+    const generated = generateRustFunction({
+      id: 'scope',
+      inputs: [{ name: 'label', type: 'text' }],
+      source
+    });
+    const block = generated.indexOf('    let _ = {');
+    expect(generated.indexOf('let __stdout = std::cell::RefCell')).toBeLessThan(block);
+    expect(generated.indexOf('let __outputs = std::cell::RefCell')).toBeLessThan(block);
+    expect(generated.indexOf('macro_rules! println')).toBeLessThan(block);
+    expect(generated.indexOf('macro_rules! emit_text')).toBeLessThan(block);
+    expect(generated.slice(block)).toContain('        let label = read_string(inputs, "label")?;');
+    expect(generated.slice(block)).toContain(
+      source
+        .split('\n')
+        .map((line) => `        ${line}`)
+        .join('\n')
+    );
+    expect(generated).toContain('        42\n    };\n\n    Ok(finish_cell_output(');
+    expect(generated.slice(generated.indexOf('    Ok(finish_cell_output('))).toContain('__stdout.into_inner()');
+  });
+});
+
 const helperCrates = new Map([
   ['doc-rust', { name: 'doc-rust', relativePath: '../../crates/doc-rust' }],
   ['doc-rust-text', { name: 'doc-rust-text', relativePath: '../../crates/doc-rust-text' }]

--- a/tests/unit/doc-runtime-core.test.mjs
+++ b/tests/unit/doc-runtime-core.test.mjs
@@ -6,7 +6,11 @@ import {
   relativePagePath,
   scopedCellId
 } from '../../packages/oxiquill/src/lib/doc-runtime/authoring-ids.mjs';
-import { rustSourceCapabilities } from '../../packages/oxiquill/src/generator/doc-runtime/rust-codegen/capabilities.mjs';
+import { scanRustMacroInvocations } from '../../packages/oxiquill/src/generator/doc-runtime/rust-codegen/macro-invocations.mjs';
+import {
+  rustOutputCapabilities,
+  rustSourceCapabilities
+} from '../../packages/oxiquill/src/generator/doc-runtime/rust-codegen/capabilities.mjs';
 import { generateRustPreludeMacros } from '../../packages/oxiquill/src/generator/doc-runtime/rust-codegen/macros.mjs';
 import {
   assertUniqueCellIds,
@@ -46,6 +50,136 @@ const { parse: parseToml } = requireFromPackage('smol-toml');
 const highlighter = {
   codeToHtml: (source, options) => Promise.resolve(`<pre data-lang="${options.lang}">${source}</pre>`)
 };
+
+describe('Rust macro invocation scanning', () => {
+  const families = [
+    ['println', [], []],
+    ['emit_text', ['text'], []],
+    ['emit_json', ['json'], []],
+    ['emit_html', ['html'], []],
+    ['emit_image_svg', ['image'], []],
+    ['emit_image_png', ['image'], []],
+    ['emit_svg', ['image'], ['emit_image_svg']],
+    ['emit_png_base64', ['image'], ['emit_image_png']],
+    ['emit_table', ['table'], []],
+    ['emit_table_with_columns', ['table'], []],
+    ['emit_records_table', ['table'], []],
+    ['emit_line_plot', ['chart', 'legacyPlot'], []],
+    ['emit_line_chart', ['chart', 'lineChart'], []],
+    ['emit_scatter_chart', ['chart', 'scatterChart'], []],
+    ['emit_bar_chart', ['chart', 'barChart'], []],
+    ['emit_histogram', ['chart', 'histogramChart'], []],
+    ['emit_heatmap', ['chart', 'heatmapChart'], []]
+  ];
+  const empty = rustSourceCapabilities('');
+  const declarations = (source) =>
+    [...generateRustPreludeMacros(source).matchAll(/macro_rules! (\w+)/gu)].map((match) => match[1]).sort();
+
+  describe.each(families)('%s', (name, capabilities, dependencies) => {
+    it.each(['', ' ', '\n\t', '/**/', ' /* outer /* nested */ comment */\n// trivia\n'])(
+      'accepts trivia %j',
+      (trivia) => {
+        const source = `${name}${trivia}!(&value);`;
+        expect(rustSourceCapabilities(source)).toEqual({
+          ...empty,
+          ...Object.fromEntries(capabilities.map((key) => [key, true]))
+        });
+        expect(declarations(source)).toEqual([name, ...dependencies].sort());
+      }
+    );
+
+    it.each([
+      ['line comment', (call) => `// ${call}`],
+      ['nested block comment', (call) => `/* outside /* ${call} */ ${call} */`],
+      ['string', (call) => `let s = "${call}";`],
+      ['escaped string', (call) => `let s = "\\"${call}\\\\";`],
+      ['byte string', (call) => `let s = b"${call}";`],
+      ['raw string', (call) => `let s = r"${call}";`],
+      ['raw byte string', (call) => `let s = br###""# ${call} "##"###;`],
+      ['raw C string', (call) => `let s = cr##"${call}"##;`],
+      ['character and string', (call) => `let quote = '"'; let s = "${call}";`],
+      ['byte character and string', (call) => `let quote = b'"'; let s = b"${call}";`],
+      ['prefix identifier', (call) => `my_${call}`],
+      ['suffix identifier', () => `${name}_extra!(&value);`],
+      ['Unicode prefix', (call) => `変数${call}`],
+      ['Unicode suffix', () => `${name}変数!(&value);`],
+      ['numeric suffix', (call) => `1${call}`],
+      ['lifetime', () => `'${name} !`],
+      ['raw lifetime', () => `'r#${name} !`],
+      ['inequality', () => `${name} != value`],
+      ['intervening punctuation', () => `${name} + !value`]
+    ])('ignores %s', (_label, wrap) => {
+      const source = wrap(`${name}!(&value);`);
+      expect(rustSourceCapabilities(source)).toEqual(empty);
+      expect(declarations(source)).toEqual([]);
+    });
+  });
+
+  it.each([0, 1, 8, 255])('matches exactly %i raw string delimiters', (count) => {
+    const hashes = '#'.repeat(count);
+    const source = `r${hashes}"emit_json! ${count ? `"${hashes.slice(1)} emit_html!` : ''}"${hashes}; emit_text ! ("ok");`;
+    expect(scanRustMacroInvocations(source)).toEqual(new Set(['emit_text']));
+  });
+
+  it.each(["'a'", "b'!'", "'🦀'", String.raw`'\''`, String.raw`b'\x27'`, String.raw`'\u{1f980}'`, String.raw`'\\'`])(
+    'skips character %s without swallowing subsequent code',
+    (literal) => {
+      expect(scanRustMacroInvocations(`let c = ${literal}; emit_json /* trivia */ !(&value);`)).toEqual(
+        new Set(['emit_json'])
+      );
+    }
+  );
+
+  it('recognizes raw identifiers and Unicode macros without mistaking lifetimes or labels for calls', () => {
+    expect(
+      scanRustMacroInvocations("fn f<'a>(s: &'a str) { 'outer: loop { r#emit_json ! (s); 変数!(); break 'outer; } }")
+    ).toEqual(new Set(['emit_json', '変数']));
+  });
+
+  it('unions capabilities and declares wrappers and their dependencies once', () => {
+    const source = 'emit_svg!(); emit_svg !(); emit_image_svg!(); emit_json!(); emit_json !();';
+    expect(scanRustMacroInvocations(source)).toEqual(new Set(['emit_svg', 'emit_image_svg', 'emit_json']));
+    expect(declarations(source)).toEqual(['emit_image_svg', 'emit_json', 'emit_svg']);
+    expect(rustSourceCapabilities(source)).toEqual({ ...empty, image: true, json: true });
+    const cells = [
+      { id: 'first', inputs: [], source: '// emit_html!()' },
+      { id: 'second', inputs: [], source }
+    ];
+    expect(rustOutputCapabilities(cells)).toEqual({ ...empty, image: true, json: true });
+    const generated = generateRustLib(cells);
+    expect(generated).toContain('Json(JsonArtifact)');
+    expect(generated).toContain('Image(ImageArtifact)');
+    expect(generated).not.toContain('Html(HtmlArtifact)');
+    expect(generated.match(/macro_rules! emit_svg/gu)).toHaveLength(1);
+  });
+
+  it.each([
+    ['/* unfinished', 'block comment'],
+    ['/* outer /* nested */', 'block comment'],
+    ['"unfinished', 'string literal'],
+    ['b"unfinished\\', 'string literal'],
+    ['r"unfinished', 'raw string literal'],
+    ['br##"unfinished"#', 'raw string literal'],
+    [String.raw`'\x27`, 'character literal'],
+    ["b'x", 'byte character literal']
+  ])('reports unterminated %s with cell and source location', (source, kind) => {
+    const cell = { id: 'broken', pagePath: 'content/docs/broken.mdx', inputs: [], source: `\n${source}` };
+    expect(() => generateRustLib([cell])).toThrow(
+      `Rust cell "broken" in content/docs/broken.mdx has an unterminated ${kind} at line 2, column`
+    );
+    expect(() => generateRustFunction(cell)).toThrow('Rust cell "broken"');
+    expect(() => rustSourceCapabilities(source)).toThrow(`Rust source has an unterminated ${kind}`);
+  });
+
+  it('does not close lexical constructs using another cell source', () => {
+    expect(() =>
+      rustOutputCapabilities([
+        { id: 'one', source: '/*' },
+        { id: 'two', source: '*/ emit_json!();' }
+      ])
+    ).toThrow('Rust cell "one" has an unterminated block comment');
+  });
+});
 
 const helperCrates = new Map([
   ['doc-rust', { name: 'doc-rust', relativePath: '../../crates/doc-rust' }],

--- a/tests/unit/process-output.test.mjs
+++ b/tests/unit/process-output.test.mjs
@@ -1,0 +1,115 @@
+// @vitest-environment node
+
+import { EventEmitter } from 'node:events';
+import { PassThrough } from 'node:stream';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { observeProcess } from '../e2e/process-output.mjs';
+
+afterEach(() => vi.useRealTimers());
+
+function processDouble() {
+  return Object.assign(new EventEmitter(), {
+    stdout: new PassThrough(),
+    stderr: new PassThrough(),
+    exitCode: null,
+    signalCode: null
+  });
+}
+
+describe('buffered process output', () => {
+  it('retains both streams before a waiter is registered', async () => {
+    const child = processDouble();
+    const process = observeProcess(child, 'runtime');
+    child.stdout.write('[runtime] rea');
+    child.stderr.write('dy: 4 cells\n');
+    await expect(process.waitForOutput('[runtime] ready:', 100)).resolves.toBeUndefined();
+  });
+
+  it('matches future split chunks and multiple waiters', async () => {
+    vi.useFakeTimers();
+    const child = processDouble();
+    const process = observeProcess(child, 'runtime');
+    const ready = process.waitForOutput('[runtime] ready:', 100);
+    const watching = process.waitForOutput(/^\[runtime\] watching .+$/mu, 100);
+    child.stdout.write('[runtime] watching documentation and helper-crate inputs\n[runtime] re');
+    child.stdout.write('ady: 4 cells');
+    await expect(Promise.all([ready, watching])).resolves.toEqual([undefined, undefined]);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('does not depend on a language list or mutate a regular expression cursor', async () => {
+    const child = processDouble();
+    const process = observeProcess(child, 'runtime');
+    const matcher = /^\[runtime\] watching .+$/gmu;
+    matcher.lastIndex = 100;
+    child.stdout.write('[runtime] watching new language sources\n');
+    await process.waitForOutput(matcher, 100);
+    await process.waitForOutput(matcher, 100);
+    expect(matcher.lastIndex).toBe(100);
+  });
+
+  it.each([false, true])('fails promptly on watcher exit (before registration: %s)', async (before) => {
+    vi.useFakeTimers();
+    const child = processDouble();
+    const process = observeProcess(child, 'runtime');
+    child.stderr.write('compile failed\n');
+    if (before) child.emit('exit', 7, null);
+    const waiting = process.waitForOutput('ready', 60_000);
+    const assertion = expect(waiting).rejects.toThrow('runtime: exited with 7\ncompile failed');
+    if (!before) child.emit('exit', 7, null);
+    await assertion;
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('rejects an exited process even when its readiness output was buffered', async () => {
+    const child = processDouble();
+    const process = observeProcess(child, 'runtime');
+    child.stdout.write('ready');
+    child.emit('exit', null, 'SIGTERM');
+    await expect(process.waitForOutput('ready', 100)).rejects.toThrow('exited with SIGTERM');
+  });
+
+  it.each([false, true])('retains spawn errors (before registration: %s)', async (before) => {
+    const child = processDouble();
+    const process = observeProcess(child, 'runtime');
+    if (before) child.emit('error', new Error('ENOENT'));
+    const waiting = process.waitForOutput('ready', 100);
+    const assertion = expect(waiting).rejects.toThrow('runtime: failed to start: ENOENT');
+    if (!before) child.emit('error', new Error('ENOENT'));
+    await assertion;
+    await expect(process.waitForExit()).rejects.toThrow('ENOENT');
+  });
+
+  it('includes startup output and the expected matcher in timeout diagnostics', async () => {
+    vi.useFakeTimers();
+    const child = processDouble();
+    const process = observeProcess(child, 'runtime');
+    child.stdout.write('still compiling');
+    const waiting = process.waitForOutput(/ready/u, 100);
+    const assertion = expect(waiting).rejects.toThrow('runtime: timed out waiting for /ready/u\nstill compiling');
+    await vi.advanceTimersByTimeAsync(100);
+    await assertion;
+    expect(vi.getTimerCount()).toBe(0);
+    child.stdout.write('ready');
+    await process.waitForOutput('ready', 100);
+  });
+
+  it.each([false, true])('observes successful command exits (before registration: %s)', async (before) => {
+    const child = processDouble();
+    const process = observeProcess(child, 'install');
+    if (before) child.emit('exit', 0, null);
+    const waiting = process.waitForExit();
+    if (!before) child.emit('exit', 0, null);
+    await expect(waiting).resolves.toBeUndefined();
+  });
+
+  it('reports unsuccessful command exits with their output', async () => {
+    const child = processDouble();
+    const process = observeProcess(child, 'install');
+    child.stderr.write('missing package');
+    const waiting = process.waitForExit();
+    const assertion = expect(waiting).rejects.toThrow('install: exited with 1\nmissing package');
+    child.emit('exit', 1, null);
+    await assertion;
+  });
+});

--- a/tests/unit/release-workflow.test.mjs
+++ b/tests/unit/release-workflow.test.mjs
@@ -487,6 +487,60 @@ function assertDevHmrContract(fixture) {
 }
 
 describe('PR CI test contracts', () => {
+  const contracts = [
+    { command: 'test:docs', jobName: 'unit-coverage', after: 'test:unit:coverage' },
+    {
+      command: 'test:bundle',
+      jobName: 'runtime',
+      after: 'test:runtime',
+      condition: "matrix.label == 'Linux'",
+      immediatelyAfter: true
+    }
+  ];
+
+  describe.each(contracts)('$command', (contract) => {
+    it('runs once in the required job after its prerequisites and remains in pnpm test', async () => {
+      assertCiCommand(await readCiContracts(), contract);
+    });
+
+    it.each(['remove', 'relocate', 'duplicate', 'aggregate', 'order', 'condition', 'prerequisite'])(
+      'rejects contract drift: %s',
+      async (change) => {
+        const fixture = await readCiContracts();
+        const job = fixture.workflow.jobs[contract.jobName];
+        const index = job.steps.findIndex((step) => step.run === `pnpm ${contract.command}`);
+        const step = job.steps[index];
+        if (change === 'remove') job.steps.splice(index, 1);
+        if (change === 'relocate') fixture.workflow.jobs['packed-browser'].steps.push(...job.steps.splice(index, 1));
+        if (change === 'duplicate') job.steps.push({ ...step });
+        if (change === 'aggregate')
+          fixture.scripts.test = fixture.scripts.test.replace(`pnpm ${contract.command} && `, '');
+        if (change === 'order') job.steps.unshift(...job.steps.splice(index, 1));
+        if (change === 'condition') step.if = contract.condition ? undefined : 'false';
+        if (change === 'prerequisite') job.steps = job.steps.filter((step) => step.run !== `pnpm ${contract.after}`);
+        expect(() => assertCiCommand(fixture, contract)).toThrow();
+      }
+    );
+  });
+
+  it('requires the Linux condition on the bundle step itself', async () => {
+    const fixture = await readCiContracts();
+    const contract = contracts[1];
+    const steps = fixture.workflow.jobs.runtime.steps;
+    const index = steps.findIndex((step) => step.run === 'pnpm test:bundle');
+    steps[index - 1].if = steps[index].if;
+    delete steps[index].if;
+    expect(() => assertCiCommand(fixture, contract)).toThrow();
+  });
+
+  it('keeps bundle inspection immediately after the runtime and site build', async () => {
+    const fixture = await readCiContracts();
+    const steps = fixture.workflow.jobs.runtime.steps;
+    const index = steps.findIndex((step) => step.run === 'pnpm test:bundle');
+    steps.splice(index, 0, { run: 'echo intervening step' });
+    expect(() => assertCiCommand(fixture, contracts[1])).toThrow();
+  });
+
   it('runs development HMR once on Linux after the packed browser smoke', async () => {
     assertDevHmrContract(await readCiContracts());
   });

--- a/tests/unit/release-workflow.test.mjs
+++ b/tests/unit/release-workflow.test.mjs
@@ -1,6 +1,7 @@
 // @vitest-environment node
 
 import { createHash } from 'node:crypto';
+import { createRequire } from 'node:module';
 import { cp, mkdir, mkdtemp, readFile, readdir, rm, writeFile } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
@@ -26,6 +27,7 @@ import { uploadReleaseAssets } from '../../.github/scripts/release-assets.mjs';
 import { verifyReleaseVersions } from '../../.github/scripts/verify-release-version.mjs';
 
 const repositoryRoot = fileURLToPath(new URL('../..', import.meta.url));
+const { parse: parseYaml } = createRequire(path.join(repositoryRoot, 'packages/oxiquill/package.json'))('yaml');
 const releaseCommit = 'a'.repeat(40);
 const workflowCommit = 'c'.repeat(40);
 const temporaryDirectories = [];
@@ -436,6 +438,77 @@ describe('GitHub Release asset upload', () => {
       })
     ).rejects.toThrow('conflicts with the verified artifact');
   });
+});
+
+async function readCiContracts() {
+  return {
+    workflow: parseYaml(await readFile(path.join(repositoryRoot, '.github/workflows/ci.yml'), 'utf8')),
+    scripts: JSON.parse(await readFile(path.join(repositoryRoot, 'package.json'), 'utf8')).scripts
+  };
+}
+
+function shellCommands(source = '') {
+  return source
+    .split(/&&|\n/gu)
+    .map((command) => command.trim())
+    .filter(Boolean);
+}
+
+function assertCiCommand({ workflow, scripts }, { command, jobName, after, condition, immediatelyAfter = false }) {
+  expect(workflow.on.pull_request.branches).toContain('main');
+  expect(shellCommands(scripts.test)).toContain(`pnpm ${command}`);
+  const matches = Object.entries(workflow.jobs).flatMap(([name, job]) =>
+    job.steps.flatMap((step, index) =>
+      shellCommands(step.run)
+        .filter((run) => run === `pnpm ${command}`)
+        .map(() => ({ name, step, index }))
+    )
+  );
+  expect(matches, `${command} must run exactly once in PR CI`).toHaveLength(1);
+  const [match] = matches;
+  expect(match.name, `${command} job`).toBe(jobName);
+  expect(match.step.if, `${command} condition`).toBe(condition);
+  const before = workflow.jobs[jobName].steps.findIndex((step) => shellCommands(step.run).includes(`pnpm ${after}`));
+  expect(before, `${after} prerequisite`).toBeGreaterThanOrEqual(0);
+  if (immediatelyAfter) expect(match.index).toBe(before + 1);
+  else expect(match.index).toBeGreaterThan(before);
+}
+
+function assertDevHmrContract(fixture) {
+  assertCiCommand(fixture, { command: 'test:dev-hmr', jobName: 'packed-browser', after: 'test:packed-browser' });
+  expect(fixture.scripts['test:dev-hmr']).toBe('node tests/e2e/dev-hmr-smoke.mjs');
+  const commands = shellCommands(fixture.scripts.test);
+  expect(commands.indexOf('pnpm test:dev-hmr')).toBeGreaterThan(commands.indexOf('pnpm test:packed-browser'));
+  expect(commands.indexOf('pnpm test:e2e')).toBeGreaterThan(commands.indexOf('pnpm test:dev-hmr'));
+  const job = fixture.workflow.jobs['packed-browser'];
+  expect(job['runs-on']).toBe('ubuntu-latest');
+  expect(job.strategy?.matrix).toBeUndefined();
+  expect(job.steps.some((step) => step.run === 'pnpm exec playwright install --with-deps chromium')).toBe(true);
+}
+
+describe('PR CI test contracts', () => {
+  it('runs development HMR once on Linux after the packed browser smoke', async () => {
+    assertDevHmrContract(await readCiContracts());
+  });
+
+  it.each(['remove', 'relocate', 'duplicate', 'guard', 'matrix', 'aggregate', 'order', 'entrypoint'])(
+    'rejects dev HMR contract drift: %s',
+    async (change) => {
+      const fixture = await readCiContracts();
+      const job = fixture.workflow.jobs['packed-browser'];
+      const index = job.steps.findIndex((step) => step.run === 'pnpm test:dev-hmr');
+      const step = job.steps[index];
+      if (change === 'remove') job.steps.splice(index, 1);
+      if (change === 'relocate') fixture.workflow.jobs['unit-coverage'].steps.push(...job.steps.splice(index, 1));
+      if (change === 'duplicate') job.steps.push({ ...step });
+      if (change === 'guard') step.if = 'false';
+      if (change === 'matrix') job.strategy = { matrix: { browser: ['chromium', 'firefox'] } };
+      if (change === 'aggregate') fixture.scripts.test = fixture.scripts.test.replace('pnpm test:dev-hmr && ', '');
+      if (change === 'order') job.steps.unshift(...job.steps.splice(index, 1));
+      if (change === 'entrypoint') fixture.scripts['test:dev-hmr'] = 'echo skipped';
+      expect(() => assertDevHmrContract(fixture)).toThrow();
+    }
+  );
 });
 
 describe('workflow supply-chain policy', () => {


### PR DESCRIPTION
Rust cells can fail to compile when output macros contain whitespace or comments before `!`, or when author variables shadow generated output collectors. This change detects macro invocations lexically and isolates author code so valid cells retain their captured output and control flow.

It also makes the existing development HMR, documentation, and browser bundle contracts part of pull-request CI.

## Changes

- Scan each Rust cell once, sharing the macro identifier set between capability and macro generation. Skip comments and literals, preserve wrapper dependencies, and report unterminated constructs with cell and source context.
- Keep collectors and generated macros outside the author block. Exercise colliding locals, inputs, `?`, early returns, and discarded tail expressions in compiled Wasm fixtures; fix empty `println!()` capture through the bounded writer.
- Run the standalone Chromium HMR smoke once in the Linux packed-browser job and in the aggregate test command. Generate its initial runtime deliberately, retain process output and failures from spawn, fail on browser errors, and verify stable source and reactive output updates.
- Run documentation contracts after unit coverage and bundle contracts immediately after the Linux runtime build. Add positive and negative workflow contract tests for placement, ordering, duplication, prerequisites, and conditions.

## Validation

- `pnpm wasm:dev` and `pnpm check` passed.
- Final unit coverage: 1,084 tests passed, 1 existing skip; all coverage thresholds passed.
- The aggregate test run passed lint, Rust coverage/docs, CLI, Wasm/Haskell, production build, bundle/docs contracts, package validation, npm/pnpm consumers, packed Chromium, and development HMR.
- Production E2E: 70 passed, 2 existing skips across Chromium, Firefox, and WebKit. The initial aggregate run was interrupted at WebKit because the local Nix browser did not support Playwright's `PushAPIEnabled` setting. The WebKit suite then passed using the matching distribution with Nix runtime libraries in a temporary test environment.
- Playwright discovery remains 72 tests in the two production spec files.

Fixes #120
Fixes #121
Fixes #122
Fixes #123
