### PR TITLE
Fix persistent chart rendering, production search and math, and Python startup

### DIFF
--- a/examples/docs-site/astro.config.mjs
+++ b/examples/docs-site/astro.config.mjs
@@ -5,6 +5,7 @@ const basePath = process.env.BASE_PATH;
 
 export default defineOxiquillConfig({
   desktopTableOfContentsToggle: true,
+  python: { preload: true },
   framework: { starlight },
   site: process.env.SITE ?? 'https://oxiquill.local',
   ...(basePath ? { base: basePath } : {}),

--- a/examples/docs-site/content/docs/features/interactive-cells.mdx
+++ b/examples/docs-site/content/docs/features/interactive-cells.mdx
@@ -7,6 +7,8 @@ Interactive cells are ordinary MDX code blocks with metadata comments at the top
 
 Rust cells are compiled to WebAssembly at build time. Python cells run in a browser Pyodide worker. Haskell cells are compiled to a WASI WebAssembly module at build time. All three languages use the same input metadata and run-mode model.
 
+Reruns retain the last successful output, with an error and retry action if execution fails. Cancellation and invalid input also keep the output. Compatible charts update the same canvas with a default 180ms transition, respecting OS reduced-motion preferences. See [rich output](/features/rich-output/#persistent-output-and-chart-styles) for the exact style schema, limits, and Rust overloads. Explicit artifact IDs are recommended for dynamically changing output sequences.
+
 ## Fence and Metadata Grammar
 
 Interactive fences use `rust`, `python`, or `haskell` (including Markdown's `{.rust}` form) and may use legal backtick or tilde fences and indentation. Metadata is one contiguous block of language-appropriate option comments at the beginning of the fence: `//|` or `///|` for Rust, `#|` for Python, and `--|` for Haskell. An option-looking comment after the first source line remains source code.

--- a/examples/docs-site/content/docs/features/interactive-cells.mdx
+++ b/examples/docs-site/content/docs/features/interactive-cells.mdx
@@ -205,3 +205,5 @@ let displayed = sort (if include_squares then map (\value -> value * value) scal
 putStrLn (label ++ ": " ++ intercalate ", " (map show displayed))
 putStrLn ("total = " ++ show (sum displayed))
 ```
+
+Python cells show **Preparing Python…** during initialization and package loading, then **Running** while authored code executes. See [Python Runtime Assets](/guides/python-runtime/#browser-preparation) for optional page preparation with `python.preload`.

--- a/examples/docs-site/content/docs/features/math.mdx
+++ b/examples/docs-site/content/docs/features/math.mdx
@@ -9,12 +9,18 @@ Math can be written directly in MDX. Use it near the prose and executable cells 
 
 Inline math uses single dollar signs. In the logistic map, the state is $x_n \in [0, 1]$ and the parameter is $r \in [0, 4]$.
 
+Subscripts and superscripts also work together: $x_n + x^2$.
+
 ## Block Math
 
 Block math uses double dollar signs:
 
 $$
 x_{n+1} = r x_n (1 - x_n)
+$$
+
+$$
+x_n + x^2
 $$
 
 ## Matrix

--- a/examples/docs-site/content/docs/features/rich-output.mdx
+++ b/examples/docs-site/content/docs/features/rich-output.mdx
@@ -49,6 +49,61 @@ Empty charts and equal point domains are valid. Heatmaps report X- and Y-categor
 
 Charts use contrast-aware colors for the current Starlight light/dark theme, recreate their ECharts instance when `html[data-theme]` changes, and expose a retry action after a transient renderer load failure.
 
+## Persistent Output and Chart Styles
+
+The last successful output stays visible while a cell reruns, including the 150ms reactive debounce. A small updating indicator does not move the layout. Failed reruns keep that output alongside an error and a **Retry cell** action; cancellation and invalid inputs also retain it. Success replaces the result and clears the error. Use explicit artifact IDs when an output sequence changes dynamically: IDs retain identity across insertions, duplicate IDs receive occurrence numbers, and artifacts without IDs are matched by kind and occurrence.
+
+Compatible charts update the existing canvas and ECharts instance, preserving the reader's zoom window. Initial and data-update transitions use 180ms with cubicOut easing. Structural changes replace chart options on the same instance; Starlight light/dark theme changes recreate it. A chart update failure keeps the last successful visualization and summary with a local retry action. Reduced-motion preferences disable chart and updating-indicator animation, even when an author requests animation.
+
+Chart specs accept an optional nested `style` object:
+
+```ts
+interface ChartPalette {
+  light?: readonly string[];
+  dark?: readonly string[];
+}
+interface BaseChartStyle {
+  palette?: ChartPalette;
+  showGrid?: boolean;
+  animation?: boolean;
+  animationDurationMs?: number;
+}
+interface LineChartStyle extends BaseChartStyle {
+  lineWidth?: number;
+}
+interface ScatterChartStyle extends BaseChartStyle {
+  symbolSize?: number;
+}
+```
+
+Line and area charts use `LineChartStyle`, scatter charts use `ScatterChartStyle`, and bar, histogram, and heatmap charts use `BaseChartStyle`.
+
+| Field                 | Allowed values and default                                                                                                                                                                         |
+| --------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `palette`             | At least one of `light` or `dark`; each supplied theme has 1–12 unique `#RGB` or `#RRGGBB` colors. Heatmaps require at least two. Colors are compared after expanding shorthand and ignoring case. |
+| `showGrid`            | Boolean; default `true`.                                                                                                                                                                           |
+| `animation`           | Boolean; default `true`, subordinate to reduced motion.                                                                                                                                            |
+| `animationDurationMs` | Integer from 0 to 2,000; default 180 for both initial and update animation.                                                                                                                        |
+| `lineWidth`           | Finite number from 1 to 8; default 2.25. Line and area only.                                                                                                                                       |
+| `symbolSize`          | Finite number from 2 to 32; default 7. Scatter only.                                                                                                                                               |
+
+Palettes color series, or the visual-map gradient for heatmaps. A missing theme palette uses the Oxiquill default for that theme. Chart chrome and typography follow Starlight. Unknown nested fields, fields for another chart kind, raw ECharts options, callbacks, formatters, and HTML are rejected. Style contributes to the normal artifact byte budget; it does not bypass output limits.
+
+Every existing Rust chart macro signature remains valid. These overloads add a final JSON-serializable style argument, such as `&serde_json::json!({ "lineWidth": 3 })`:
+
+```text
+emit_line_chart!(series, style)
+emit_line_chart!(series, x_label, y_label, style)
+emit_scatter_chart!(series, style)
+emit_scatter_chart!(series, x_label, y_label, style)
+emit_bar_chart!(categories, values, style)
+emit_histogram!(bins, style)
+emit_heatmap!(data, style)
+emit_line_plot!(points, x_label, y_label, style)
+```
+
+The macro serializes the argument into `spec.style`; normal chart validation enforces the same contract.
+
 ## Resource Limits
 
 Producers enforce limits inside each language worker before `postMessage`; the main thread independently validates the bounded response again. Limits are UTF-8 byte limits and are cumulative for each run where noted:
@@ -137,7 +192,10 @@ let heatmap = [[0, 0, 1], [1, 0, 3], [0, 1, 2], [1, 1, 4]];
 emit_json!(&serde_json::json!({"status": "ok", "rows": rows.len()}));
 emit_records_table!(&rows);
 emit_table_with_columns!(&columns, &rows);
-emit_bar_chart!(&["alpha", "beta", "gamma"], &[3, 5, 4]);
+emit_bar_chart!(&["alpha", "beta", "gamma"], &[3, 5, 4], &serde_json::json!({
+    "palette": { "light": ["#7c3aed"], "dark": ["#c4b5fd"] },
+    "animationDurationMs": 180
+}));
 emit_heatmap!(&heatmap);
 emit_svg!(
     r##"<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 48"><rect width="160" height="48" fill="#ecfeff"/><circle cx="32" cy="24" r="14" fill="#0f766e"/><rect x="64" y="12" width="72" height="24" rx="4" fill="#2563eb"/></svg>"##,

--- a/examples/docs-site/content/docs/guides/project-configuration.mdx
+++ b/examples/docs-site/content/docs/guides/project-configuration.mdx
@@ -44,7 +44,7 @@ export const collections = createOxiquillCollections({ defineCollection, docsLoa
 | `markdown`                        | Supported Astro Markdown settings and plugins. Oxiquill's required plugins run first.                                |
 | `vite`                            | Additional Vite settings. Oxiquill preserves required aliases, deduplication, worker plugins, and filesystem access. |
 | `paths`                           | Oxiquill-owned source, cache, generated, and public paths described below.                                           |
-| `python`                          | Pyodide download behavior: `offline` and the optional `packageMirror`.                                               |
+| `python`                          | Pyodide download behavior: `preload`, `offline`, and the optional `packageMirror`.                                   |
 | Other Astro fields                | Passed through to Astro. Oxiquill always produces static output.                                                     |
 
 Use `oxiquillIntegration()` only when composing an Astro configuration manually. It accepts `base`, `markdown`, `paths`, `python`, and `vite`; the caller is then responsible for adding Preact and Starlight.
@@ -96,6 +96,7 @@ Astro's `root`, `publicDir`, `outDir`, and `cacheDir` and Oxiquill's explicit pa
 ```js
 export default defineOxiquillConfig({
   python: {
+    preload: false,
     offline: process.env.OXIQUILL_OFFLINE === '1',
     packageMirror: new URL('https://packages.example/pyodide/')
   },
@@ -136,3 +137,5 @@ Set Astro's `base` when publishing below a subpath. Oxiquill applies it to inter
 Generated runtime files belong under `.oxiquill` and `public/oxiquill`; the verified download cache belongs under `.cache/oxiquill/downloads/v1`; and the final static site belongs under Astro's `outDir` (normally `dist`). Generated directories and their ownership markers must not be edited directly. The download cache may be retained across builds and reconstructed outputs, but its files are verified before every use.
 
 When you customize generated directories, update `tsconfig.json` exclusions to the resolved cache, helper-crate target, output, and public-asset paths. Otherwise a broad include such as `**/*` can make Astro/TypeScript analyze generated JavaScript such as Pyodide instead of treating it as output.
+
+`python.preload` defaults to `false`. Enable it to prepare Python at DOM readiness on pages containing Python cells. See [Python Runtime Assets](/guides/python-runtime/#browser-preparation).

--- a/examples/docs-site/content/docs/guides/python-runtime.mdx
+++ b/examples/docs-site/content/docs/guides/python-runtime.mdx
@@ -25,6 +25,16 @@ export default defineOxiquillConfig({
 
 `offline` defaults to `false`. `packageMirror` and `downloadCacheDir` accept either a string or URL. TypeScript consumers can import `OxiquillPythonOptions` and `OxiquillPathOptions` from `oxiquill/astro`.
 
+## Browser Preparation
+
+Set `python: { preload: true }` to prepare Python as soon as the page DOM is ready. The default is `false`; this documentation site enables it. Pages without Python cells do not start a Python worker. Preparation uses only the first Python cell's declared packages and does not execute authored code. Button cells still wait for **Run**, and reactive and autorun cells retain their visible hydration behavior.
+
+The first request passes its declared packages into Pyodide initialization so their downloads overlap runtime startup. Preparation and execution share one worker, one initialization promise, and a serial queue. Later cells load additional declared packages and discover imports before execution. The UI distinguishes **Preparing Python…** from **Running**. A failed preparation can be retried by running a cell; cancellation, timeout, and runtime reset clear the worker and preparation state together.
+
+Browser assets remain on the site's origin and respect its base path, including `/oxiquill/`. This option adds no CDN dependency, service worker, custom Pyodide distribution, or persistent browser cache. Normal HTTP caching still applies. Display helpers use pandas and Matplotlib only when authored imports have loaded them; Matplotlib keeps the noninteractive Agg backend and automatic figure collection.
+
+For local profiling, browser User Timing entries named `oxiquill:<phase>:<cell-id>` record hydration, worker startup, initialization, display support, package loading, import discovery, execution, and output rendering. Initialization entries use `python` as their ID. Entries retain the latest measurement per phase and cell and are never sent to a server. The repository's `tests/performance/python-startup.mjs` measures fresh contexts, reloads, and repeated runs against a gzip-served production build.
+
 ## Verified Downloads
 
 For each wheel, Oxiquill takes the filename, release location, and expected SHA-256 from the installed `pyodide-lock.json`. A configured mirror changes only the download base; it never weakens or replaces the lockfile hash.

--- a/examples/docs-site/content/docs/ja/features/interactive-cells.mdx
+++ b/examples/docs-site/content/docs/ja/features/interactive-cells.mdx
@@ -205,3 +205,5 @@ let displayed = sort (if include_squares then map (\value -> value * value) scal
 putStrLn (label ++ ": " ++ intercalate ", " (map show displayed))
 putStrLn ("total = " ++ show (sum displayed))
 ```
+
+Python の初期化と package 読み込み中は「Python を準備中…」、執筆した code の実行中は「実行中…」と表示します。`python.preload` による page 単位の先読みは [Python runtime asset](/ja/guides/python-runtime/#browser-の準備) を参照してください。

--- a/examples/docs-site/content/docs/ja/features/interactive-cells.mdx
+++ b/examples/docs-site/content/docs/ja/features/interactive-cells.mdx
@@ -7,6 +7,8 @@ description: 静的サイト上で動く Rust、Python、Haskell のセルを設
 
 Rust セルは build 時に WebAssembly に compile されます。Python セルは browser の Pyodide worker で動きます。Haskell セルは build 時に WASI WebAssembly module に compile されます。3つの言語は同じ input metadata と run mode model を使います。
 
+再実行中も最後に成功した出力を保持し、失敗時にはエラーと再試行操作を併記します。キャンセルや入力不正でも出力を消しません。互換性のあるグラフは同じ canvas を更新し、既定で180msの遷移を使います。OS の動作軽減設定を優先します。style の型・制限と Rust overload は [リッチ出力](/ja/features/rich-output/#出力の保持とグラフのスタイル) を参照してください。動的な出力の並びには明示的な artifact ID を推奨します。
+
 ## Fence と metadata grammar
 
 interactive fence は `rust`、`python`、`haskell`（Markdown の `{.rust}` form を含む）を使い、legal backtick/tilde fence と indentation に対応します。metadata は fence 先頭の一つの contiguous な language-specific option-comment block です。Rust は `//|`/`///|`、Python は `#|`、Haskell は `--|` を使います。最初の source line より後にある option 風 comment は source code のままです。

--- a/examples/docs-site/content/docs/ja/features/math.mdx
+++ b/examples/docs-site/content/docs/ja/features/math.mdx
@@ -9,12 +9,18 @@ description: MDX ノートで KaTeX の inline math と block math を表示し�
 
 inline math は dollar sign 1つで囲みます。ロジスティック写像では、状態は $x_n \in [0, 1]$、parameter は $r \in [0, 4]$ です。
 
+下付き文字と上付き文字も組み合わせて使えます: $x_n + x^2$。
+
 ## ブロック数式
 
 block math は dollar sign 2つで囲みます。
 
 $$
 x_{n+1} = r x_n (1 - x_n)
+$$
+
+$$
+x_n + x^2
 $$
 
 ## 行列

--- a/examples/docs-site/content/docs/ja/features/rich-output.mdx
+++ b/examples/docs-site/content/docs/ja/features/rich-output.mdx
@@ -49,6 +49,61 @@ empty chart と equal point domain は valid です。heatmap は X/Y の catego
 
 chart は現在の Starlight light/dark theme に合わせた contrast-aware color を使い、`html[data-theme]` の変更時に ECharts instance を作り直します。一時的な renderer load failure の後には retry action を表示します。
 
+## 出力の保持とグラフのスタイル
+
+セルを再実行している間も、最後に成功した出力を表示し続けます。150ms の reactive debounce 中も同様です。更新中の表示はレイアウトを動かしません。再実行が失敗した場合は出力とエラーを併記し、**セルの実行を再試行**からやり直せます。キャンセルや入力不正でも出力を保持し、成功時に結果を置き換えてエラーを消します。出力の並びが動的に変わる場合は artifact に明示的な `id` を付けてください。重複 ID は出現番号で区別し、ID のない artifact は種類ごとの出現番号で対応付けます。
+
+互換性のあるグラフは既存の canvas と ECharts instance を更新し、読者のズーム範囲を保持します。初回とデータ更新のアニメーションは既定で180ms、easing は cubicOut です。構造変更時は同じ instance の設定を置き換え、Starlight の light/dark 変更時には instance を作り直します。グラフ更新が失敗しても最後の表示と概要を残し、局所的な再試行操作を表示します。OS の動作軽減設定は著者の animation 指定より優先され、グラフと更新表示のアニメーションを無効にします。
+
+chart spec は次の optional `style` object を受け取ります。
+
+```ts
+interface ChartPalette {
+  light?: readonly string[];
+  dark?: readonly string[];
+}
+interface BaseChartStyle {
+  palette?: ChartPalette;
+  showGrid?: boolean;
+  animation?: boolean;
+  animationDurationMs?: number;
+}
+interface LineChartStyle extends BaseChartStyle {
+  lineWidth?: number;
+}
+interface ScatterChartStyle extends BaseChartStyle {
+  symbolSize?: number;
+}
+```
+
+line と area は `LineChartStyle`、scatter は `ScatterChartStyle`、bar・histogram・heatmap は `BaseChartStyle` を使います。
+
+| Field                 | 許可される値と既定値                                                                                                                                                    |
+| --------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `palette`             | `light` / `dark` の少なくとも片方を指定。各テーマに重複しない `#RGB` / `#RRGGBB` を1〜12色。heatmap は2色以上。短縮表記を展開し、大文字小文字を区別せず重複判定します。 |
+| `showGrid`            | boolean。既定値は `true`。                                                                                                                                              |
+| `animation`           | boolean。既定値は `true`。動作軽減設定を優先します。                                                                                                                    |
+| `animationDurationMs` | 0〜2,000の整数。初回と更新の既定値は180。                                                                                                                               |
+| `lineWidth`           | 1〜8の有限値。既定値2.25。line / area のみ。                                                                                                                            |
+| `symbolSize`          | 2〜32の有限値。既定値7。scatter のみ。                                                                                                                                  |
+
+palette は系列色を選び、heatmap では visual-map のグラデーションになります。片方のテーマが未指定なら、そのテーマの Oxiquill 既定色を使います。文字やグラフ周辺の色は Starlight に従います。不明な nested field、別の種類専用の field、生の ECharts options、callback、formatter、HTML は拒否します。style も通常の artifact byte 制限に含まれます。
+
+既存の Rust macro signature はすべて利用できます。次の overload では末尾に JSON-serializable な style（例: `&serde_json::json!({ "lineWidth": 3 })`）を追加できます。
+
+```text
+emit_line_chart!(series, style)
+emit_line_chart!(series, x_label, y_label, style)
+emit_scatter_chart!(series, style)
+emit_scatter_chart!(series, x_label, y_label, style)
+emit_bar_chart!(categories, values, style)
+emit_histogram!(bins, style)
+emit_heatmap!(data, style)
+emit_line_plot!(points, x_label, y_label, style)
+```
+
+macro は `spec.style` にシリアライズし、通常のグラフ検証が同じ制限を適用します。
+
 ## Resource limit
 
 producer は各 language worker 内で `postMessage` より前に limit を適用し、main thread でも bounded response を独立して再検証します。limit は UTF-8 byte 単位で、記載のものは run ごとに累積します。
@@ -137,7 +192,10 @@ let heatmap = [[0, 0, 1], [1, 0, 3], [0, 1, 2], [1, 1, 4]];
 emit_json!(&serde_json::json!({"status": "ok", "rows": rows.len()}));
 emit_records_table!(&rows);
 emit_table_with_columns!(&columns, &rows);
-emit_bar_chart!(&["alpha", "beta", "gamma"], &[3, 5, 4]);
+emit_bar_chart!(&["alpha", "beta", "gamma"], &[3, 5, 4], &serde_json::json!({
+    "palette": { "light": ["#7c3aed"], "dark": ["#c4b5fd"] },
+    "animationDurationMs": 180
+}));
 emit_heatmap!(&heatmap);
 emit_svg!(
     r##"<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 48"><rect width="160" height="48" fill="#ecfeff"/><circle cx="32" cy="24" r="14" fill="#0f766e"/><rect x="64" y="12" width="72" height="24" rx="4" fill="#2563eb"/></svg>"##,

--- a/examples/docs-site/content/docs/ja/guides/project-configuration.mdx
+++ b/examples/docs-site/content/docs/ja/guides/project-configuration.mdx
@@ -44,7 +44,7 @@ export const collections = createOxiquillCollections({ defineCollection, docsLoa
 | `markdown`                        | 対応する Astro Markdown setting/plugin。Oxiquill 必須 plugin が先に動きます。              |
 | `vite`                            | 追加の Vite setting。必須 alias、dedupe、worker plugin、filesystem access は保持されます。 |
 | `paths`                           | 下記の source/cache/generated/public path。                                                |
-| `python`                          | Pyodide download の `offline` と optional `packageMirror`。                                |
+| `python`                          | Pyodide download の `preload`、`offline` と optional `packageMirror`。                     |
 | その他の Astro field              | Astro に渡されます。Oxiquill の output は常に static です。                                |
 
 Astro config を手動で組み立てる場合だけ `oxiquillIntegration()` を使います。受け取る option は `base`、`markdown`、`paths`、`python`、`vite` で、Preact と Starlight は caller が追加します。
@@ -96,6 +96,7 @@ Astro の `root`、`publicDir`、`outDir`、`cacheDir` と Oxiquill の path set
 ```js
 export default defineOxiquillConfig({
   python: {
+    preload: false,
     offline: process.env.OXIQUILL_OFFLINE === '1',
     packageMirror: new URL('https://packages.example/pyodide/')
   },
@@ -136,3 +137,5 @@ subpath 配下へ公開するときは Astro の `base` を設定します。Oxi
 生成 runtime は `.oxiquill` と `public/oxiquill`、verified download cache は `.cache/oxiquill/downloads/v1`、最終 static site は Astro の `outDir`（通常 `dist`）に置かれます。生成 directory と ownership marker を直接編集しないでください。download cache は build や output 再生成をまたいで保持できますが、file は利用前に毎回検証されます。
 
 生成 directory を変更するときは、resolved cache、helper-crate target、output、public-asset path に合わせて `tsconfig.json` の exclusion も更新します。そうしないと `**/*` のような広い include により、Astro/TypeScript が Pyodide などの生成 JavaScript を output ではなく source として解析することがあります。
+
+`python.preload` の default は `false` です。有効にすると Python cell がある page の DOM ready 時に準備を始めます。詳細は [Python runtime asset](/ja/guides/python-runtime/#browser-の準備) を参照してください。

--- a/examples/docs-site/content/docs/ja/guides/python-runtime.mdx
+++ b/examples/docs-site/content/docs/ja/guides/python-runtime.mdx
@@ -25,6 +25,16 @@ export default defineOxiquillConfig({
 
 `offline` の default は `false` です。`packageMirror` と `downloadCacheDir` は string または URL を受け取ります。TypeScript consumer は `OxiquillPythonOptions` と `OxiquillPathOptions` を `oxiquill/astro` から import できます。
 
+## Browser の準備
+
+`python: { preload: true }` を設定すると、page の DOM が準備できた時点で Python の準備を始めます。default は `false` で、この documentation site では有効にしています。Python cell がない page では Python worker を起動しません。準備対象は最初の Python cell の declared packages だけで、執筆した code は実行しません。button cell は引き続き「実行」を待ち、reactive / autorun cell の visible hydration も維持します。
+
+最初の request の declared packages を Pyodide initialization に渡し、download と runtime startup を重ねます。準備と実行は同じ worker、initialization promise、serial queue を使います。後続 cell の追加 package と source の import discovery は実行前に処理します。UI は「Python を準備中…」と「実行中…」を区別します。準備に失敗しても cell の実行で再試行でき、cancel、timeout、runtime reset は worker と準備状態を一緒に破棄します。
+
+Browser asset は同一 origin から読み込み、`/oxiquill/` を含む site base path に従います。CDN、service worker、custom Pyodide distribution、永続 browser cache は追加しません。通常の HTTP cache は利用します。表示 helper は執筆した import が読み込んだ pandas / Matplotlib だけを使います。Matplotlib の非対話 Agg backend と figure の自動回収は維持します。
+
+ローカルでの分析には `oxiquill:<phase>:<cell-id>` という browser User Timing entry を利用できます。hydration、worker startup、initialization、display support、package loading、import discovery、execution、output rendering を記録し、initialization の ID は `python` です。各 phase / cell の最新計測だけを保持し、server への送信は行いません。repository の `tests/performance/python-startup.mjs` は gzip 配信した production build で fresh context、reload、同じ page での再実行を計測します。
+
 ## 検証付き download
 
 各 wheel の filename、release location、expected SHA-256 は install 済み `pyodide-lock.json` から取得します。mirror setting が変えるのは download base だけで、lockfile hash を弱めたり置き換えたりしません。

--- a/packages/oxiquill/package.json
+++ b/packages/oxiquill/package.json
@@ -100,7 +100,7 @@
     "astro": "7.2.9",
     "chokidar": "5.0.0",
     "echarts": "6.1.0",
-    "katex": "0.18.4",
+    "katex": "0.16.47",
     "mermaid": "11.17.2",
     "preact": "10.29.8",
     "pyodide": "314.0.6",

--- a/packages/oxiquill/src/astro/index.ts
+++ b/packages/oxiquill/src/astro/index.ts
@@ -1,7 +1,7 @@
 import { existsSync, readFileSync } from 'node:fs';
 import { createRequire } from 'node:module';
 import path from 'node:path';
-import { pathToFileURL } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import { defineConfig } from 'astro/config';
 import { unified } from '@astrojs/markdown-remark';
 import preact from '@astrojs/preact';
@@ -105,6 +105,7 @@ export interface OxiquillFrameworkOptions<StarlightOptions extends object = obje
 }
 
 export interface OxiquillPythonOptions {
+  preload?: boolean;
   offline?: boolean;
   packageMirror?: string | URL;
 }
@@ -149,7 +150,7 @@ export interface OxiquillIntegrationOptions {
 
 const createDocRuntimeContextForPaths = createDocRuntimeContext as unknown as (options: {
   paths: OxiquillPaths;
-  pythonOptions?: Readonly<{ offline: boolean; packageMirror?: string }>;
+  pythonOptions?: Readonly<{ offline: boolean; preload: boolean; packageMirror?: string }>;
 }) => Promise<DocRuntimeContext>;
 const syncDocRuntimeForBuild = syncDocRuntime as unknown as (
   options: DocRuntimeContext & { mode: 'build' }
@@ -257,7 +258,7 @@ function createOxiquillIntegration(
   rejectCustomMarkdownProcessor(markdown);
   const metadata = createOxiquillIntegrationMetadata({ astro: astroOptions, paths: pathOptions, python });
   let paths: OxiquillPaths | undefined;
-  let pythonOptions: Readonly<{ offline: boolean; packageMirror?: string }> | undefined;
+  let pythonOptions: Readonly<{ offline: boolean; preload: boolean; packageMirror?: string }> | undefined;
   let buildOwnership: Awaited<ReturnType<typeof prepareCleanupOwnership>> = Object.freeze([]);
   const bundledModules = createBundledModuleCollector();
   const browserBundle = createBrowserBundleCollector();
@@ -265,7 +266,7 @@ function createOxiquillIntegration(
   const integration: AstroIntegration = {
     name: 'oxiquill',
     hooks: {
-      'astro:config:setup': ({ addWatchFile, config, updateConfig }) => {
+      'astro:config:setup': ({ addWatchFile, config, updateConfig, injectScript }) => {
         const projectConfig = resolveOxiquillProjectConfig({
           astroConfig: config,
           astroExplicitFields: inferAstroDirectoryFields(config),
@@ -274,6 +275,14 @@ function createOxiquillIntegration(
         });
         paths = projectConfig.paths;
         pythonOptions = projectConfig.python;
+        if (pythonOptions?.preload) {
+          injectScript(
+            'page',
+            'import ' +
+              JSON.stringify(fileURLToPath(new URL('../lib/doc-runtime/python-preload.js', import.meta.url))) +
+              ';'
+          );
+        }
         addWatchFile(paths.docsDir);
         addWatchFile(paths.cratesDir);
 

--- a/packages/oxiquill/src/components/doc-runtime/CellOutput.tsx
+++ b/packages/oxiquill/src/components/doc-runtime/CellOutput.tsx
@@ -11,18 +11,24 @@ type RuntimeLabels = ReturnType<typeof labelsForLanguage>;
 export function CellOutput({
   cellTitle,
   error,
+  isComplete = true,
   isRunning,
   labels,
   outputId,
   result,
+  retry,
+  canRetry = true,
   runMode
 }: {
   cellTitle: string;
   error?: string;
+  isComplete?: boolean;
   isRunning: boolean;
   labels: RuntimeLabels;
   outputId: string;
   result?: CellExecutionResult | NormalizedCellExecutionResult;
+  retry?: () => void;
+  canRetry?: boolean;
   runMode: CellManifest['run'];
 }) {
   const outputResults = result
@@ -32,7 +38,7 @@ export function CellOutput({
     : undefined;
   const liveMessage = isRunning
     ? labels.cellRunningAnnouncement
-    : result
+    : result && isComplete && error === undefined
       ? outputResults?.length
         ? labels.cellCompleted
         : labels.cellCompletedWithoutOutput
@@ -50,20 +56,32 @@ export function CellOutput({
         {liveMessage}
       </p>
       {error !== undefined ? (
-        <p class="error-state" role="alert">
-          {labels.executionErrorLabel} <span>{labels.diagnosticDetail(error)}</span>
-        </p>
-      ) : isRunning ? (
-        <p class="empty-state">{labels.runningCell}</p>
-      ) : !result ? (
-        <p class="empty-state">{idleOutputMessage(runMode, labels)}</p>
-      ) : outputResults?.length ? (
-        <div class="doc-cell__outputs">
-          <OutputRenderer idPrefix={outputId} labels={labels} outputs={outputResults} resultIdentity={result} />
+        <div class="doc-cell__error">
+          <p class="error-state" role="alert">
+            {labels.executionErrorLabel} <span>{labels.diagnosticDetail(error)}</span>
+          </p>
+          {retry ? (
+            <button type="button" onClick={retry} disabled={isRunning || !canRetry}>
+              {labels.cellRetry}
+            </button>
+          ) : null}
         </div>
+      ) : null}
+      {result ? (
+        <div class="doc-cell__outputs" key="outputs">
+          <OutputRenderer idPrefix={outputId} labels={labels} outputs={outputResults ?? []} resultIdentity={result} />
+          {outputResults?.length ? null : <p class="empty-state">{labels.cellCompletedWithoutOutput}</p>}
+        </div>
+      ) : error !== undefined ? null : isRunning ? (
+        <p class="empty-state">{labels.runningCell}</p>
       ) : (
-        <p class="empty-state">{labels.cellCompletedWithoutOutput}</p>
+        <p class="empty-state">{idleOutputMessage(runMode, labels)}</p>
       )}
+      {result && isRunning ? (
+        <span class="doc-cell__updating" aria-hidden="true">
+          {labels.cellUpdating}
+        </span>
+      ) : null}
     </div>
   );
 }

--- a/packages/oxiquill/src/components/doc-runtime/CellOutput.tsx
+++ b/packages/oxiquill/src/components/doc-runtime/CellOutput.tsx
@@ -13,6 +13,7 @@ export function CellOutput({
   error,
   isComplete = true,
   isRunning,
+  isPreparing = false,
   labels,
   outputId,
   result,
@@ -24,6 +25,7 @@ export function CellOutput({
   error?: string;
   isComplete?: boolean;
   isRunning: boolean;
+  isPreparing?: boolean;
   labels: RuntimeLabels;
   outputId: string;
   result?: CellExecutionResult | NormalizedCellExecutionResult;
@@ -37,7 +39,9 @@ export function CellOutput({
       : normalizeCellExecutionResult(result).outputResults
     : undefined;
   const liveMessage = isRunning
-    ? labels.cellRunningAnnouncement
+    ? isPreparing
+      ? labels.pythonPreparing
+      : labels.cellRunningAnnouncement
     : result && isComplete && error === undefined
       ? outputResults?.length
         ? labels.cellCompleted
@@ -73,7 +77,7 @@ export function CellOutput({
           {outputResults?.length ? null : <p class="empty-state">{labels.cellCompletedWithoutOutput}</p>}
         </div>
       ) : error !== undefined ? null : isRunning ? (
-        <p class="empty-state">{labels.runningCell}</p>
+        <p class="empty-state">{isPreparing ? labels.pythonPreparing : labels.runningCell}</p>
       ) : (
         <p class="empty-state">{idleOutputMessage(runMode, labels)}</p>
       )}

--- a/packages/oxiquill/src/components/doc-runtime/ChartOutput.tsx
+++ b/packages/oxiquill/src/components/doc-runtime/ChartOutput.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'preact/hooks';
+import { useEffect, useMemo, useRef, useState } from 'preact/hooks';
 import { normalizeHeatmapSpec, type NormalizedHeatmapSpec } from '../../lib/doc-runtime/heatmap-normalization.js';
 import { boundedErrorMessage } from '../../lib/doc-runtime/output-limits.mjs';
 import type { RuntimeLabels } from '../../lib/doc-runtime/runtime-localization.js';
@@ -22,7 +22,7 @@ const chartColors = {
   dark: {
     axis: '#d1d5db',
     border: '#6b7280',
-    palette: ['#5eead4', '#60a5fa', '#c084fc', '#fb7185', '#facc15', '#d1d5db'],
+    palette: ['#5eead4', '#60a5fa', '#c4b5fd', '#f9a8d4', '#fbbf24', '#cbd5e1'],
     splitLine: '#4b5563',
     text: '#f3f4f6',
     tooltipBackground: '#111827'
@@ -30,7 +30,7 @@ const chartColors = {
   light: {
     axis: '#374151',
     border: '#9ca3af',
-    palette: ['#0f766e', '#1d4ed8', '#7e22ce', '#be123c', '#a16207', '#374151'],
+    palette: ['#0f766e', '#2563eb', '#7c3aed', '#be185d', '#b45309', '#475569'],
     splitLine: '#d1d5db',
     text: '#111827',
     tooltipBackground: '#ffffff'
@@ -70,14 +70,58 @@ function loadECharts(): Promise<EChartsCore> {
 }
 
 export default function ChartOutput({ artifact, idPrefix, labels }: ChartOutputProps) {
-  const { spec } = artifact;
   const element = useRef<HTMLDivElement>(null);
-  const chart = useRef<EChartsInstance>();
-  const latestSpec = useRef(spec);
+  const chart = useRef<{
+    instance: EChartsInstance;
+    signature?: string;
+    spec?: ChartSpec;
+    reducedMotion?: boolean;
+    replace?: boolean;
+  }>();
+  const reducedMotion = useReducedMotion();
+  const latest = useRef({ artifact, reducedMotion });
+  latest.current = { artifact, reducedMotion };
+  const [displayed, setDisplayed] = useState(artifact);
   const [theme, setTheme] = useState<ChartTheme>(() => currentChartTheme());
-  const [renderError, setRenderError] = useState<Error>();
+  const [renderError, setRenderError] = useState<{ message: string; initialization: boolean }>();
   const [renderAttempt, setRenderAttempt] = useState(0);
-  latestSpec.current = spec;
+
+  function applyLatest(force = false): void {
+    const current = chart.current;
+    if (!current) return;
+    const { artifact: next, reducedMotion: motion } = latest.current;
+    try {
+      if (force || current.spec !== next.spec || current.reducedMotion !== motion || current.replace) {
+        const signature = chartStructuralSignature(next.spec);
+        const notMerge = force || current.replace || current.signature !== signature;
+        const options = chartSpecToEChartsOptions(next.spec, theme, {
+          reducedMotion: motion,
+          chrome: resolveChartChrome(theme, element.current ?? undefined)
+        });
+        // Leaving the dataZoom component out of a merge retains the reader's current window.
+        if (!notMerge) delete options.dataZoom;
+        current.instance.setOption(
+          options,
+          notMerge
+            ? { notMerge: true }
+            : {
+                notMerge: false,
+                lazyUpdate: true,
+                replaceMerge: ['series']
+              }
+        );
+        current.signature = signature;
+        current.spec = next.spec;
+        current.reducedMotion = motion;
+        current.replace = false;
+      }
+      setDisplayed(next);
+      setRenderError(undefined);
+    } catch (error) {
+      current.replace = true;
+      setRenderError({ message: boundedErrorMessage(error), initialization: current.spec === undefined });
+    }
+  }
 
   useEffect(() => {
     const root = globalThis.document?.documentElement;
@@ -91,63 +135,38 @@ export default function ChartOutput({ artifact, idPrefix, labels }: ChartOutputP
     const chartElement = element.current;
     if (!chartElement) return undefined;
     let cancelled = false;
-    let nextChart: EChartsInstance | undefined;
+    let instance: EChartsInstance | undefined;
     let resizeObserver: ResizeObserver | undefined;
-
     void loadECharts()
       .then((echarts) => {
         if (cancelled) return;
-
-        nextChart = echarts.init(chartElement, chartThemeDefinition(theme), { renderer: 'canvas' });
-        chart.current = nextChart;
-        nextChart.setOption(chartSpecToEChartsOptions(latestSpec.current, theme), true);
-        resizeObserver = new ResizeObserver(() => nextChart?.resize());
+        instance = echarts.init(chartElement, chartThemeDefinition(theme, resolveChartChrome(theme, chartElement)), {
+          renderer: 'canvas'
+        });
+        chart.current = { instance };
+        resizeObserver = new ResizeObserver(() => instance?.resize());
         resizeObserver.observe(chartElement);
+        applyLatest(true);
       })
       .catch((error: unknown) => {
-        if (!cancelled) setRenderError(toError(error));
+        if (!cancelled) setRenderError({ message: boundedErrorMessage(error), initialization: true });
       });
-
     return () => {
       cancelled = true;
       resizeObserver?.disconnect();
-      nextChart?.dispose();
+      instance?.dispose();
       chart.current = undefined;
     };
   }, [renderAttempt, theme]);
 
   useEffect(() => {
-    try {
-      chart.current?.setOption(chartSpecToEChartsOptions(spec, theme), true);
-    } catch (error) {
-      setRenderError(toError(error));
-    }
-  }, [spec, theme]);
+    applyLatest();
+  }, [artifact, reducedMotion]);
 
-  if (renderError) {
-    return (
-      <div class="doc-chart-output__error">
-        <p class="error-state" data-testid="artifact-error" role="alert">
-          {labels.chartLoadError(renderError.message)}
-        </p>
-        <button
-          type="button"
-          onClick={() => {
-            setRenderError(undefined);
-            setRenderAttempt((attempt) => attempt + 1);
-          }}
-        >
-          {labels.chartRetry}
-        </button>
-      </div>
-    );
-  }
-
-  const titleId = `${idPrefix}-title`;
-  const captionId = artifact.caption ? `${idPrefix}-caption` : undefined;
-  const descriptionId = `${idPrefix}-description`;
-  const title = artifact.title ?? spec.title ?? labels.chartTitle(spec.kind);
-
+  const titleId = idPrefix + '-title';
+  const captionId = displayed.caption ? idPrefix + '-caption' : undefined;
+  const descriptionId = idPrefix + '-description';
+  const title = displayed.title ?? displayed.spec.title ?? labels.chartTitle(displayed.spec.kind);
   return (
     <figure
       class="doc-chart-output"
@@ -156,98 +175,185 @@ export default function ChartOutput({ artifact, idPrefix, labels }: ChartOutputP
     >
       <figcaption>
         <strong id={titleId}>{title}</strong>
-        {artifact.caption ? <span id={captionId}>{artifact.caption}</span> : null}
+        {displayed.caption ? <span id={captionId}>{displayed.caption}</span> : null}
       </figcaption>
-      <div ref={element} class="doc-plot" aria-hidden="true" data-chart-theme={theme} data-testid="doc-plot" />
+      <div
+        ref={element}
+        class="doc-plot"
+        aria-hidden="true"
+        data-chart-theme={theme}
+        data-chart-motion={reducedMotion ? 'reduced' : 'full'}
+        data-testid="doc-plot"
+      />
       <p id={descriptionId} class="doc-chart-output__summary">
         <span class="doc-visually-hidden">{labels.chartCaption}: </span>
-        {chartDataSummary(spec, labels)}
+        {chartDataSummary(displayed.spec, labels)}
       </p>
+      {renderError ? (
+        <div class="doc-chart-output__error">
+          <p class="error-state" data-testid="artifact-error" role="alert">
+            {renderError.initialization
+              ? labels.chartLoadError(renderError.message)
+              : labels.chartUpdateError(renderError.message)}
+          </p>
+          <button
+            type="button"
+            onClick={() => {
+              if (renderError.initialization) {
+                setRenderError(undefined);
+                setRenderAttempt((attempt) => attempt + 1);
+              } else applyLatest(true);
+            }}
+          >
+            {labels.chartRetry}
+          </button>
+        </div>
+      ) : null}
     </figure>
   );
 }
 
-function toError(value: unknown): Error {
-  return new Error(boundedErrorMessage(value));
+function useReducedMotion(): boolean {
+  const media = useMemo(() => globalThis.matchMedia?.('(prefers-reduced-motion: reduce)'), []);
+  const [reduced, setReduced] = useState(media?.matches ?? false);
+  useEffect(() => {
+    if (!media) return;
+    const update = () => setReduced(media.matches);
+    update();
+    media.addEventListener('change', update);
+    return () => media.removeEventListener('change', update);
+  }, [media]);
+  return reduced;
 }
 
 export function currentChartTheme(): ChartTheme {
   return globalThis.document?.documentElement.dataset.theme === 'dark' ? 'dark' : 'light';
 }
 
-export function chartSpecToEChartsOptions(spec: ChartSpec, theme: ChartTheme = 'light'): EChartsOptions {
+export type ChartChrome = {
+  axis: string;
+  border: string;
+  splitLine: string;
+  text: string;
+  tooltipBackground: string;
+  fontFamily: string;
+};
+
+export function resolveChartChrome(theme: ChartTheme, element?: Element): ChartChrome {
+  const fallback = chartColors[theme];
+  const computed = element ? getComputedStyle(element) : undefined;
+  const property = (name: string, defaultValue: string) => computed?.getPropertyValue(name).trim() || defaultValue;
+  return {
+    axis: property('--sl-color-gray-2', fallback.axis),
+    border: property('--sl-color-gray-5', fallback.border),
+    splitLine: property('--sl-color-gray-5', fallback.splitLine),
+    text: property('--sl-color-text', fallback.text),
+    tooltipBackground: property('--sl-color-bg', fallback.tooltipBackground),
+    fontFamily: computed?.fontFamily || 'system-ui, sans-serif'
+  };
+}
+
+export function chartStructuralSignature(spec: ChartSpec): string {
+  const categorical = spec.kind === 'bar' || spec.kind === 'histogram' || spec.kind === 'heatmap';
+  return JSON.stringify([
+    spec.kind,
+    categorical ? 'category' : (spec.xType ?? 'value'),
+    spec.kind === 'heatmap' ? 'category' : (spec.yType ?? 'value'),
+    Boolean(spec.title),
+    shouldShowLegend(spec, 'series' in spec ? spec.series : []),
+    spec.tooltip !== false,
+    spec.kind !== 'heatmap' && spec.dataZoom !== false,
+    spec.kind === 'heatmap'
+  ]);
+}
+
+export function chartSpecToEChartsOptions(
+  spec: ChartSpec,
+  theme: ChartTheme = 'light',
+  { reducedMotion = false, chrome = resolveChartChrome(theme) }: { reducedMotion?: boolean; chrome?: ChartChrome } = {}
+): EChartsOptions {
   const structure = chartStructure(spec);
   const { series } = structure;
-  const colors = chartColors[theme];
+  const style = spec.style;
+  const palette = style?.palette?.[theme];
+  const legend = shouldShowLegend(spec, series);
+  const animation = !reducedMotion && style?.animation !== false;
+  const duration = animation ? (style?.animationDurationMs ?? 180) : 0;
   const axisStyle = {
-    axisLabel: { color: colors.axis },
-    axisLine: { lineStyle: { color: colors.border } },
-    nameTextStyle: { color: colors.text },
-    splitLine: { lineStyle: { color: colors.splitLine } }
+    axisLabel: { color: chrome.axis },
+    axisLine: { show: false },
+    axisTick: { show: false },
+    nameTextStyle: { color: chrome.text },
+    splitLine: { show: style?.showGrid !== false, lineStyle: { color: chrome.splitLine, opacity: 0.45 } }
   };
   const base = {
-    animation: false,
+    animation,
+    animationDuration: duration,
+    animationDurationUpdate: duration,
+    animationEasing: 'cubicOut',
+    animationEasingUpdate: 'cubicOut',
     backgroundColor: 'transparent',
-    color: colors.palette,
-    grid: { left: 56, right: 24, top: spec.title || shouldShowLegend(spec, series) ? 48 : 24, bottom: 56 },
+    color: palette ?? chartColors[theme].palette,
+    grid: {
+      containLabel: true,
+      left: 16,
+      right: 20,
+      top: spec.title && legend ? 72 : spec.title || legend ? 48 : 20,
+      bottom: 36
+    },
     tooltip:
       spec.tooltip === false
         ? undefined
         : {
             trigger: tooltipTrigger(spec),
-            backgroundColor: colors.tooltipBackground,
-            borderColor: colors.border,
-            textStyle: { color: colors.text }
+            confine: true,
+            padding: [10, 12],
+            borderWidth: 1,
+            backgroundColor: chrome.tooltipBackground,
+            borderColor: chrome.border,
+            textStyle: { color: chrome.text, fontFamily: chrome.fontFamily },
+            extraCssText: 'border-radius:8px;box-shadow:0 4px 18px rgba(0,0,0,0.12);'
           },
-    legend: shouldShowLegend(spec, series) ? { top: 4, textStyle: { color: colors.text } } : undefined,
-    textStyle: { color: colors.text },
+    legend: legend ? { top: spec.title ? 32 : 8, textStyle: { color: chrome.text } } : undefined,
+    textStyle: { color: chrome.text, fontFamily: chrome.fontFamily },
     title: spec.title
-      ? { text: spec.title, left: 'center', textStyle: { color: colors.text, fontSize: 14, fontWeight: 600 } }
+      ? { text: spec.title, left: 'center', top: 8, textStyle: { color: chrome.text, fontSize: 14, fontWeight: 600 } }
       : undefined,
     xAxis: { ...structure.xAxis, ...axisStyle },
     yAxis: { ...structure.yAxis, ...axisStyle },
     dataZoom: spec.dataZoom === false ? undefined : [{ type: 'inside' }],
-    series
+    series: series.map((series, index) => ({
+      ...series,
+      id: spec.kind + ':' + index,
+      ...(spec.kind === 'scatter' ? { itemStyle: { borderColor: chrome.tooltipBackground, borderWidth: 1 } } : {})
+    }))
   };
-
   if (structure.heatmap) {
     const valueRange = numericBounds(structure.heatmap.data, (item) => item[2]);
     return {
       ...base,
+      grid: { ...base.grid, bottom: 64 },
       dataZoom: undefined,
       visualMap: {
         calculable: true,
         orient: 'horizontal',
         left: 'center',
-        bottom: 0,
+        bottom: 8,
         min: valueRange?.minimum ?? 0,
         max: valueRange?.maximum ?? 1,
-        textStyle: { color: colors.text }
+        textStyle: { color: chrome.text },
+        inRange: { color: palette ?? (theme === 'dark' ? ['#173c3b', '#5eead4'] : ['#e6f4f1', '#0f766e']) }
       }
     };
   }
-
   return base;
 }
 
-function chartThemeDefinition(theme: ChartTheme): Record<string, unknown> {
-  const colors = chartColors[theme];
+function chartThemeDefinition(theme: ChartTheme, chrome: ChartChrome): Record<string, unknown> {
   return {
-    color: colors.palette,
+    color: chartColors[theme].palette,
     backgroundColor: 'transparent',
-    textStyle: { color: colors.text },
-    title: { textStyle: { color: colors.text } },
-    legend: { textStyle: { color: colors.text } },
-    categoryAxis: {
-      axisLabel: { color: colors.axis },
-      axisLine: { lineStyle: { color: colors.border } },
-      splitLine: { lineStyle: { color: colors.splitLine } }
-    },
-    valueAxis: {
-      axisLabel: { color: colors.axis },
-      axisLine: { lineStyle: { color: colors.border } },
-      splitLine: { lineStyle: { color: colors.splitLine } }
-    }
+    textStyle: { color: chrome.text, fontFamily: chrome.fontFamily }
   };
 }
 
@@ -408,18 +514,21 @@ function chartSeries(spec: Exclude<ChartSpec, { kind: 'heatmap' }>): readonly Re
         type: 'line',
         name: series.name,
         showSymbol: false,
+        lineStyle: { width: spec.style?.lineWidth ?? 2.25, cap: 'round', join: 'round' },
         data: series.points
       }));
     case 'scatter':
       return spec.series.map((series) => ({
         type: 'scatter',
         name: series.name,
-        symbolSize: 6,
+        symbolSize: spec.style?.symbolSize ?? 7,
         data: series.points
       }));
     case 'bar':
       return spec.series.map((series) => ({
         type: 'bar',
+        barMaxWidth: 40,
+        itemStyle: { borderRadius: [3, 3, 0, 0] },
         name: series.name,
         data: series.values
       }));
@@ -427,6 +536,8 @@ function chartSeries(spec: Exclude<ChartSpec, { kind: 'heatmap' }>): readonly Re
       return [
         {
           type: 'bar',
+          barMaxWidth: 40,
+          itemStyle: { borderRadius: [3, 3, 0, 0] },
           barCategoryGap: '8%',
           data: spec.bins.map((bin) => bin[2])
         }
@@ -436,7 +547,8 @@ function chartSeries(spec: Exclude<ChartSpec, { kind: 'heatmap' }>): readonly Re
         type: 'line',
         name: series.name,
         showSymbol: false,
-        areaStyle: { opacity: 0.18 },
+        lineStyle: { width: spec.style?.lineWidth ?? 2.25, cap: 'round', join: 'round' },
+        areaStyle: { opacity: 0.14 },
         data: series.points
       }));
     default:
@@ -475,7 +587,7 @@ function tooltipTrigger(spec: ChartSpec): 'axis' | 'item' {
   return spec.kind === 'scatter' || spec.kind === 'heatmap' ? 'item' : 'axis';
 }
 
-function shouldShowLegend(spec: ChartSpec, series: readonly Record<string, unknown>[]): boolean {
+function shouldShowLegend(spec: ChartSpec, series: readonly { name?: unknown }[]): boolean {
   if (spec.legend != null) return spec.legend;
   return series.filter((item) => typeof item.name === 'string' && item.name.length > 0).length > 1;
 }

--- a/packages/oxiquill/src/components/doc-runtime/InteractiveCell.tsx
+++ b/packages/oxiquill/src/components/doc-runtime/InteractiveCell.tsx
@@ -1,4 +1,5 @@
-import { useState } from 'preact/hooks';
+import { useLayoutEffect, useState } from 'preact/hooks';
+import { markRuntimeEvent } from '../../lib/doc-runtime/runtime-timing.js';
 import { shouldShowInputControls, shouldShowRunButton } from '../../lib/doc-runtime/interactive-cell-model.js';
 import type { RuntimeLabels } from '../../lib/doc-runtime/runtime-localization.js';
 import type { CellManifest } from '../../lib/doc-runtime/types.js';
@@ -43,6 +44,12 @@ function InteractiveCellPanel({
   const [isSourceVisible, setIsSourceVisible] = useState(cell.showSource);
   const runtime = useInteractiveCellRun(cell, runtimeVersion);
   const ids = interactiveCellIds(cell.id);
+  useLayoutEffect(() => {
+    markRuntimeEvent('hydrated', cell.id);
+  }, [cell.id]);
+  useLayoutEffect(() => {
+    if (runtime.result) markRuntimeEvent('output-rendered', cell.id);
+  }, [cell.id, runtime.result]);
 
   return (
     <section

--- a/packages/oxiquill/src/components/doc-runtime/InteractiveCell.tsx
+++ b/packages/oxiquill/src/components/doc-runtime/InteractiveCell.tsx
@@ -45,7 +45,7 @@ function InteractiveCellPanel({
   const [isSourceVisible, setIsSourceVisible] = useState(cell.showSource);
   const runtime = useInteractiveCellRun(cell, runtimeVersion);
   const ids = interactiveCellIds(cell.id);
-  const [pythonPreparation, setPythonPreparation] = useState(getPythonPreparationState);
+  const [pythonPreparation, setPythonPreparation] = useState<ReturnType<typeof getPythonPreparationState>>('idle');
   useEffect(() => {
     if (cell.language !== 'python') return;
     const update = () => setPythonPreparation(getPythonPreparationState());

--- a/packages/oxiquill/src/components/doc-runtime/InteractiveCell.tsx
+++ b/packages/oxiquill/src/components/doc-runtime/InteractiveCell.tsx
@@ -1,4 +1,5 @@
-import { useLayoutEffect, useState } from 'preact/hooks';
+import { useEffect, useLayoutEffect, useState } from 'preact/hooks';
+import { getPythonPreparationState, subscribePythonPreparation } from '../../lib/doc-runtime/runtime-client.js';
 import { markRuntimeEvent } from '../../lib/doc-runtime/runtime-timing.js';
 import { shouldShowInputControls, shouldShowRunButton } from '../../lib/doc-runtime/interactive-cell-model.js';
 import type { RuntimeLabels } from '../../lib/doc-runtime/runtime-localization.js';
@@ -44,6 +45,14 @@ function InteractiveCellPanel({
   const [isSourceVisible, setIsSourceVisible] = useState(cell.showSource);
   const runtime = useInteractiveCellRun(cell, runtimeVersion);
   const ids = interactiveCellIds(cell.id);
+  const [pythonPreparation, setPythonPreparation] = useState(getPythonPreparationState);
+  useEffect(() => {
+    if (cell.language !== 'python') return;
+    const update = () => setPythonPreparation(getPythonPreparationState());
+    const unsubscribe = subscribePythonPreparation(update);
+    update();
+    return unsubscribe;
+  }, [cell.language]);
   useLayoutEffect(() => {
     markRuntimeEvent('hydrated', cell.id);
   }, [cell.id]);
@@ -57,6 +66,8 @@ function InteractiveCellPanel({
       aria-labelledby={ids.title}
       data-cell-id={cell.id}
       data-language={cell.language}
+      data-python-packages={cell.language === 'python' ? JSON.stringify(cell.packages) : undefined}
+      data-python-timeout={cell.language === 'python' ? cell.timeoutMs : undefined}
       data-testid={`cell-${cell.id}`}
     >
       <div class="doc-cell__header">
@@ -89,7 +100,11 @@ function InteractiveCellPanel({
                 if (!runtime.isRunning && runtime.inputsValid) runtime.run();
               }}
             >
-              {runtime.isRunning ? labels.running : labels.run}
+              {runtime.isRunning
+                ? runtime.phase === 'preparing'
+                  ? labels.pythonPreparing
+                  : labels.running
+                : labels.run}
             </button>
           ) : null}
         </div>
@@ -124,11 +139,17 @@ function InteractiveCellPanel({
         />
       ) : null}
 
+      {cell.language === 'python' && pythonPreparation === 'preparing' && !runtime.isRunning ? (
+        <p class="doc-cell__preparing" role="status">
+          {labels.pythonPreparing}
+        </p>
+      ) : null}
       <CellOutput
         cellTitle={cell.title}
         result={runtime.result}
         error={runtime.error}
         isRunning={runtime.isRunning}
+        isPreparing={runtime.phase === 'preparing'}
         isComplete={runtime.isComplete}
         retry={runtime.run}
         canRetry={runtime.inputsValid}

--- a/packages/oxiquill/src/components/doc-runtime/InteractiveCell.tsx
+++ b/packages/oxiquill/src/components/doc-runtime/InteractiveCell.tsx
@@ -122,6 +122,9 @@ function InteractiveCellPanel({
         result={runtime.result}
         error={runtime.error}
         isRunning={runtime.isRunning}
+        isComplete={runtime.isComplete}
+        retry={runtime.run}
+        canRetry={runtime.inputsValid}
         labels={labels}
         outputId={ids.output}
         runMode={cell.run}

--- a/packages/oxiquill/src/components/doc-runtime/OutputRenderer.tsx
+++ b/packages/oxiquill/src/components/doc-runtime/OutputRenderer.tsx
@@ -34,10 +34,11 @@ export default function OutputRenderer({
   outputs,
   resultIdentity
 }: OutputRendererProps) {
+  const keys = artifactKeys(outputs);
   return (
     <>
       {outputs.map((output, index) => (
-        <ArtifactErrorBoundary key={artifactKey(output, index)} index={output.index} labels={labels} resetKey={output}>
+        <ArtifactErrorBoundary key={keys[index]} index={output.index} labels={labels} resetKey={output}>
           <ArtifactOutput
             idPrefix={`${idPrefix}-artifact-${output.index}`}
             labels={labels}
@@ -250,8 +251,20 @@ export function imageArtifactSource(output: ValidatedImageArtifact): string {
   return output.source;
 }
 
-function artifactKey(output: ValidatedArtifactResult, index: number): string {
-  return output.status === 'valid' && output.artifact.id ? `${output.artifact.id}:${index}` : String(index);
+export function artifactKeys(outputs: readonly ValidatedArtifactResult[]): string[] {
+  const occurrences = new Map<string, number>();
+  return outputs.map((output) => {
+    const identity =
+      output.status === 'error'
+        ? ['error']
+        : output.artifact.id !== undefined
+          ? ['id', output.artifact.id]
+          : ['kind', output.artifact.kind];
+    const group = JSON.stringify(identity);
+    const occurrence = (occurrences.get(group) ?? 0) + 1;
+    occurrences.set(group, occurrence);
+    return JSON.stringify([...identity, occurrence]);
+  });
 }
 
 function loadChartOutput(): Promise<ChartOutputModule> {

--- a/packages/oxiquill/src/components/doc-runtime/useInteractiveCellRun.ts
+++ b/packages/oxiquill/src/components/doc-runtime/useInteractiveCellRun.ts
@@ -4,7 +4,7 @@ import { createLatestRequestScheduler, createRunOnceCache } from '../../lib/doc-
 import { boundedErrorMessage } from '../../lib/doc-runtime/output-limits.mjs';
 import { runInteractiveCell } from '../../lib/doc-runtime/runtime-client.js';
 import type { NormalizedCellExecutionResult } from '../../lib/doc-runtime/output-artifacts.js';
-import type { CellManifest, InputValues } from '../../lib/doc-runtime/types.js';
+import type { CellManifest, InputValues, RuntimeExecutionPhase } from '../../lib/doc-runtime/types.js';
 
 type InputValue = InputValues[string];
 
@@ -16,6 +16,7 @@ type CellRunRequest = {
 };
 
 type ExecutionState = {
+  phase?: RuntimeExecutionPhase;
   status: 'idle' | 'running' | 'success' | 'error';
   result?: NormalizedCellExecutionResult;
   error?: string;
@@ -38,7 +39,12 @@ export function useInteractiveCellRun(cell: CellManifest, runtimeVersion: string
       { autorunKey, cell: requestedCell, runtimeVersion: requestedVersion, values: requestedValues },
       signal
     ) => {
-      const execute = () => runInteractiveCell(requestedCell, requestedValues, requestedVersion, signal);
+      const execute = () =>
+        requestedCell.language === 'python'
+          ? runInteractiveCell(requestedCell, requestedValues, requestedVersion, signal, (phase) => {
+              if (!signal.aborted) setExecution((previous) => ({ ...previous, phase }));
+            })
+          : runInteractiveCell(requestedCell, requestedValues, requestedVersion, signal);
       return autorunKey ? autorunRequests.getOrCreate(autorunKey, execute) : execute();
     },
     onCancelled: () => {
@@ -51,7 +57,11 @@ export function useInteractiveCellRun(cell: CellManifest, runtimeVersion: string
       setExecution({ result, status: 'success' });
     },
     onScheduled: () => {
-      setExecution((previous) => ({ ...previous, status: 'running' }));
+      setExecution((previous) => ({
+        ...previous,
+        phase: cell.language === 'python' ? 'preparing' : 'executing',
+        status: 'running'
+      }));
     }
   });
 
@@ -105,6 +115,7 @@ export function useInteractiveCellRun(cell: CellManifest, runtimeVersion: string
   }
 
   return {
+    phase: execution.phase,
     error: execution.error,
     isComplete: execution.status === 'success',
     inputsValid,

--- a/packages/oxiquill/src/components/doc-runtime/useInteractiveCellRun.ts
+++ b/packages/oxiquill/src/components/doc-runtime/useInteractiveCellRun.ts
@@ -15,11 +15,11 @@ type CellRunRequest = {
   values: InputValues;
 };
 
-type ExecutionState =
-  | { status: 'idle' }
-  | { status: 'running' }
-  | { result: NormalizedCellExecutionResult; status: 'success' }
-  | { error: string; status: 'error' };
+type ExecutionState = {
+  status: 'idle' | 'running' | 'success' | 'error';
+  result?: NormalizedCellExecutionResult;
+  error?: string;
+};
 
 const autorunRequests = createRunOnceCache<string, NormalizedCellExecutionResult>();
 const reactiveDebounceMs = 150;
@@ -42,16 +42,16 @@ export function useInteractiveCellRun(cell: CellManifest, runtimeVersion: string
       return autorunKey ? autorunRequests.getOrCreate(autorunKey, execute) : execute();
     },
     onCancelled: () => {
-      setExecution({ status: 'idle' });
+      setExecution((previous) => ({ ...previous, status: 'idle' }));
     },
     onError: (caught) => {
-      setExecution({ error: boundedErrorMessage(caught), status: 'error' });
+      setExecution((previous) => ({ ...previous, error: boundedErrorMessage(caught), status: 'error' }));
     },
     onResult: (result) => {
       setExecution({ result, status: 'success' });
     },
     onScheduled: () => {
-      setExecution({ status: 'running' });
+      setExecution((previous) => ({ ...previous, status: 'running' }));
     }
   });
 
@@ -100,15 +100,16 @@ export function useInteractiveCellRun(cell: CellManifest, runtimeVersion: string
     setInputsValid(nextInvalidInputs.size === 0);
     if (!valid) {
       schedulerRef.current?.cancel();
-      setExecution({ status: 'idle' });
+      setExecution((previous) => ({ ...previous, status: 'idle' }));
     }
   }
 
   return {
-    error: execution.status === 'error' ? execution.error : undefined,
+    error: execution.error,
+    isComplete: execution.status === 'success',
     inputsValid,
     isRunning: execution.status === 'running',
-    result: execution.status === 'success' ? execution.result : undefined,
+    result: execution.result,
     run,
     setInputValue,
     setInputValidity,

--- a/packages/oxiquill/src/config/metadata.mjs
+++ b/packages/oxiquill/src/config/metadata.mjs
@@ -36,15 +36,19 @@ function normalizePythonOptions(options) {
   if (!options || typeof options !== 'object' || Array.isArray(options)) {
     throw new TypeError('python must be an object.');
   }
-  const unknownFields = Object.keys(options).filter((name) => name !== 'offline' && name !== 'packageMirror');
+  const unknownFields = Object.keys(options).filter(
+    (name) => name !== 'offline' && name !== 'packageMirror' && name !== 'preload'
+  );
   if (unknownFields.length > 0) {
     throw new TypeError(`Unknown python option: ${unknownFields.sort().join(', ')}.`);
   }
 
+  const preload = options.preload ?? false;
+  if (typeof preload !== 'boolean') throw new TypeError('python.preload must be a boolean.');
   const offline = options.offline ?? false;
   if (typeof offline !== 'boolean') throw new TypeError('python.offline must be a boolean.');
   const packageMirror = normalizePackageMirror(options.packageMirror);
-  return Object.freeze({ offline, ...(packageMirror ? { packageMirror } : {}) });
+  return Object.freeze({ offline, preload, ...(packageMirror ? { packageMirror } : {}) });
 }
 
 function normalizePackageMirror(value) {

--- a/packages/oxiquill/src/config/project-config.mjs
+++ b/packages/oxiquill/src/config/project-config.mjs
@@ -17,6 +17,8 @@ export async function loadOxiquillProjectConfig({ cwd = process.cwd(), configFil
   const invocationCwd = path.resolve(pathFromConfigValue(cwd, process.cwd(), 'cwd'));
   const resolvedConfigFile = resolveAstroConfigFile({ cwd: invocationCwd, configFile });
   let loaded;
+  const hadNodeEnv = Object.hasOwn(process.env, 'NODE_ENV');
+  const nodeEnv = process.env.NODE_ENV;
 
   try {
     loaded = await loadConfigFromFile(
@@ -29,6 +31,9 @@ export async function loadOxiquillProjectConfig({ cwd = process.cwd(), configFil
     );
   } catch (error) {
     throw new Error(`Unable to load Oxiquill project config from ${resolvedConfigFile}.`, { cause: error });
+  } finally {
+    if (hadNodeEnv) process.env.NODE_ENV = nodeEnv;
+    else delete process.env.NODE_ENV;
   }
 
   if (!loaded) {

--- a/packages/oxiquill/src/generator/doc-runtime/rust-codegen/macros.mjs
+++ b/packages/oxiquill/src/generator/doc-runtime/rust-codegen/macros.mjs
@@ -166,22 +166,32 @@ function generateRecordsTableMacro() {
 
 function generateLineChartMacro() {
   return `    macro_rules! emit_line_chart {
-        ($series:expr) => {{
+        ($series:expr$(, $style:expr)?) => {{
             let spec = xy_chart_spec(
                 "line",
                 serde_json::to_value(&$series).map_err(|error| error.to_string())?,
                 None,
                 None,
             )?;
+            $(let spec = {
+                let mut spec = spec;
+                spec["style"] = serde_json::to_value(&$style).map_err(|error| error.to_string())?;
+                spec
+            };)?
             __outputs.borrow_mut().push(OutputArtifact::Chart(ChartArtifact { spec }));
         }};
-        ($series:expr, $x_label:expr, $y_label:expr) => {{
+        ($series:expr, $x_label:expr, $y_label:expr$(, $style:expr)?) => {{
             let spec = xy_chart_spec(
                 "line",
                 serde_json::to_value(&$series).map_err(|error| error.to_string())?,
                 Some(($x_label).to_string()),
                 Some(($y_label).to_string()),
             )?;
+            $(let spec = {
+                let mut spec = spec;
+                spec["style"] = serde_json::to_value(&$style).map_err(|error| error.to_string())?;
+                spec
+            };)?
             __outputs.borrow_mut().push(OutputArtifact::Chart(ChartArtifact { spec }));
         }};
     }`;
@@ -189,22 +199,32 @@ function generateLineChartMacro() {
 
 function generateScatterChartMacro() {
   return `    macro_rules! emit_scatter_chart {
-        ($series:expr) => {{
+        ($series:expr$(, $style:expr)?) => {{
             let spec = xy_chart_spec(
                 "scatter",
                 serde_json::to_value(&$series).map_err(|error| error.to_string())?,
                 None,
                 None,
             )?;
+            $(let spec = {
+                let mut spec = spec;
+                spec["style"] = serde_json::to_value(&$style).map_err(|error| error.to_string())?;
+                spec
+            };)?
             __outputs.borrow_mut().push(OutputArtifact::Chart(ChartArtifact { spec }));
         }};
-        ($series:expr, $x_label:expr, $y_label:expr) => {{
+        ($series:expr, $x_label:expr, $y_label:expr$(, $style:expr)?) => {{
             let spec = xy_chart_spec(
                 "scatter",
                 serde_json::to_value(&$series).map_err(|error| error.to_string())?,
                 Some(($x_label).to_string()),
                 Some(($y_label).to_string()),
             )?;
+            $(let spec = {
+                let mut spec = spec;
+                spec["style"] = serde_json::to_value(&$style).map_err(|error| error.to_string())?;
+                spec
+            };)?
             __outputs.borrow_mut().push(OutputArtifact::Chart(ChartArtifact { spec }));
         }};
     }`;
@@ -212,11 +232,16 @@ function generateScatterChartMacro() {
 
 function generateBarChartMacro() {
   return `    macro_rules! emit_bar_chart {
-        ($categories:expr, $values:expr) => {{
+        ($categories:expr, $values:expr$(, $style:expr)?) => {{
             let spec = bar_chart_spec(
                 serde_json::to_value(&$categories).map_err(|error| error.to_string())?,
                 serde_json::to_value(&$values).map_err(|error| error.to_string())?,
             )?;
+            $(let spec = {
+                let mut spec = spec;
+                spec["style"] = serde_json::to_value(&$style).map_err(|error| error.to_string())?;
+                spec
+            };)?
             __outputs.borrow_mut().push(OutputArtifact::Chart(ChartArtifact { spec }));
         }};
     }`;
@@ -224,10 +249,15 @@ function generateBarChartMacro() {
 
 function generateHistogramMacro() {
   return `    macro_rules! emit_histogram {
-        ($bins:expr) => {{
+        ($bins:expr$(, $style:expr)?) => {{
             let spec = histogram_chart_spec(
                 serde_json::to_value(&$bins).map_err(|error| error.to_string())?,
             )?;
+            $(let spec = {
+                let mut spec = spec;
+                spec["style"] = serde_json::to_value(&$style).map_err(|error| error.to_string())?;
+                spec
+            };)?
             __outputs.borrow_mut().push(OutputArtifact::Chart(ChartArtifact { spec }));
         }};
     }`;
@@ -235,10 +265,15 @@ function generateHistogramMacro() {
 
 function generateHeatmapMacro() {
   return `    macro_rules! emit_heatmap {
-        ($data:expr) => {{
+        ($data:expr$(, $style:expr)?) => {{
             let spec = heatmap_chart_spec(
                 serde_json::to_value(&$data).map_err(|error| error.to_string())?,
             )?;
+            $(let spec = {
+                let mut spec = spec;
+                spec["style"] = serde_json::to_value(&$style).map_err(|error| error.to_string())?;
+                spec
+            };)?
             __outputs.borrow_mut().push(OutputArtifact::Chart(ChartArtifact { spec }));
         }};
     }`;
@@ -246,15 +281,14 @@ function generateHeatmapMacro() {
 
 function generateLinePlotMacro() {
   return `    macro_rules! emit_line_plot {
-        ($points:expr, $x_label:expr, $y_label:expr) => {{
+        ($points:expr, $x_label:expr, $y_label:expr$(, $style:expr)?) => {{
             let x_label = ($x_label).to_owned();
             let y_label = ($y_label).to_owned();
             let points: Vec<[f64; 2]> = ($points)
                 .iter()
                 .map(|point| [f64::from(point.n), point.x])
                 .collect();
-            __outputs.borrow_mut().push(OutputArtifact::Chart(ChartArtifact {
-                spec: serde_json::json!({
+            let spec = serde_json::json!({
                     "kind": "line",
                     "xLabel": x_label,
                     "yLabel": y_label,
@@ -263,8 +297,13 @@ function generateLinePlotMacro() {
                     "tooltip": true,
                     "dataZoom": true,
                     "series": [{ "points": points }],
-                }),
-            }));
+                });
+            $(let spec = {
+                let mut spec = spec;
+                spec["style"] = serde_json::to_value(&$style).map_err(|error| error.to_string())?;
+                spec
+            };)?
+            __outputs.borrow_mut().push(OutputArtifact::Chart(ChartArtifact { spec }));
         }};
     }`;
 }

--- a/packages/oxiquill/src/generator/doc-runtime/toolchain-preflight.mjs
+++ b/packages/oxiquill/src/generator/doc-runtime/toolchain-preflight.mjs
@@ -141,16 +141,15 @@ function errorMessage(error) {
   return error instanceof Error && error.message ? error.message : String(error);
 }
 
-/* v8 ignore start -- external process adapter is covered through injected runCommand. */
-function runCommandWithCapturedOutput(command, args) {
+export function runCommandWithCapturedOutput(command, args, spawnProcess = spawn) {
   return new Promise((resolve, reject) => {
-    const child = spawn(command, args, { stdio: ['ignore', 'pipe', 'pipe'] });
+    const child = spawnProcess(command, args, { stdio: ['ignore', 'pipe', 'pipe'] });
     const stdout = [];
     const stderr = [];
     child.stdout.on('data', (chunk) => stdout.push(chunk));
     child.stderr.on('data', (chunk) => stderr.push(chunk));
     child.on('error', reject);
-    child.on('exit', (code, signal) => {
+    child.on('close', (code, signal) => {
       if (code === 0) {
         resolve(Buffer.concat(stdout).toString('utf8'));
       } else {
@@ -159,4 +158,3 @@ function runCommandWithCapturedOutput(command, args) {
     });
   });
 }
-/* v8 ignore stop */

--- a/packages/oxiquill/src/lib/doc-runtime/output-artifact-validation.ts
+++ b/packages/oxiquill/src/lib/doc-runtime/output-artifact-validation.ts
@@ -3,6 +3,9 @@ import type {
   BaseChartSpec,
   ChartAxisType,
   ChartSpec,
+  ChartPalette,
+  LineChartStyle,
+  ScatterChartStyle,
   HtmlArtifact,
   ImageArtifact,
   JsonArtifact,
@@ -434,7 +437,12 @@ function validateTableCell(
 function validateChartSpec(value: unknown): ChartSpec {
   const record = plainRecord(value, 'Chart spec');
   const kind = requiredString(record, 'kind', 'Chart spec');
-  const base = validateBaseChartSpec(record);
+  const base = {
+    ...validateBaseChartSpec(record),
+    ...(Object.hasOwn(record, 'style')
+      ? { style: validateChartStyle(requiredOwnValue(record, 'style', 'Chart spec'), kind) }
+      : {})
+  };
 
   switch (kind) {
     case 'line': {
@@ -554,6 +562,85 @@ function validateChartSpec(value: unknown): ChartSpec {
     }
     default:
       throw new ArtifactValidationError(`Chart kind ${quoted(kind)} is not supported.`);
+  }
+}
+
+function validateChartStyle(value: unknown, kind: string): LineChartStyle & ScatterChartStyle {
+  const context = `${kind} chart style`;
+  const record = plainRecord(value, context);
+  const line = kind === 'line' || kind === 'area';
+  rejectUnknownStyleFields(
+    record,
+    [
+      'palette',
+      'showGrid',
+      'animation',
+      'animationDurationMs',
+      ...(line ? ['lineWidth'] : []),
+      ...(kind === 'scatter' ? ['symbolSize'] : [])
+    ],
+    context
+  );
+  const style: LineChartStyle & ScatterChartStyle = {};
+  for (const field of ['showGrid', 'animation'] as const) {
+    if (Object.hasOwn(record, field)) style[field] = optionalBoolean(record, field, context);
+  }
+  for (const [field, minimum, maximum] of [
+    ['animationDurationMs', 0, 2000],
+    ['lineWidth', 1, 8],
+    ['symbolSize', 2, 32]
+  ] as const) {
+    if (!Object.hasOwn(record, field)) continue;
+    const number = requiredOwnValue(record, field, context);
+    if (
+      typeof number !== 'number' ||
+      !Number.isFinite(number) ||
+      number < minimum ||
+      number > maximum ||
+      (field === 'animationDurationMs' && !Number.isInteger(number))
+    ) {
+      throw new ArtifactValidationError(
+        `${context} ${field} must be ${field === 'animationDurationMs' ? 'an integer' : 'finite'} within ${minimum}–${maximum}.`
+      );
+    }
+    style[field] = number;
+  }
+  if (Object.hasOwn(record, 'palette')) {
+    const palette = plainRecord(requiredOwnValue(record, 'palette', context), `${context} palette`);
+    rejectUnknownStyleFields(palette, ['light', 'dark'], `${context} palette`);
+    if (Reflect.ownKeys(palette).length === 0)
+      throw new ArtifactValidationError(`${context} palette must contain light or dark colors.`);
+    const validated: ChartPalette = {};
+    for (const theme of ['light', 'dark'] as const) {
+      if (!Object.hasOwn(palette, theme)) continue;
+      const colors = plainArray(requiredOwnValue(palette, theme, context), `${context} palette.${theme}`);
+      const minimum = kind === 'heatmap' ? 2 : 1;
+      if (colors.length < minimum || colors.length > 12)
+        throw new ArtifactValidationError(`${context} palette.${theme} must contain ${minimum}–12 colors.`);
+      const seen = new Set<string>();
+      validated[theme] = colors.map((color) => {
+        if (typeof color !== 'string' || !/^#(?:[\da-f]{3}|[\da-f]{6})$/iu.test(color)) {
+          throw new ArtifactValidationError(`${context} palette colors must be #RGB or #RRGGBB.`);
+        }
+        const normalized = (
+          color.length === 4 ? Array.from(color.slice(1), (part) => part + part).join('') : color.slice(1)
+        ).toLowerCase();
+        if (seen.has(normalized))
+          throw new ArtifactValidationError(`${context} palette.${theme} colors must be unique.`);
+        seen.add(normalized);
+        return color;
+      });
+    }
+    style.palette = validated;
+  }
+  return style;
+}
+
+function rejectUnknownStyleFields(record: Record<string, unknown>, allowed: readonly string[], context: string): void {
+  for (const field of Reflect.ownKeys(record)) {
+    if (typeof field !== 'string' || !allowed.includes(field)) {
+      throw new ArtifactValidationError(`${context} has unknown field ${quoted(String(field))}.`);
+    }
   }
 }
 

--- a/packages/oxiquill/src/lib/doc-runtime/python-display-support.ts
+++ b/packages/oxiquill/src/lib/doc-runtime/python-display-support.ts
@@ -5,6 +5,8 @@ import base64
 import builtins
 import io
 import json
+import os
+import sys
 
 __oxiquill_outputs = []
 __oxiquill_displayed_figures = set()
@@ -70,8 +72,8 @@ def __oxiquill_json_artifact(value, title=None, caption=None):
 
 def __oxiquill_scalar_value(value):
     try:
-        import pandas as pd
-        is_missing = pd.isna(value)
+        pd = sys.modules.get("pandas")
+        is_missing = pd.isna(value) if pd is not None else False
         try:
             if bool(is_missing):
                 return None
@@ -344,9 +346,9 @@ def __oxiquill_markdown_repr_artifact(value, *, title=None, caption=None):
 
 const pythonDisplayMatplotlibSupport = String.raw`
 def __oxiquill_configure_matplotlib():
-    try:
-        import matplotlib
-    except Exception:
+    os.environ["MPLBACKEND"] = "Agg"
+    matplotlib = sys.modules.get("matplotlib")
+    if matplotlib is None:
         return False
     try:
         matplotlib.use("Agg", force=True)
@@ -388,9 +390,8 @@ def __oxiquill_figure_to_image(fig, *, preferred="svg", title=None, caption=None
     )
 
 def __oxiquill_collect_matplotlib_outputs(preferred="svg", close_figures=True):
-    try:
-        import matplotlib.pyplot as plt
-    except Exception:
+    plt = sys.modules.get("matplotlib.pyplot")
+    if plt is None:
         return []
     outputs = []
     for number in list(plt.get_fignums()):

--- a/packages/oxiquill/src/lib/doc-runtime/python-preload.ts
+++ b/packages/oxiquill/src/lib/doc-runtime/python-preload.ts
@@ -1,0 +1,41 @@
+import type { preparePythonRuntime } from './runtime-client.js';
+
+export function installPythonPreloader(
+  page: Document,
+  loadRuntime: () => Promise<{ preparePythonRuntime: typeof preparePythonRuntime }>
+): () => void {
+  let firstCell: Element | null = null;
+  let disposed = false;
+  const prepare = () => {
+    const cell = page.querySelector('.doc-cell[data-language="python"]');
+    if (!cell || cell === firstCell) return;
+    firstCell = cell;
+    let packages: unknown;
+    try {
+      packages = JSON.parse(cell.getAttribute('data-python-packages') ?? '[]');
+    } catch {
+      return;
+    }
+    const timeout = Number(cell.getAttribute('data-python-timeout'));
+    if (!Array.isArray(packages) || !packages.every((name): name is string => typeof name === 'string')) return;
+    void loadRuntime()
+      .then((runtime) => {
+        if (!disposed) return runtime.preparePythonRuntime(packages, timeout > 0 ? timeout : undefined);
+      })
+      .catch(() => {
+        // A later cell run retries through the shared runtime's recovery path.
+      });
+  };
+  if (page.readyState === 'loading') page.addEventListener('DOMContentLoaded', prepare, { once: true });
+  else prepare();
+  page.addEventListener('astro:page-load', prepare);
+  return () => {
+    disposed = true;
+    page.removeEventListener('DOMContentLoaded', prepare);
+    page.removeEventListener('astro:page-load', prepare);
+  };
+}
+
+if (typeof document !== 'undefined') {
+  installPythonPreloader(document, () => import('./runtime-client.js'));
+}

--- a/packages/oxiquill/src/lib/doc-runtime/python-worker.ts
+++ b/packages/oxiquill/src/lib/doc-runtime/python-worker.ts
@@ -3,7 +3,7 @@ import { boundedErrorMessage, createBoundedTextAccumulator, outputArtifactLimits
 import { pythonDisplaySupportCode } from './python-display-support.js';
 import { createPythonCellResult, toOutputArtifacts } from './python-cell-result.js';
 import { createSerialRequestQueue } from './python-worker-queue.js';
-import type { RuntimeWorkerRequest, RuntimeWorkerResponse } from './types.js';
+import type { PythonWorkerRequest, PythonWorkerResponse } from './types.js';
 import { boundWorkerResult } from './worker-output.js';
 import { markRuntimeEvent, measureRuntimePhase } from './runtime-timing.js';
 
@@ -15,14 +15,14 @@ type LoadPyodide = typeof import('pyodide').loadPyodide;
 type PyodideRuntime = Awaited<ReturnType<LoadPyodide>>;
 
 type WorkerScope = {
-  addEventListener(type: 'message', listener: (event: MessageEvent<RuntimeWorkerRequest>) => void): void;
-  postMessage(response: RuntimeWorkerResponse): void;
+  addEventListener(type: 'message', listener: (event: MessageEvent<PythonWorkerRequest>) => void): void;
+  postMessage(response: PythonWorkerResponse): void;
 };
 
 type PyodideModule = { loadPyodide: LoadPyodide };
 type PythonWorkerHandlerDependencies = {
-  ensurePyodide: () => Promise<PyodideRuntime>;
-  postMessage: (response: RuntimeWorkerResponse) => void;
+  ensurePyodide: (packages?: readonly string[]) => Promise<PyodideRuntime>;
+  postMessage: (response: PythonWorkerResponse) => void;
 };
 type PyodideModuleDependencies = {
   createObjectUrl?: (blob: Blob) => string;
@@ -48,21 +48,27 @@ worker.addEventListener('message', (event) => {
 export function createPythonWorkerRequestHandler({
   ensurePyodide,
   postMessage
-}: PythonWorkerHandlerDependencies): (request: RuntimeWorkerRequest) => Promise<void> {
+}: PythonWorkerHandlerDependencies): (request: PythonWorkerRequest) => Promise<void> {
   return async (request) => {
     try {
-      const pyodide = await ensurePyodide();
+      postMessage({ type: 'progress', requestId: request.requestId, phase: 'preparing' });
+      const pyodide = await ensurePyodide(request.packages);
+      const packages = request.packages?.filter((name) => !Object.hasOwn(pyodide.loadedPackages ?? {}, name)) ?? [];
+      if (packages.length > 0) {
+        await measureRuntimePhase('packages', 'cellId' in request ? request.cellId : 'python', () =>
+          pyodide.loadPackage(packages)
+        );
+      }
+      if (!('cellId' in request)) {
+        postMessage({ type: 'ready', requestId: request.requestId, ok: true });
+        return;
+      }
       const stdout = createBoundedTextAccumulator(outputArtifactLimits.bytesPerStream, '\n');
       const stderr = createBoundedTextAccumulator(outputArtifactLimits.bytesPerStream, '\n');
 
       pyodide.setStdout({ batched: stdout.append });
       pyodide.setStderr({ batched: stderr.append });
 
-      if (request.packages && request.packages.length > 0) {
-        await measureRuntimePhase('packages', request.cellId, () =>
-          pyodide.loadPackage(Array.from(request.packages ?? []))
-        );
-      }
       if (request.source) {
         await measureRuntimePhase('imports', request.cellId, () =>
           pyodide.loadPackagesFromImports(request.source ?? '')
@@ -71,6 +77,7 @@ export function createPythonWorkerRequestHandler({
       await measureRuntimePhase('display-prepare', request.cellId, () =>
         pyodide.runPython('__oxiquill_prepare_cell()')
       );
+      postMessage({ type: 'progress', requestId: request.requestId, phase: 'executing' });
 
       const globals = pyodide.toPy(request.inputs);
       let value: unknown = null;
@@ -129,11 +136,11 @@ export function createPythonRuntimeLoader({
   indexUrl: string;
   importModule?: (moduleUrl: string) => Promise<PyodideModule>;
   moduleUrl: string;
-}): () => Promise<PyodideRuntime> {
+}): (packages?: readonly string[]) => Promise<PyodideRuntime> {
   let pyodideReady: Promise<PyodideRuntime> | undefined;
   let loadPyodideReady: Promise<LoadPyodide> | undefined;
 
-  return () => {
+  return (packages = []) => {
     if (!loadPyodideReady) {
       const importedLoader = importModule(moduleUrl).then((module) => module.loadPyodide);
       loadPyodideReady = importedLoader;
@@ -145,7 +152,7 @@ export function createPythonRuntimeLoader({
     if (!pyodideReady) {
       const runtime = loadPyodideReady.then(async (loadPyodide) => {
         const pyodide = await measureRuntimePhase('initialization', 'python', () =>
-          loadPyodide({ indexURL: indexUrl })
+          loadPyodide({ indexURL: indexUrl, packages: Array.from(packages) })
         );
         await measureRuntimePhase('display-support', 'python', () => pyodide.runPythonAsync(pythonDisplaySupportCode));
         return pyodide;

--- a/packages/oxiquill/src/lib/doc-runtime/python-worker.ts
+++ b/packages/oxiquill/src/lib/doc-runtime/python-worker.ts
@@ -5,6 +5,7 @@ import { createPythonCellResult, toOutputArtifacts } from './python-cell-result.
 import { createSerialRequestQueue } from './python-worker-queue.js';
 import type { RuntimeWorkerRequest, RuntimeWorkerResponse } from './types.js';
 import { boundWorkerResult } from './worker-output.js';
+import { markRuntimeEvent, measureRuntimePhase } from './runtime-timing.js';
 
 export { pythonDisplaySupportCode } from './python-display-support.js';
 export { createPythonCellResult } from './python-cell-result.js';
@@ -31,6 +32,7 @@ type PyodideModuleDependencies = {
 };
 
 const worker = self as unknown as WorkerScope;
+markRuntimeEvent('worker-ready', 'python');
 const pyodideUrls = resolvePyodideUrls();
 const ensurePyodide = createPythonRuntimeLoader(pyodideUrls);
 const handleRequest = createPythonWorkerRequestHandler({
@@ -57,12 +59,18 @@ export function createPythonWorkerRequestHandler({
       pyodide.setStderr({ batched: stderr.append });
 
       if (request.packages && request.packages.length > 0) {
-        await pyodide.loadPackage(Array.from(request.packages));
+        await measureRuntimePhase('packages', request.cellId, () =>
+          pyodide.loadPackage(Array.from(request.packages ?? []))
+        );
       }
       if (request.source) {
-        await pyodide.loadPackagesFromImports(request.source);
+        await measureRuntimePhase('imports', request.cellId, () =>
+          pyodide.loadPackagesFromImports(request.source ?? '')
+        );
       }
-      pyodide.runPython('__oxiquill_prepare_cell()');
+      await measureRuntimePhase('display-prepare', request.cellId, () =>
+        pyodide.runPython('__oxiquill_prepare_cell()')
+      );
 
       const globals = pyodide.toPy(request.inputs);
       let value: unknown = null;
@@ -71,13 +79,21 @@ export function createPythonWorkerRequestHandler({
         for (const inputName of request.integerInputNames ?? []) {
           pyodide.runPython(pythonIntegerConversionCode(inputName), { globals });
         }
-        value = toSerializable(await pyodide.runPythonAsync(request.source ?? '', { globals }));
+        value = toSerializable(
+          await measureRuntimePhase('execution', request.cellId, () =>
+            pyodide.runPythonAsync(request.source ?? '', { globals })
+          )
+        );
       } finally {
         globals.destroy();
       }
       const displayOutputs = toOutputArtifacts(toSerializable(pyodide.runPython('__oxiquill_take_outputs()')));
       const matplotlibOutputs = toOutputArtifacts(
-        toSerializable(pyodide.runPython('__oxiquill_collect_matplotlib_outputs()'))
+        toSerializable(
+          await measureRuntimePhase('display-collect', request.cellId, () =>
+            pyodide.runPython('__oxiquill_collect_matplotlib_outputs()')
+          )
+        )
       );
 
       const stdoutResult = stdout.take();
@@ -128,8 +144,10 @@ export function createPythonRuntimeLoader({
 
     if (!pyodideReady) {
       const runtime = loadPyodideReady.then(async (loadPyodide) => {
-        const pyodide = await loadPyodide({ indexURL: indexUrl });
-        await pyodide.runPythonAsync(pythonDisplaySupportCode);
+        const pyodide = await measureRuntimePhase('initialization', 'python', () =>
+          loadPyodide({ indexURL: indexUrl })
+        );
+        await measureRuntimePhase('display-support', 'python', () => pyodide.runPythonAsync(pythonDisplaySupportCode));
         return pyodide;
       });
       pyodideReady = runtime;

--- a/packages/oxiquill/src/lib/doc-runtime/runtime-client.ts
+++ b/packages/oxiquill/src/lib/doc-runtime/runtime-client.ts
@@ -3,6 +3,7 @@ import { ExecutionCancellationError } from './execution-cancellation.js';
 import { assertValidInputValues, completeInputValues } from './interactive-input-validation.js';
 import { normalizeCellExecutionResult, type NormalizedCellExecutionResult } from './output-artifacts.js';
 import { boundedErrorMessage } from './output-limits.mjs';
+import { markRuntimeEvent } from './runtime-timing.js';
 
 type PendingRequest = {
   reject: (reason: Error) => void;
@@ -105,6 +106,7 @@ export function createInteractiveCellRunner(dependencies: RuntimeClientDependenc
     const current = workers.get(language);
     if (current) return current;
 
+    markRuntimeEvent('worker-start', language);
     const worker = dependencies.createWorker(language);
 
     try {

--- a/packages/oxiquill/src/lib/doc-runtime/runtime-client.ts
+++ b/packages/oxiquill/src/lib/doc-runtime/runtime-client.ts
@@ -1,4 +1,11 @@
-import type { CellLanguage, CellManifest, InputValues, RuntimeWorkerRequest, RuntimeWorkerResponse } from './types.js';
+import type {
+  CellLanguage,
+  CellManifest,
+  InputValues,
+  RuntimeWorkerRequest,
+  PythonWorkerResponse,
+  RuntimeExecutionPhase
+} from './types.js';
 import { ExecutionCancellationError } from './execution-cancellation.js';
 import { assertValidInputValues, completeInputValues } from './interactive-input-validation.js';
 import { normalizeCellExecutionResult, type NormalizedCellExecutionResult } from './output-artifacts.js';
@@ -7,11 +14,19 @@ import { markRuntimeEvent } from './runtime-timing.js';
 
 type PendingRequest = {
   reject: (reason: Error) => void;
-  resolve: (value: NormalizedCellExecutionResult) => void;
   timeout: ReturnType<typeof setTimeout>;
   worker: Worker;
   removeAbortListener: () => void;
-};
+} & (
+  | {
+      type: 'execute';
+      resolve: (value: NormalizedCellExecutionResult) => void;
+      onPhase?: (phase: RuntimeExecutionPhase) => void;
+    }
+  | { type: 'prepare'; resolve: () => void }
+);
+
+export type PythonPreparationState = 'idle' | 'preparing' | 'ready';
 
 type RuntimeClientDependencies = {
   clearTimeout: (timeout: ReturnType<typeof setTimeout>) => void;
@@ -23,10 +38,23 @@ export function runInteractiveCell(
   cell: CellManifest,
   inputs: InputValues,
   runtimeVersion?: string,
-  signal?: AbortSignal
+  signal?: AbortSignal,
+  onPhase?: (phase: RuntimeExecutionPhase) => void
 ): Promise<NormalizedCellExecutionResult> {
   /* v8 ignore next -- the factory is unit-tested; this delegates to browser Worker adapters. */
-  return defaultRuntimeClient.runInteractiveCell(cell, inputs, runtimeVersion, signal);
+  return defaultRuntimeClient.runInteractiveCell(cell, inputs, runtimeVersion, signal, onPhase);
+}
+
+export function preparePythonRuntime(packages: readonly string[], timeoutMs?: number): Promise<void> {
+  return defaultRuntimeClient.preparePythonRuntime(packages, timeoutMs);
+}
+
+export function getPythonPreparationState(): PythonPreparationState {
+  return defaultRuntimeClient.getPythonPreparationState();
+}
+
+export function subscribePythonPreparation(listener: () => void): () => void {
+  return defaultRuntimeClient.subscribePythonPreparation(listener);
 }
 
 export function resetInteractiveRuntime(language?: CellLanguage): void {
@@ -44,12 +72,68 @@ export function createInteractiveCellRunner(dependencies: RuntimeClientDependenc
   let nextRequestId = 1;
   const workers = new Map<CellLanguage, Worker>();
   const pending = new Map<number, PendingRequest>();
+  let preparation: { worker: Worker; key: string; promise: Promise<void> } | undefined;
+  let preparationState: PythonPreparationState = 'idle';
+  const preparationListeners = new Set<() => void>();
+  function setPreparationState(state: PythonPreparationState): void {
+    if (state === preparationState) return;
+    preparationState = state;
+    for (const listener of preparationListeners) listener();
+  }
+
+  function preparePythonRuntime(packages: readonly string[], timeoutMs = 120_000): Promise<void> {
+    let worker: Worker;
+    try {
+      worker = getWorker('python');
+    } catch (error) {
+      return Promise.reject(toError(error));
+    }
+    const names = [...new Set(packages)].sort();
+    const key = JSON.stringify(names);
+    if (preparation?.worker === worker && preparation.key === key) return preparation.promise;
+    const requestId = nextRequestId++;
+    setPreparationState('preparing');
+    const promise = new Promise<void>((resolve, reject) => {
+      const timeout = dependencies.setTimeout(
+        () => failWorker(worker, new Error('Python preparation timed out after ' + timeoutMs + 'ms')),
+        timeoutMs
+      );
+      pending.set(requestId, {
+        type: 'prepare',
+        resolve,
+        reject,
+        timeout,
+        worker,
+        removeAbortListener: () => undefined
+      });
+      try {
+        worker.postMessage({ type: 'prepare', requestId, packages: names });
+      } catch (error) {
+        failWorker(worker, toError(error));
+      }
+    });
+    const attempt = { worker, key, promise };
+    preparation = attempt;
+    void promise.then(
+      () => {
+        if (preparation === attempt) setPreparationState('ready');
+      },
+      () => {
+        if (preparation === attempt) {
+          preparation = undefined;
+          setPreparationState('idle');
+        }
+      }
+    );
+    return promise;
+  }
 
   function runCell(
     cell: CellManifest,
     inputs: InputValues,
     runtimeVersion?: string,
-    signal?: AbortSignal
+    signal?: AbortSignal,
+    onPhase?: (phase: RuntimeExecutionPhase) => void
   ): Promise<NormalizedCellExecutionResult> {
     const completeValues = completeInputValues(cell, inputs);
     try {
@@ -75,6 +159,8 @@ export function createInteractiveCellRunner(dependencies: RuntimeClientDependenc
         const abort = () => failWorker(ownedWorker, new ExecutionCancellationError());
         signal?.addEventListener('abort', abort, { once: true });
         pending.set(requestId, {
+          type: 'execute',
+          onPhase,
           resolve,
           reject,
           timeout,
@@ -110,14 +196,24 @@ export function createInteractiveCellRunner(dependencies: RuntimeClientDependenc
     const worker = dependencies.createWorker(language);
 
     try {
-      worker.addEventListener('message', (event: MessageEvent<RuntimeWorkerResponse>) => {
-        if (!isRuntimeWorkerResponse(event.data)) {
+      worker.addEventListener('message', (event: MessageEvent<PythonWorkerResponse>) => {
+        if (workers.get(language) !== worker) return;
+        if (!isRuntimeWorkerResponse(event.data) || (language !== 'python' && 'type' in event.data)) {
           failWorker(worker, new Error(`${language} worker sent an invalid message`));
           return;
         }
 
         const request = pending.get(event.data.requestId);
         if (!request || request.worker !== worker) return;
+        if ('type' in event.data && event.data.type === 'progress') {
+          if (request.type === 'execute') request.onPhase?.(event.data.phase);
+          return;
+        }
+        const ready = 'type' in event.data && event.data.type === 'ready';
+        if (event.data.ok && (request.type === 'prepare') !== ready) {
+          failWorker(worker, new Error(language + ' worker sent an unexpected response'));
+          return;
+        }
 
         pending.delete(event.data.requestId);
         dependencies.clearTimeout(request.timeout);
@@ -129,7 +225,8 @@ export function createInteractiveCellRunner(dependencies: RuntimeClientDependenc
         }
 
         try {
-          request.resolve(normalizeCellExecutionResult(event.data.result));
+          if (request.type === 'prepare') request.resolve();
+          else if ('result' in event.data) request.resolve(normalizeCellExecutionResult(event.data.result));
         } catch (error) {
           request.reject(toError(error));
         }
@@ -166,6 +263,10 @@ export function createInteractiveCellRunner(dependencies: RuntimeClientDependenc
 
       ownsWorker = true;
       workers.delete(language);
+      if (language === 'python') {
+        preparation = undefined;
+        setPreparationState('idle');
+      }
     }
 
     const ownedRequests = Array.from(pending.entries()).filter(([, request]) => request.worker === worker);
@@ -183,6 +284,14 @@ export function createInteractiveCellRunner(dependencies: RuntimeClientDependenc
 
   return {
     runInteractiveCell: runCell,
+    preparePythonRuntime,
+    getPythonPreparationState: () => preparationState,
+    subscribePythonPreparation: (listener: () => void) => {
+      preparationListeners.add(listener);
+      return () => {
+        preparationListeners.delete(listener);
+      };
+    },
     resetWorker
   };
 }
@@ -237,8 +346,11 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null;
 }
 
-function isRuntimeWorkerResponse(value: unknown): value is RuntimeWorkerResponse {
-  if (!isRecord(value) || !Number.isSafeInteger(value.requestId) || typeof value.ok !== 'boolean') return false;
+function isRuntimeWorkerResponse(value: unknown): value is PythonWorkerResponse {
+  if (!isRecord(value) || !Number.isSafeInteger(value.requestId)) return false;
+  if (value.type === 'progress') return value.phase === 'preparing' || value.phase === 'executing';
+  if (value.type === 'ready') return value.ok === true;
+  if (typeof value.ok !== 'boolean') return false;
   return value.ok ? isRecord(value.result) : typeof value.error === 'string';
 }
 

--- a/packages/oxiquill/src/lib/doc-runtime/runtime-localization.ts
+++ b/packages/oxiquill/src/lib/doc-runtime/runtime-localization.ts
@@ -25,6 +25,8 @@ export type RuntimeLabels = {
   cellInputs: string;
   cellOutput: (title: string) => string;
   cellRunningAnnouncement: string;
+  cellRetry: string;
+  cellUpdating: string;
   chartCaption: string;
   chartLoadError: (detail: string) => string;
   chartLoading: string;
@@ -125,6 +127,8 @@ const runtimeLabels = {
     cellInputs: 'Cell inputs',
     cellOutput: (title) => `Output for ${title}`,
     cellRunningAnnouncement: 'Cell execution started.',
+    cellRetry: 'Retry cell',
+    cellUpdating: 'Updating…',
     chartCaption: 'Chart data summary',
     chartLoadError: (detail) => `Chart renderer could not be loaded: ${detail}`,
     chartLoading: 'Loading chart renderer...',
@@ -191,6 +195,8 @@ const runtimeLabels = {
     cellInputs: 'セルの入力',
     cellOutput: (title) => `${title} の出力`,
     cellRunningAnnouncement: 'セルの実行を開始しました。',
+    cellRetry: 'セルの実行を再試行',
+    cellUpdating: '更新中…',
     chartCaption: 'グラフデータの概要',
     chartLoadError: (detail) => `グラフ表示を読み込めませんでした: ${detail}`,
     chartLoading: 'グラフ表示を読み込んでいます…',

--- a/packages/oxiquill/src/lib/doc-runtime/runtime-localization.ts
+++ b/packages/oxiquill/src/lib/doc-runtime/runtime-localization.ts
@@ -29,6 +29,7 @@ export type RuntimeLabels = {
   cellUpdating: string;
   chartCaption: string;
   chartLoadError: (detail: string) => string;
+  chartUpdateError: (detail: string) => string;
   chartLoading: string;
   chartRetry: string;
   chartSummary: (details: ChartSummaryDetails) => string;
@@ -131,6 +132,7 @@ const runtimeLabels = {
     cellUpdating: 'Updating…',
     chartCaption: 'Chart data summary',
     chartLoadError: (detail) => `Chart renderer could not be loaded: ${detail}`,
+    chartUpdateError: (detail) => `Chart could not be updated: ${detail}`,
     chartLoading: 'Loading chart renderer...',
     chartRetry: 'Retry chart rendering',
     chartSummary: ({
@@ -199,6 +201,7 @@ const runtimeLabels = {
     cellUpdating: '更新中…',
     chartCaption: 'グラフデータの概要',
     chartLoadError: (detail) => `グラフ表示を読み込めませんでした: ${detail}`,
+    chartUpdateError: (detail) => `グラフを更新できませんでした: ${detail}`,
     chartLoading: 'グラフ表示を読み込んでいます…',
     chartRetry: 'グラフ表示を再試行',
     chartSummary: ({

--- a/packages/oxiquill/src/lib/doc-runtime/runtime-localization.ts
+++ b/packages/oxiquill/src/lib/doc-runtime/runtime-localization.ts
@@ -63,6 +63,7 @@ export type RuntimeLabels = {
   rowsRange: (first: number, last: number, total: number, truncated: boolean) => string;
   run: string;
   runtimeLanguage: (language: 'haskell' | 'python' | 'rust') => string;
+  pythonPreparing: string;
   running: string;
   runningCell: string;
   showCode: string;
@@ -176,6 +177,7 @@ const runtimeLabels = {
     rowsRange: (first, last, total, truncated) => `Rows ${first}-${last} of ${total}${truncated ? ' (truncated)' : ''}`,
     run: 'Run',
     runtimeLanguage: runtimeLanguageLabel,
+    pythonPreparing: 'Preparing Python…',
     running: 'Running',
     runningCell: 'Running cell...',
     showCode: 'Show code',
@@ -245,6 +247,7 @@ const runtimeLabels = {
     rowsRange: (first, last, total, truncated) => `${total} 行中 ${first}–${last} 行${truncated ? '（省略あり）' : ''}`,
     run: '実行',
     runtimeLanguage: runtimeLanguageLabel,
+    pythonPreparing: 'Python を準備中…',
     running: '実行中…',
     runningCell: 'セルを実行中…',
     showCode: 'コードを表示',

--- a/packages/oxiquill/src/lib/doc-runtime/runtime-timing.ts
+++ b/packages/oxiquill/src/lib/doc-runtime/runtime-timing.ts
@@ -1,0 +1,23 @@
+// Local User Timing entries are bounded to the latest observation per phase and cell.
+// They can be inspected in developer tools; nothing is sent to a remote service.
+export function markRuntimeEvent(phase: string, cellId: string): void {
+  const performance = globalThis.performance;
+  if (typeof performance?.mark !== 'function') return;
+  const name = `oxiquill:${phase}:${cellId}`;
+  performance.clearMarks(name);
+  performance.mark(name, { detail: { cellId, phase } });
+}
+
+export async function measureRuntimePhase<T>(phase: string, cellId: string, action: () => T | Promise<T>): Promise<T> {
+  const performance = globalThis.performance;
+  const start = performance?.now() ?? 0;
+  try {
+    return await action();
+  } finally {
+    if (typeof performance?.measure === 'function') {
+      const name = `oxiquill:${phase}:${cellId}`;
+      performance.clearMeasures(name);
+      performance.measure(name, { start, end: performance.now(), detail: { cellId, phase } });
+    }
+  }
+}

--- a/packages/oxiquill/src/lib/doc-runtime/types.ts
+++ b/packages/oxiquill/src/lib/doc-runtime/types.ts
@@ -106,7 +106,28 @@ export interface HtmlArtifact extends BaseArtifact {
   sandboxed: true;
 }
 
+export interface ChartPalette {
+  light?: readonly string[];
+  dark?: readonly string[];
+}
+
+export interface BaseChartStyle {
+  palette?: ChartPalette;
+  showGrid?: boolean;
+  animation?: boolean;
+  animationDurationMs?: number;
+}
+
+export interface LineChartStyle extends BaseChartStyle {
+  lineWidth?: number;
+}
+
+export interface ScatterChartStyle extends BaseChartStyle {
+  symbolSize?: number;
+}
+
 export interface BaseChartSpec {
+  style?: BaseChartStyle;
   title?: string;
   xLabel?: string;
   yLabel?: string;
@@ -123,11 +144,13 @@ export interface XyChartSeries {
 }
 
 export interface LineChartSpec extends BaseChartSpec {
+  style?: LineChartStyle;
   kind: 'line';
   series: readonly XyChartSeries[];
 }
 
 export interface ScatterChartSpec extends BaseChartSpec {
+  style?: ScatterChartStyle;
   kind: 'scatter';
   series: readonly XyChartSeries[];
 }
@@ -149,6 +172,7 @@ export interface HistogramChartSpec extends BaseChartSpec {
 }
 
 export interface AreaChartSpec extends BaseChartSpec {
+  style?: LineChartStyle;
   kind: 'area';
   series: readonly XyChartSeries[];
 }

--- a/packages/oxiquill/src/lib/doc-runtime/types.ts
+++ b/packages/oxiquill/src/lib/doc-runtime/types.ts
@@ -213,6 +213,20 @@ export interface RuntimeWorkerRequest {
   packages?: readonly string[];
 }
 
+export type RuntimeExecutionPhase = 'preparing' | 'executing';
+
+export interface PythonPrepareRequest {
+  type: 'prepare';
+  requestId: number;
+  packages: readonly string[];
+}
+
+export type PythonWorkerRequest = RuntimeWorkerRequest | PythonPrepareRequest;
+export type PythonWorkerResponse =
+  | RuntimeWorkerResponse
+  | { type: 'ready'; requestId: number; ok: true }
+  | { type: 'progress'; requestId: number; phase: RuntimeExecutionPhase };
+
 export type RuntimeWorkerResponse =
   | {
       requestId: number;

--- a/packages/oxiquill/src/styles/custom.css
+++ b/packages/oxiquill/src/styles/custom.css
@@ -281,8 +281,9 @@
   width: 100%;
   height: 360px;
   border: 1px solid color-mix(in srgb, var(--sl-color-gray-5), transparent 35%);
-  border-radius: 6px;
-  background: var(--sl-color-bg);
+  border-radius: 10px;
+  background: color-mix(in srgb, var(--sl-color-bg), var(--sl-color-gray-6) 8%);
+  overflow: hidden;
 }
 
 .doc-html-output {

--- a/packages/oxiquill/src/styles/custom.css
+++ b/packages/oxiquill/src/styles/custom.css
@@ -228,8 +228,34 @@
 }
 
 .doc-cell__output-region {
+  position: relative;
   display: grid;
   gap: 0.85rem;
+}
+
+.doc-cell__updating {
+  position: absolute;
+  inset-block-start: 0.4rem;
+  inset-inline-end: 0.4rem;
+  padding: 0.15rem 0.5rem;
+  border-radius: 1rem;
+  background: var(--sl-color-bg);
+  color: var(--sl-color-gray-2);
+  font-size: 0.8rem;
+  pointer-events: none;
+  animation: doc-cell-updating 1s ease-in-out infinite alternate;
+}
+
+@keyframes doc-cell-updating {
+  to {
+    opacity: 0.55;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .doc-cell__updating {
+    animation: none;
+  }
 }
 
 .doc-chart-output {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -111,8 +111,8 @@ importers:
         specifier: 6.1.0
         version: 6.1.0
       katex:
-        specifier: 0.18.4
-        version: 0.18.4
+        specifier: 0.16.47
+        version: 0.16.47
       mermaid:
         specifier: 11.17.2
         version: 11.17.2
@@ -2842,10 +2842,6 @@ packages:
 
   katex@0.16.47:
     resolution: {integrity: sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==}
-    hasBin: true
-
-  katex@0.18.4:
-    resolution: {integrity: sha512-IMPntbRLOU+eu88XDiFKqQ8Akhr9Tv7jDMXqPhjG9SI1JMA4DIgXk4x9k4skJz2NZJXBRbC+2pYBLj9olqcZow==}
     hasBin: true
 
   keyv@4.5.4:
@@ -7474,10 +7470,6 @@ snapshots:
   jsonc-parser@3.3.1: {}
 
   katex@0.16.47:
-    dependencies:
-      commander: 8.3.0
-
-  katex@0.18.4:
     dependencies:
       commander: 8.3.0
 

--- a/tests/e2e/interactive.spec.ts
+++ b/tests/e2e/interactive.spec.ts
@@ -462,6 +462,7 @@ test('rich output examples render browser-visible artifacts', async ({ page }) =
   await expect(rustHeatmap.locator('canvas').first()).toBeVisible();
   await expect(rustBarChart).toHaveAttribute('data-chart-theme', 'light');
   await expect(rustHeatmap).toHaveAttribute('data-chart-theme', 'light');
+  await expect.poll(() => canvasColorPixels(rustBarChart.locator('canvas'), [124, 58, 237])).toBeGreaterThan(500);
   expect((await canvasStats(rustBarChart.locator('canvas'))).inkPixels).toBeGreaterThan(1_000);
   const heatmapCanvases = rustHeatmap.locator('canvas');
   const heatmapStats = await Promise.all(
@@ -473,6 +474,7 @@ test('rich output examples render browser-visible artifacts', async ({ page }) =
   });
   await expect(rustBarChart).toHaveAttribute('data-chart-theme', 'dark');
   await expect(rustHeatmap).toHaveAttribute('data-chart-theme', 'dark');
+  await expect.poll(() => canvasColorPixels(rustBarChart.locator('canvas'), [196, 181, 253])).toBeGreaterThan(500);
   await expect(rustBarChart.locator('canvas')).toHaveCount(1);
   await expect(rustHeatmap.locator('canvas').first()).toBeVisible();
   await page.evaluate(() => {
@@ -678,6 +680,19 @@ async function canvasStats(canvas: Locator): Promise<{
 
     return { height: canvasElement.height, inkPixels, width: canvasElement.width };
   });
+}
+
+async function canvasColorPixels(canvas: Locator, rgb: number[]): Promise<number> {
+  return canvas.evaluate((element, color) => {
+    const canvas = element as HTMLCanvasElement;
+    const data = canvas.getContext('2d')?.getImageData(0, 0, canvas.width, canvas.height).data ?? [];
+    let count = 0;
+    for (let index = 0; index < data.length; index += 4) {
+      if (data[index + 3] > 200 && color.every((channel, offset) => Math.abs(data[index + offset] - channel) < 3))
+        count += 1;
+    }
+    return count;
+  }, rgb);
 }
 
 function captureRequestPaths(page: Page): string[] {

--- a/tests/e2e/interactive.spec.ts
+++ b/tests/e2e/interactive.spec.ts
@@ -219,7 +219,8 @@ test('static pages do not reference optional browser runtimes', async ({ page })
   expect(requests.filter(isOptionalRuntimeRequest)).toEqual([]);
 });
 
-test('off-screen reactive cells wait for visible hydration', async ({ page }) => {
+test('off-screen reactive cells wait for visible hydration while Python prepares', async ({ page }) => {
+  await captureWorkerMessages(page);
   await page.setViewportSize({ width: 800, height: 240 });
   const requests = captureRequestPaths(page);
 
@@ -236,7 +237,8 @@ test('off-screen reactive cells wait for visible hydration', async ({ page }) =>
 
   expect(requests.some((request) => request.includes('/rust-worker-'))).toBe(true);
   expect(requests.some((request) => request.includes('/rust-wasm/'))).toBe(true);
-  expect(requests.some((request) => request.includes('/python-worker-'))).toBe(false);
+  expect(requests.some((request) => request.includes('/python-worker-'))).toBe(true);
+  expect(await workerMessagesForCell(page, 'features__interactive-cells__python-controls')).toHaveLength(0);
   expect(requests.some((request) => request.includes('/haskell-worker-'))).toBe(false);
 });
 

--- a/tests/e2e/interactive.spec.ts
+++ b/tests/e2e/interactive.spec.ts
@@ -308,6 +308,18 @@ test('text-only Haskell cells do not load chart or unrelated runtimes', async ({
 });
 
 test('Rust cells run from MDX code fences and redraw plots', async ({ page }) => {
+  await page.addInitScript(`
+    globalThis.__heldChartResults = [];
+    const add = Worker.prototype.addEventListener;
+    Worker.prototype.addEventListener = function (type, listener, ...rest) {
+      const worker = this;
+      return Reflect.apply(add, this, [type, type === 'message' ? function (event) {
+        const deliver = () => listener.call(worker, event);
+        if (globalThis.__holdChartResults) globalThis.__heldChartResults.push(deliver);
+        else deliver();
+      } : listener, ...rest]);
+    };
+  `);
   await page.goto('/samples/logistic-map/');
 
   await expect(page.getByRole('heading', { name: 'Logistic Map', exact: true })).toBeVisible();
@@ -321,6 +333,9 @@ test('Rust cells run from MDX code fences and redraw plots', async ({ page }) =>
   await expect(chart).toBeVisible();
   await expect(chart.locator('canvas')).toHaveCount(1);
   const canvas = chart.locator('canvas');
+  const originalCanvas = await canvas.elementHandle();
+  // Let the initial 180ms animation finish before comparing the retained image.
+  await page.waitForTimeout(250);
 
   const initialStats = await canvasStats(canvas);
   expect(initialStats.width).toBeGreaterThan(100);
@@ -328,6 +343,7 @@ test('Rust cells run from MDX code fences and redraw plots', async ({ page }) =>
   expect(initialStats.inkPixels).toBeGreaterThan(1_000);
 
   const initialImage = await canvas.evaluate((element) => (element as HTMLCanvasElement).toDataURL());
+  await page.evaluate('globalThis.__holdChartResults = true');
 
   await page.getByRole('slider', { name: 'r' }).evaluate((input) => {
     const slider = input as HTMLInputElement;
@@ -336,6 +352,22 @@ test('Rust cells run from MDX code fences and redraw plots', async ({ page }) =>
   });
 
   await expect(page.getByTestId('r-value')).toHaveText('3.70');
+  await expect.poll(() => page.evaluate('globalThis.__heldChartResults.length')).toBe(1);
+  await expect(cell.locator('.doc-cell__output-region')).toHaveAttribute('aria-busy', 'true');
+  await expect(canvas).toBeVisible();
+  expect(await canvas.evaluate((node, previous) => node === previous, originalCanvas)).toBe(true);
+  expect(await canvas.evaluate((node) => (node as HTMLCanvasElement).toDataURL())).toBe(initialImage);
+  await expect(cell.locator('.doc-cell__updating')).toHaveAttribute('aria-hidden', 'true');
+  await page.emulateMedia({ reducedMotion: 'reduce' });
+  await expect(chart).toHaveAttribute('data-chart-motion', 'reduced');
+  expect(await cell.locator('.doc-cell__updating').evaluate((node) => getComputedStyle(node).animationName)).toBe(
+    'none'
+  );
+  await page.emulateMedia({ reducedMotion: 'no-preference' });
+  await expect(chart).toHaveAttribute('data-chart-motion', 'full');
+  await page.evaluate(
+    'globalThis.__holdChartResults = false; globalThis.__heldChartResults.splice(0).forEach(deliver => deliver())'
+  );
 
   await expect
     .poll(async () => canvas.evaluate((element) => (element as HTMLCanvasElement).toDataURL()))
@@ -343,6 +375,7 @@ test('Rust cells run from MDX code fences and redraw plots', async ({ page }) =>
 
   const updatedImage = await canvas.evaluate((element) => (element as HTMLCanvasElement).toDataURL());
   expect(updatedImage.length).toBeGreaterThan(1_000);
+  expect(await canvas.evaluate((node, previous) => node === previous, originalCanvas)).toBe(true);
 });
 
 test('interactive cells and math rendering are available', async ({ page }) => {

--- a/tests/e2e/math.spec.ts
+++ b/tests/e2e/math.spec.ts
@@ -8,7 +8,7 @@ test('KaTeX scripts use upstream sizing in inline and display formulas', async (
         text: script.textContent,
         ratio:
           Number.parseFloat(getComputedStyle(script).fontSize) /
-          Number.parseFloat(getComputedStyle(script.closest('.katex')!).fontSize)
+          Number.parseFloat(getComputedStyle(script.closest('.katex') ?? script).fontSize)
       }))
     );
     expect(ratios.some(({ text }) => text?.includes('n'))).toBe(true);

--- a/tests/e2e/math.spec.ts
+++ b/tests/e2e/math.spec.ts
@@ -1,0 +1,18 @@
+import { expect, test } from '@playwright/test';
+
+test('KaTeX scripts use upstream sizing in inline and display formulas', async ({ page }) => {
+  await page.goto('/features/math/');
+  for (const selector of ['p > .katex', '.katex-display > .katex']) {
+    const ratios = await page.locator(`${selector} .katex-html .sizing.reset-size6.size3`).evaluateAll((scripts) =>
+      scripts.map((script) => ({
+        text: script.textContent,
+        ratio:
+          Number.parseFloat(getComputedStyle(script).fontSize) /
+          Number.parseFloat(getComputedStyle(script.closest('.katex')!).fontSize)
+      }))
+    );
+    expect(ratios.some(({ text }) => text?.includes('n'))).toBe(true);
+    expect(ratios.some(({ text }) => text?.includes('2'))).toBe(true);
+    for (const { ratio } of ratios) expect(Math.abs(ratio - 0.7)).toBeLessThan(0.02);
+  }
+});

--- a/tests/e2e/python-preload.spec.ts
+++ b/tests/e2e/python-preload.spec.ts
@@ -19,10 +19,11 @@ test('prepares first-cell dependencies before visible hydration without running 
   await page.goto('/features/rich-output/', { waitUntil: 'networkidle' });
   const cell = page.getByTestId('cell-features__rich-output__python-rich-outputs');
   await expect.poll(() => workerRequests.length).toBe(1);
-  expect(workerRequests[0]).toMatchObject({ type: 'prepare', packages: ['matplotlib', 'numpy', 'pandas'] });
+  expect(workerRequests[0]).toMatchObject({ type: 'prepare', packages: ['matplotlib', 'pandas'] });
   expect(workerRequests[0]).not.toHaveProperty('source');
   await expect(cell.locator('.doc-cell__outputs')).toHaveCount(0);
   await cell.scrollIntoViewIfNeeded();
+  await expect(cell.locator('xpath=ancestor::astro-island[1]')).not.toHaveAttribute('ssr', '');
   await expect(cell.locator('.run-button')).toBeVisible();
   await cell.locator('.run-button').click();
   await expect(cell.locator('.doc-cell__outputs')).toBeVisible({ timeout: 90_000 });
@@ -34,15 +35,18 @@ test('prepares first-cell dependencies before visible hydration without running 
     .find((worker) => worker.url().includes('python-worker'))
     ?.evaluate(() =>
       performance
-        .getEntriesByType('resource')
+        .getEntries()
+        .filter((entry) => entry.entryType === 'resource' || entry.name === 'oxiquill:initialization:python')
         .map((entry) => ({ name: entry.name, startTime: entry.startTime, end: entry.startTime + entry.duration }))
     );
   const core = timings?.find((entry) => entry.name.endsWith('/pyodide.asm.wasm'));
+  const initialization = timings?.find((entry) => entry.name === 'oxiquill:initialization:python');
   const wheels = timings?.filter((entry) => entry.name.endsWith('.whl')) ?? [];
   expect(core).toBeDefined();
   expect(wheels.length).toBeGreaterThan(0);
   expect(wheels.every((entry) => new URL(entry.name).origin === new URL(page.url()).origin)).toBe(true);
-  expect(wheels.some((entry) => entry.startTime < (core?.end ?? 0))).toBe(true);
+  expect(initialization).toBeDefined();
+  expect(wheels.some((entry) => entry.startTime < (initialization?.end ?? 0))).toBe(true);
 });
 
 test('a failed page preparation recovers when a reader runs the cell', async ({ page }) => {
@@ -58,6 +62,7 @@ test('a failed page preparation recovers when a reader runs the cell', async ({ 
   await expect.poll(() => failed).toBe(true);
   const cell = page.getByTestId('cell-features__rich-output__python-rich-outputs');
   await cell.scrollIntoViewIfNeeded();
+  await expect(cell.locator('xpath=ancestor::astro-island[1]')).not.toHaveAttribute('ssr', '');
   await cell.locator('.run-button').click();
   await expect(cell.locator('.doc-cell__outputs')).toBeVisible({ timeout: 90_000 });
   await expect(cell.getByRole('alert')).toHaveCount(0);

--- a/tests/e2e/python-preload.spec.ts
+++ b/tests/e2e/python-preload.spec.ts
@@ -1,0 +1,64 @@
+import { expect, test } from '@playwright/test';
+
+test('prepares first-cell dependencies before visible hydration without running authored code', async ({ page }) => {
+  test.setTimeout(120_000);
+  await page.setViewportSize({ width: 800, height: 240 });
+  const workerRequests: unknown[] = [];
+  await page.exposeFunction('observePythonRequest', (message: unknown) => workerRequests.push(message));
+  await page.addInitScript(() => {
+    const post = Worker.prototype.postMessage;
+    Worker.prototype.postMessage = function (message: unknown, ...rest: unknown[]) {
+      if (message && typeof message === 'object' && ('source' in message || 'type' in message)) {
+        void (
+          globalThis as unknown as { observePythonRequest: (message: unknown) => Promise<void> }
+        ).observePythonRequest(message);
+      }
+      return Reflect.apply(post, this, [message, ...rest]);
+    };
+  });
+  await page.goto('/features/rich-output/', { waitUntil: 'networkidle' });
+  const cell = page.getByTestId('cell-features__rich-output__python-rich-outputs');
+  await expect.poll(() => workerRequests.length).toBe(1);
+  expect(workerRequests[0]).toMatchObject({ type: 'prepare', packages: ['matplotlib', 'numpy', 'pandas'] });
+  expect(workerRequests[0]).not.toHaveProperty('source');
+  await expect(cell.locator('.doc-cell__outputs')).toHaveCount(0);
+  await cell.scrollIntoViewIfNeeded();
+  await expect(cell.locator('.run-button')).toBeVisible();
+  await cell.locator('.run-button').click();
+  await expect(cell.locator('.doc-cell__outputs')).toBeVisible({ timeout: 90_000 });
+  await expect(cell.getByRole('alert')).toHaveCount(0);
+  expect(workerRequests.filter((request) => (request as { type?: string }).type === 'prepare')).toHaveLength(1);
+  expect(page.workers().filter((worker) => worker.url().includes('python-worker'))).toHaveLength(1);
+  const timings = await page
+    .workers()
+    .find((worker) => worker.url().includes('python-worker'))
+    ?.evaluate(() =>
+      performance
+        .getEntriesByType('resource')
+        .map((entry) => ({ name: entry.name, startTime: entry.startTime, end: entry.startTime + entry.duration }))
+    );
+  const core = timings?.find((entry) => entry.name.endsWith('/pyodide.asm.wasm'));
+  const wheels = timings?.filter((entry) => entry.name.endsWith('.whl')) ?? [];
+  expect(core).toBeDefined();
+  expect(wheels.length).toBeGreaterThan(0);
+  expect(wheels.every((entry) => new URL(entry.name).origin === new URL(page.url()).origin)).toBe(true);
+  expect(wheels.some((entry) => entry.startTime < (core?.end ?? 0))).toBe(true);
+});
+
+test('a failed page preparation recovers when a reader runs the cell', async ({ page }) => {
+  test.setTimeout(120_000);
+  let failed = false;
+  await page.route('**/pyodide/pyodide.mjs', async (route) => {
+    if (!failed) {
+      failed = true;
+      await route.fulfill({ status: 503, body: 'Temporary failure' });
+    } else await route.continue();
+  });
+  await page.goto('/features/rich-output/', { waitUntil: 'networkidle' });
+  await expect.poll(() => failed).toBe(true);
+  const cell = page.getByTestId('cell-features__rich-output__python-rich-outputs');
+  await cell.scrollIntoViewIfNeeded();
+  await cell.locator('.run-button').click();
+  await expect(cell.locator('.doc-cell__outputs')).toBeVisible({ timeout: 90_000 });
+  await expect(cell.getByRole('alert')).toHaveCount(0);
+});

--- a/tests/e2e/search.spec.ts
+++ b/tests/e2e/search.spec.ts
@@ -6,7 +6,8 @@ test('production Pagefind search loads its index and returns documentation resul
     if (new URL(response.url()).pathname.includes('/pagefind/')) assets.push(response.status());
   });
   const response = await page.goto('/features/math/');
-  const html = await response!.text();
+  if (!response) throw new Error('Expected a production page response');
+  const html = await response.text();
   expect(html).not.toMatch(/search\.devWarning|Search is only available in production builds/u);
   expect(html).toContain('id="starlight__search"');
   await page.locator('site-search button[data-open-modal]').click();

--- a/tests/e2e/search.spec.ts
+++ b/tests/e2e/search.spec.ts
@@ -1,0 +1,20 @@
+import { expect, test } from '@playwright/test';
+
+test('production Pagefind search loads its index and returns documentation results', async ({ page }) => {
+  const assets: number[] = [];
+  page.on('response', (response) => {
+    if (new URL(response.url()).pathname.includes('/pagefind/')) assets.push(response.status());
+  });
+  const response = await page.goto('/features/math/');
+  const html = await response!.text();
+  expect(html).not.toMatch(/search\.devWarning|Search is only available in production builds/u);
+  expect(html).toContain('id="starlight__search"');
+  await page.locator('site-search button[data-open-modal]').click();
+  const dialog = page.getByRole('dialog');
+  const input = dialog.locator('.pagefind-ui__search-input');
+  await expect(input).toBeVisible();
+  await input.fill('logistic');
+  await expect(dialog.locator('.pagefind-ui__result-link').first()).toBeVisible();
+  expect(assets.length).toBeGreaterThan(0);
+  expect(assets.every((status) => status >= 200 && status < 400)).toBe(true);
+});

--- a/tests/fixtures/rust-codegen/content/docs/index.mdx
+++ b/tests/fixtures/rust-codegen/content/docs/index.mdx
@@ -3,6 +3,30 @@ title: Rust code generation regressions
 ---
 
 ```rust
+//| id: chart-style-overloads
+let points = [[0.0, 1.0], [1.0, 2.0]];
+let style = serde_json::json!({ "animation": false, "palette": { "light": ["#123", "#456"] } });
+emit_line_chart!(&points);
+emit_line_chart!(&points, &style);
+emit_line_chart!(&points, "x", "y");
+emit_line_chart!(&points, "x", "y", &style);
+emit_scatter_chart!(&points);
+emit_scatter_chart!(&points, &style);
+emit_scatter_chart!(&points, "x", "y");
+emit_scatter_chart!(&points, "x", "y", &style);
+emit_bar_chart!(&["a", "b"], &[1, 2]);
+emit_bar_chart!(&["a", "b"], &[1, 2], &style);
+emit_histogram!(&[[0, 1, 2]]);
+emit_histogram!(&[[0, 1, 2]], &style);
+emit_heatmap!(&[[0, 0, 2]]);
+emit_heatmap!(&[[0, 0, 2]], &style);
+struct Point { n: u32, x: f64 }
+let legacy = [Point { n: 0, x: 1.0 }];
+emit_line_plot!(&legacy, "n", "x");
+emit_line_plot!(&legacy, "n", "x", &style);
+```
+
+```rust
 //| id: spaced-macros
 println /* trivia */ ! ("spaced output");
 emit_json ! (&serde_json::json!({ "ok": true }));

--- a/tests/package/consumer-smoke.mjs
+++ b/tests/package/consumer-smoke.mjs
@@ -29,6 +29,7 @@ const packageManagerArgument = process.argv.indexOf('--package-manager');
 const packageManager = process.argv[packageManagerArgument + 1];
 const browserSmoke = process.argv.includes('--browser');
 const consumerEnvironment = { ...process.env, ASTRO_TELEMETRY_DISABLED: '1' };
+delete consumerEnvironment.NODE_ENV;
 assert.ok(
   packageManagerArgument >= 0 && (packageManager === 'npm' || packageManager === 'pnpm'),
   '--package-manager must be either "npm" or "pnpm".'
@@ -201,6 +202,9 @@ try {
   ]);
   const initialBuild = run(process.execPath, [installedCliPath, 'build'], consumerRoot, true, nodeOnlyEnvironment);
   assertNo404Warning(initialBuild);
+  const productionHtml = await readFile(path.join(consumerRoot, 'dist/index.html'), 'utf8');
+  assert.match(productionHtml, /id="starlight__search"/u);
+  assert.doesNotMatch(productionHtml, /search\.devWarning|Search is only available in production builds/u);
   run(packageManager, ['run', 'preview', '--', '--background', '--host', '127.0.0.1', '--port', '4321'], consumerRoot);
   await assertFile(path.join(consumerRoot, '.astro/preview.json'));
   stopAstroPreview(packageManager, consumerRoot);

--- a/tests/package/consumer-smoke.mjs
+++ b/tests/package/consumer-smoke.mjs
@@ -8,6 +8,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { chromium } from '@playwright/test';
 import { loadDocumentedConsumerConfig } from '../docs/documented-config.mjs';
+import { assertMathDependencies } from './math-contract.mjs';
 
 const supportedPythonPackages = [
   'contourpy',
@@ -195,6 +196,11 @@ try {
   }
 
   const nodeOnlyEnvironment = createNodeOnlyEnvironment();
+  await assertMathDependencies(path.join(consumerRoot, 'node_modules/oxiquill'));
+  await appendFile(
+    path.join(consumerRoot, 'content/docs/index.mdx'),
+    '\nInline scripts: $x_n + x^2$.\n\n$$\nx_n + x^2\n$$\n'
+  );
   run(process.execPath, [installedCliPath, 'check'], consumerRoot, false, nodeOnlyEnvironment);
   await Promise.all([
     writeFile(path.join(consumerRoot, 'astro.config.mjs'), starterConfig.astro),
@@ -204,6 +210,8 @@ try {
   assertNo404Warning(initialBuild);
   const productionHtml = await readFile(path.join(consumerRoot, 'dist/index.html'), 'utf8');
   assert.match(productionHtml, /id="starlight__search"/u);
+  assert.match(productionHtml, /class="katex-html"/u);
+  assert.match(productionHtml, /sizing reset-size6 size3/u);
   assert.doesNotMatch(productionHtml, /search\.devWarning|Search is only available in production builds/u);
   run(packageManager, ['run', 'preview', '--', '--background', '--host', '127.0.0.1', '--port', '4321'], consumerRoot);
   await assertFile(path.join(consumerRoot, '.astro/preview.json'));

--- a/tests/package/consumer-smoke.mjs
+++ b/tests/package/consumer-smoke.mjs
@@ -62,7 +62,7 @@ import type { CellManifest } from 'oxiquill/runtime/types';
 
 const cell = {} as CellManifest;
 const paths = { downloadCacheDir: new URL('./verified downloads/', import.meta.url) } satisfies OxiquillPathOptions;
-const python = { offline: true, packageMirror: new URL('https://packages.example/pyodide/') } satisfies OxiquillPythonOptions;
+const python = { preload: true, offline: true, packageMirror: new URL('https://packages.example/pyodide/') } satisfies OxiquillPythonOptions;
 const publicTypes = {} as [
   OxiquillConfig,
   OxiquillFrameworkOptions,

--- a/tests/package/math-contract.mjs
+++ b/tests/package/math-contract.mjs
@@ -1,0 +1,15 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+
+export async function assertMathDependencies(packageRoot) {
+  const require = createRequire(path.join(packageRoot, 'package.json'));
+  const rendererRequire = createRequire(require.resolve('rehype-katex'));
+  const stylesheet = JSON.parse(await readFile(require.resolve('katex/package.json'), 'utf8'));
+  const renderer = JSON.parse(await readFile(rendererRequire.resolve('katex/package.json'), 'utf8'));
+  const manifest = JSON.parse(await readFile(path.join(packageRoot, 'package.json'), 'utf8'));
+  assert.equal(manifest.dependencies.katex, stylesheet.version, 'KaTeX CSS must be a pinned production dependency');
+  assert.equal(stylesheet.version, renderer.version, 'KaTeX markup and stylesheet must use the same version');
+  assert.equal(manifest.exports['./styles/katex.css'], './dist/styles/katex.css');
+}

--- a/tests/package/math-contract.mjs
+++ b/tests/package/math-contract.mjs
@@ -1,10 +1,10 @@
 import assert from 'node:assert/strict';
-import { readFile } from 'node:fs/promises';
+import { readFile, realpath } from 'node:fs/promises';
 import { createRequire } from 'node:module';
 import path from 'node:path';
 
 export async function assertMathDependencies(packageRoot) {
-  const require = createRequire(path.join(packageRoot, 'package.json'));
+  const require = createRequire(await realpath(path.join(packageRoot, 'package.json')));
   const rendererRequire = createRequire(require.resolve('rehype-katex'));
   const stylesheet = JSON.parse(await readFile(require.resolve('katex/package.json'), 'utf8'));
   const renderer = JSON.parse(await readFile(rendererRequire.resolve('katex/package.json'), 'utf8'));

--- a/tests/package/package-contents.mjs
+++ b/tests/package/package-contents.mjs
@@ -4,6 +4,7 @@ import { mkdtemp, mkdir, readFile, readdir, rm, stat, writeFile } from 'node:fs/
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { assertMathDependencies } from './math-contract.mjs';
 
 const repositoryRoot = fileURLToPath(new URL('../../', import.meta.url));
 const packageRoot = path.join(repositoryRoot, 'packages/oxiquill');
@@ -13,6 +14,7 @@ const starterManifest = JSON.parse(await readFile(path.join(repositoryRoot, 'tem
 const temporaryRoot = await mkdtemp(path.join(tmpdir(), 'oxiquill-package-'));
 
 try {
+  await assertMathDependencies(packageRoot);
   assert.equal(packageManifest.scripts.prepack, 'pnpm run build');
   for (const lifecycleHook of ['prepare', 'install', 'postinstall']) {
     assert.ok(

--- a/tests/performance/README.md
+++ b/tests/performance/README.md
@@ -1,0 +1,54 @@
+# Python startup measurements
+
+Issue #133 was measured on 2026-09-05 against production output served locally with gzip, at the same-origin `/oxiquill/` base path. The browser was headless Chromium 149.0.7827.55 from the development environment's Nix Playwright package. Hardware: Intel Core i7-12700F, 16 available CPUs, 25,199,001,600 bytes of RAM; Linux, Node 24.19.0, pnpm 11.2.2. Neither network nor CPU throttling was enabled. HTTP responses used `Cache-Control: public, max-age=600`.
+
+Each example has five fresh browser contexts, five reloads of the same context, and five repeated executions on the same page. Fresh and reload latency runs from navigation start to Preact's committed output; repeat latency runs from the input/button trigger to output. The viewport was 1280 × 900 with full motion. Reactive repeats include the existing 150 ms debounce. The gzip server remains running throughout each measurement set, but browser contexts do not share an HTTP cache.
+
+The baseline production build is commit `4047eb4` (timing instrumentation plus the preceding fixes, before Python optimization). The optimized build is `21839af` (shared preparation, overlapped package loading, lazy optional display imports, and `python.preload: true` in the dogfood site). Both used the same Pyodide assets and browser. The raw reports record `dirty: true` because source work or untracked reports existed when metadata was captured; the served build revisions above identify the measured runtime. No development server or working-tree source was served.
+
+| Example           | Condition | Before median | After median | Change |
+| ----------------- | --------- | ------------: | -----------: | -----: |
+| Interactive cells | Fresh     |     1526.6 ms |    1538.7 ms |  +0.8% |
+| Interactive cells | Reload    |     1386.4 ms |    1429.3 ms |  +3.1% |
+| Interactive cells | Repeat    |      162.9 ms |     161.4 ms |  −0.9% |
+| Rich output       | Fresh     |     8998.4 ms |    5779.3 ms | −35.8% |
+| Rich output       | Reload    |     6444.1 ms |    5675.6 ms | −11.9% |
+| Rich output       | Repeat    |      117.9 ms |     119.9 ms |  +1.7% |
+
+The rich-output cold median meets the under-10-second target under these conditions. Its five optimized cold samples range from 5643.7 to 5801.7 ms; baseline samples varied more widely, so the median improvement is not a guarantee for other hardware or network conditions. The lightweight example is effectively unchanged, with a 42.9 ms reload increase. No claim is made about GitHub Pages transfer performance.
+
+The cold-run browser boundaries were also recorded independently:
+
+| Example and boundary                                   | Before median | After median |
+| ------------------------------------------------------ | ------------: | -----------: |
+| Interactive cells: hydration, since navigation         |      152.8 ms |     170.7 ms |
+| Interactive cells: worker construction to module ready |        6.0 ms |      18.1 ms |
+| Interactive cells: output committed, since navigation  |     1526.6 ms |    1538.7 ms |
+| Rich output: hydration, since navigation               |      161.9 ms |     168.6 ms |
+| Rich output: worker construction to module ready       |        5.9 ms |      16.2 ms |
+| Rich output: output committed, since navigation        |     8998.4 ms |    5779.3 ms |
+
+The worker's median cold phases explain the remaining rich-output cost:
+
+| Phase                                        |    Before |                                  After |
+| -------------------------------------------- | --------: | -------------------------------------: |
+| Pyodide initialization                       | 1345.5 ms | 2271.0 ms, including declared packages |
+| Additional declared package loading          | 1615.5 ms |              No separate load required |
+| Display support installation                 |   34.0 ms |                                21.4 ms |
+| Import discovery                             |    1.0 ms |                                 1.6 ms |
+| Display preparation                          | 1143.4 ms |                                 0.5 ms |
+| Authored execution, including Python imports | 2349.1 ms |                              3260.0 ms |
+| Figure collection                            |  124.0 ms |                               111.6 ms |
+
+These are per-phase medians and should not be added to reconstruct a navigation median. Package transfer now overlaps initialization. Removing unconditional optional imports moves Matplotlib's necessary import into authored execution; it does not eliminate that cost for a page that uses Matplotlib. Roughly 3.3 seconds of rich-output execution and 2.3 seconds of initialization/packages remain. A service worker, persistent browser cache, CDN, and custom Pyodide distribution were not needed to meet the local target and were not introduced.
+
+The raw [before](./python-startup-before.json) and [after](./python-startup-after.json) reports include all samples, navigation and worker time origins, hydration/startup/output marks, phase durations, request/response timestamps, and resource transfer sizes. Resource entries retain relevant timing/size fields; unused browser-specific fields are omitted. `renderObserverDeltaMs` can be negative because the benchmark's response observer runs after the runtime's listener, which may already have committed output. This diagnostic is not a rendering duration; output completion is measured by the layout-effect mark instead. The boundary marks do not isolate rendering CPU time from result normalization. No telemetry or authored source is collected.
+
+To reproduce, first build the desired revision, then run the benchmark without other builds or tests running:
+
+```sh
+BASE_PATH=/oxiquill/ env -u NODE_ENV pnpm build
+pnpm exec node tests/performance/python-startup.mjs --runs 5 --label local --output test-results/python-startup.json
+```
+
+Set `PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH` when using a system/Nix Chromium. The script defaults to `examples/docs-site/dist`, `/oxiquill/`, and localhost gzip. Override `--site` or `--base` only if the build uses matching paths. User Timing entries are bounded to the latest phase per cell and stay local to the browser.

--- a/tests/performance/python-startup-after.json
+++ b/tests/performance/python-startup-after.json
@@ -1,0 +1,13351 @@
+{
+  "label": "after",
+  "date": "2026-09-05T07:24:31.195Z",
+  "revision": "21839af69deb6be099f0f78c8b3e4e22b12d8dc3",
+  "dirty": true,
+  "browser": "149.0.7827.55",
+  "hardware": {
+    "platform": "linux",
+    "cpu": "12th Gen Intel(R) Core(TM) i7-12700F",
+    "parallelism": 16,
+    "memoryBytes": 25199001600
+  },
+  "network": {
+    "origin": "loopback",
+    "gzip": true,
+    "cacheMaxAgeSeconds": 600,
+    "throttling": false
+  },
+  "base": "/oxiquill/",
+  "runs": 5,
+  "medians": {
+    "features/interactive-cells/:fresh": 1538.7000000029802,
+    "features/interactive-cells/:reload": 1429.2999999970198,
+    "features/interactive-cells/:repeat": 161.40000000596046,
+    "features/rich-output/:fresh": 5779.29999999702,
+    "features/rich-output/:reload": 5675.5999999940395,
+    "features/rich-output/:repeat": 119.8999999910593
+  },
+  "samples": [
+    {
+      "example": "features/interactive-cells/",
+      "condition": "fresh",
+      "run": 1,
+      "triggerMs": 595.2000000029802,
+      "outputMs": 1925.5999999940395,
+      "latencyMs": 1925.5999999940395,
+      "renderObserverDeltaMs": 0,
+      "main": {
+        "timeOrigin": 1788592996042.8,
+        "entries": [
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/index.DANjJwMU.css",
+            "entryType": "resource",
+            "startTime": 13.200000002980232,
+            "duration": 6.399999991059303,
+            "initiatorType": "link",
+            "transferSize": 21909,
+            "encodedBodySize": 21609,
+            "decodedBodySize": 105367
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/page.B1wUxXOO.js",
+            "entryType": "resource",
+            "startTime": 13.5,
+            "duration": 8,
+            "initiatorType": "script",
+            "transferSize": 1881,
+            "encodedBodySize": 1581,
+            "decodedBodySize": 3458
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/Search.astro_astro_type_script_index_0_lang.DzL-jWp_.js",
+            "entryType": "resource",
+            "startTime": 13.700000002980232,
+            "duration": 7.899999991059303,
+            "initiatorType": "script",
+            "transferSize": 1245,
+            "encodedBodySize": 945,
+            "decodedBodySize": 1830
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/MobileTableOfContents.astro_astro_type_script_index_0_lang.BcSo_yiZ.js",
+            "entryType": "resource",
+            "startTime": 13.799999997019768,
+            "duration": 11.299999997019768,
+            "initiatorType": "script",
+            "transferSize": 664,
+            "encodedBodySize": 364,
+            "decodedBodySize": 622
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/TwoColumnContent.astro_astro_type_script_index_0_lang.DPGAuL8N.js",
+            "entryType": "resource",
+            "startTime": 13.900000005960464,
+            "duration": 11.399999991059303,
+            "initiatorType": "script",
+            "transferSize": 569,
+            "encodedBodySize": 269,
+            "decodedBodySize": 452
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/TableOfContents.astro_astro_type_script_index_0_lang.Csloo1VZ.js",
+            "entryType": "resource",
+            "startTime": 13.900000005960464,
+            "duration": 11.299999997019768,
+            "initiatorType": "script",
+            "transferSize": 356,
+            "encodedBodySize": 56,
+            "decodedBodySize": 36
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/PageFrame.astro_astro_type_script_index_0_lang.iwTubUja.js",
+            "entryType": "resource",
+            "startTime": 14,
+            "duration": 11.400000005960464,
+            "initiatorType": "script",
+            "transferSize": 557,
+            "encodedBodySize": 257,
+            "decodedBodySize": 392
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/print.ehPL0gv-.css",
+            "entryType": "resource",
+            "startTime": 18.400000005960464,
+            "duration": 9,
+            "initiatorType": "link",
+            "transferSize": 1296,
+            "encodedBodySize": 996,
+            "decodedBodySize": 3318
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/preload-helper.BnKG7j8P.js",
+            "entryType": "resource",
+            "startTime": 35.900000005960464,
+            "duration": 4.5999999940395355,
+            "initiatorType": "script",
+            "transferSize": 1037,
+            "encodedBodySize": 737,
+            "decodedBodySize": 1351
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/starlight-toc.CTCQXEge.js",
+            "entryType": "resource",
+            "startTime": 36.099999994039536,
+            "duration": 4.600000008940697,
+            "initiatorType": "script",
+            "transferSize": 1251,
+            "encodedBodySize": 951,
+            "decodedBodySize": 1981
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/persistent-toggle.t6KkBAiq.js",
+            "entryType": "resource",
+            "startTime": 36.20000000298023,
+            "duration": 4.5,
+            "initiatorType": "script",
+            "transferSize": 1005,
+            "encodedBodySize": 705,
+            "decodedBodySize": 2082
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/runtime-client.CDKwXtrO.js",
+            "entryType": "resource",
+            "startTime": 42.400000005960464,
+            "duration": 5.0999999940395355,
+            "initiatorType": "script",
+            "transferSize": 9996,
+            "encodedBodySize": 9696,
+            "decodedBodySize": 29967
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/rolldown-runtime.hePW80VL.js",
+            "entryType": "resource",
+            "startTime": 42.5,
+            "duration": 4.700000002980232,
+            "initiatorType": "script",
+            "transferSize": 730,
+            "encodedBodySize": 430,
+            "decodedBodySize": 716
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/output-limits.BuPdYbfn.js",
+            "entryType": "resource",
+            "startTime": 42.599999994039536,
+            "duration": 4.800000011920929,
+            "initiatorType": "script",
+            "transferSize": 884,
+            "encodedBodySize": 584,
+            "decodedBodySize": 1017
+          },
+          {
+            "name": "oxiquill:worker-start:python",
+            "entryType": "mark",
+            "startTime": 86.09999999403954,
+            "duration": 0
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/favicon.svg",
+            "entryType": "resource",
+            "startTime": 87.09999999403954,
+            "duration": 4.9000000059604645,
+            "initiatorType": "other",
+            "transferSize": 559,
+            "encodedBodySize": 259,
+            "decodedBodySize": 331
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/python-worker-DetX1Kyh.js",
+            "entryType": "resource",
+            "startTime": 102.29999999701977,
+            "duration": -10.200000002980232,
+            "initiatorType": "other",
+            "transferSize": 13470,
+            "encodedBodySize": 13170,
+            "decodedBodySize": 48070
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/ui-core.BwVUYzUq.js",
+            "entryType": "resource",
+            "startTime": 112.59999999403954,
+            "duration": 7.100000008940697,
+            "initiatorType": "script",
+            "transferSize": 26419,
+            "encodedBodySize": 26119,
+            "decodedBodySize": 93799
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/InteractiveCell.Ccnnhmwl.js",
+            "entryType": "resource",
+            "startTime": 569.4000000059605,
+            "duration": 6.5999999940395355,
+            "initiatorType": "script",
+            "transferSize": 8435,
+            "encodedBodySize": 8135,
+            "decodedBodySize": 22927
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/client.BJAMOzhD.js",
+            "entryType": "resource",
+            "startTime": 569.5,
+            "duration": 6.299999997019768,
+            "initiatorType": "script",
+            "transferSize": 1114,
+            "encodedBodySize": 814,
+            "decodedBodySize": 1412
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/preact.Bl7PEaKa.js",
+            "entryType": "resource",
+            "startTime": 577.2000000029802,
+            "duration": 5.700000002980232,
+            "initiatorType": "script",
+            "transferSize": 4713,
+            "encodedBodySize": 4413,
+            "decodedBodySize": 10470
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/runtime-localization.vhNiaX9V.js",
+            "entryType": "resource",
+            "startTime": 577.4000000059605,
+            "duration": 5.299999997019768,
+            "initiatorType": "script",
+            "transferSize": 3498,
+            "encodedBodySize": 3198,
+            "decodedBodySize": 8034
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/hooks.ClbWuNs9.js",
+            "entryType": "resource",
+            "startTime": 577.4000000059605,
+            "duration": 5.5,
+            "initiatorType": "script",
+            "transferSize": 1453,
+            "encodedBodySize": 1153,
+            "decodedBodySize": 2677
+          },
+          {
+            "name": "oxiquill:hydrated:features__interactive-cells__python-controls",
+            "entryType": "mark",
+            "startTime": 587.0999999940395,
+            "duration": 0
+          },
+          {
+            "name": "oxiquill:output-rendered:features__interactive-cells__python-controls",
+            "entryType": "mark",
+            "startTime": 1925.5999999940395,
+            "duration": 0
+          }
+        ]
+      },
+      "workers": [
+        {
+          "timeOrigin": 1788592996141.7,
+          "entries": [
+            {
+              "name": "oxiquill:worker-ready:python",
+              "entryType": "mark",
+              "startTime": 5.699999988079071,
+              "duration": 0
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pyodide.mjs",
+              "entryType": "resource",
+              "startTime": 6.799999997019768,
+              "duration": 2.5999999940395355,
+              "initiatorType": "fetch",
+              "transferSize": 7456,
+              "encodedBodySize": 7156,
+              "decodedBodySize": 17931
+            },
+            {
+              "name": "oxiquill:initialization:python",
+              "entryType": "measure",
+              "startTime": 13.5,
+              "duration": 1769.5
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pyodide-lock.json",
+              "entryType": "resource",
+              "startTime": 13.899999991059303,
+              "duration": 10,
+              "initiatorType": "fetch",
+              "transferSize": 26834,
+              "encodedBodySize": 26534,
+              "decodedBodySize": 114440
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/python_stdlib.zip",
+              "entryType": "resource",
+              "startTime": 14.399999991059303,
+              "duration": 103.20000000298023,
+              "initiatorType": "fetch",
+              "transferSize": 2503474,
+              "encodedBodySize": 2503174,
+              "decodedBodySize": 2545564
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pyodide.asm.wasm",
+              "entryType": "resource",
+              "startTime": 14.599999994039536,
+              "duration": 487.59999999403954,
+              "initiatorType": "fetch",
+              "transferSize": 3546429,
+              "encodedBodySize": 3546129,
+              "decodedBodySize": 9598218
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pyodide.asm.mjs",
+              "entryType": "resource",
+              "startTime": 14.799999997019768,
+              "duration": 40.70000000298023,
+              "initiatorType": "script",
+              "transferSize": 260407,
+              "encodedBodySize": 260107,
+              "decodedBodySize": 1250344
+            },
+            {
+              "name": "oxiquill:display-support:python",
+              "entryType": "measure",
+              "startTime": 1783.0999999940395,
+              "duration": 35.79999999701977
+            },
+            {
+              "name": "oxiquill:imports:features__interactive-cells__python-controls",
+              "entryType": "measure",
+              "startTime": 1819,
+              "duration": 0.8999999910593033
+            },
+            {
+              "name": "oxiquill:display-prepare:features__interactive-cells__python-controls",
+              "entryType": "measure",
+              "startTime": 1819.8999999910593,
+              "duration": 0.5
+            },
+            {
+              "name": "oxiquill:execution:features__interactive-cells__python-controls",
+              "entryType": "measure",
+              "startTime": 1820.5999999940395,
+              "duration": 3.4000000059604645
+            },
+            {
+              "name": "oxiquill:display-collect:features__interactive-cells__python-controls",
+              "entryType": "measure",
+              "startTime": 1824.5,
+              "duration": 0.29999999701976776
+            }
+          ]
+        }
+      ],
+      "observed": {
+        "requests": [
+          {
+            "requestId": 2,
+            "at": 1788592996637.3
+          }
+        ],
+        "responses": [
+          {
+            "requestId": 2,
+            "at": 1788592997968.4001,
+            "ok": true
+          }
+        ]
+      }
+    },
+    {
+      "example": "features/interactive-cells/",
+      "condition": "reload",
+      "run": 1,
+      "triggerMs": 107,
+      "outputMs": 1481.0999999940395,
+      "latencyMs": 1481.0999999940395,
+      "renderObserverDeltaMs": -0.199951171875,
+      "main": {
+        "timeOrigin": 1788592997981.7,
+        "entries": [
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/index.DANjJwMU.css",
+            "entryType": "resource",
+            "startTime": 12.699999988079071,
+            "duration": 0,
+            "initiatorType": "link",
+            "transferSize": 0,
+            "encodedBodySize": 21609,
+            "decodedBodySize": 105367
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/page.B1wUxXOO.js",
+            "entryType": "resource",
+            "startTime": 12.699999988079071,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 1581,
+            "decodedBodySize": 3458
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/Search.astro_astro_type_script_index_0_lang.DzL-jWp_.js",
+            "entryType": "resource",
+            "startTime": 12.799999997019768,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 945,
+            "decodedBodySize": 1830
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/MobileTableOfContents.astro_astro_type_script_index_0_lang.BcSo_yiZ.js",
+            "entryType": "resource",
+            "startTime": 13,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 364,
+            "decodedBodySize": 622
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/TableOfContents.astro_astro_type_script_index_0_lang.Csloo1VZ.js",
+            "entryType": "resource",
+            "startTime": 13,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 56,
+            "decodedBodySize": 36
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/TwoColumnContent.astro_astro_type_script_index_0_lang.DPGAuL8N.js",
+            "entryType": "resource",
+            "startTime": 13.099999994039536,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 269,
+            "decodedBodySize": 452
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/PageFrame.astro_astro_type_script_index_0_lang.iwTubUja.js",
+            "entryType": "resource",
+            "startTime": 13.099999994039536,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 257,
+            "decodedBodySize": 392
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/print.ehPL0gv-.css",
+            "entryType": "resource",
+            "startTime": 17,
+            "duration": 0,
+            "initiatorType": "link",
+            "transferSize": 0,
+            "encodedBodySize": 996,
+            "decodedBodySize": 3318
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/preload-helper.BnKG7j8P.js",
+            "entryType": "resource",
+            "startTime": 23.099999994039536,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 737,
+            "decodedBodySize": 1351
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/starlight-toc.CTCQXEge.js",
+            "entryType": "resource",
+            "startTime": 23.299999997019768,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 951,
+            "decodedBodySize": 1981
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/persistent-toggle.t6KkBAiq.js",
+            "entryType": "resource",
+            "startTime": 23.399999991059303,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 705,
+            "decodedBodySize": 2082
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/runtime-client.CDKwXtrO.js",
+            "entryType": "resource",
+            "startTime": 36.69999998807907,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 9696,
+            "decodedBodySize": 29967
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/rolldown-runtime.hePW80VL.js",
+            "entryType": "resource",
+            "startTime": 37,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 430,
+            "decodedBodySize": 716
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/output-limits.BuPdYbfn.js",
+            "entryType": "resource",
+            "startTime": 37.099999994039536,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 584,
+            "decodedBodySize": 1017
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/InteractiveCell.Ccnnhmwl.js",
+            "entryType": "resource",
+            "startTime": 40.599999994039536,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 8135,
+            "decodedBodySize": 22927
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/client.BJAMOzhD.js",
+            "entryType": "resource",
+            "startTime": 40.8999999910593,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 814,
+            "decodedBodySize": 1412
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/preact.Bl7PEaKa.js",
+            "entryType": "resource",
+            "startTime": 43.5,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 4413,
+            "decodedBodySize": 10470
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/runtime-localization.vhNiaX9V.js",
+            "entryType": "resource",
+            "startTime": 43.69999998807907,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 3198,
+            "decodedBodySize": 8034
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/hooks.ClbWuNs9.js",
+            "entryType": "resource",
+            "startTime": 43.8999999910593,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 1153,
+            "decodedBodySize": 2677
+          },
+          {
+            "name": "oxiquill:worker-start:python",
+            "entryType": "mark",
+            "startTime": 44.19999998807907,
+            "duration": 0
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/favicon.svg",
+            "entryType": "resource",
+            "startTime": 44.599999994039536,
+            "duration": 2.5,
+            "initiatorType": "other",
+            "transferSize": 0,
+            "encodedBodySize": 259,
+            "decodedBodySize": 331
+          },
+          {
+            "name": "oxiquill:hydrated:features__interactive-cells__python-controls",
+            "entryType": "mark",
+            "startTime": 53.69999998807907,
+            "duration": 0
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/python-worker-DetX1Kyh.js",
+            "entryType": "resource",
+            "startTime": 56.19999998807907,
+            "duration": -9.199999988079071,
+            "initiatorType": "other",
+            "transferSize": 0,
+            "encodedBodySize": 13170,
+            "decodedBodySize": 48070
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/ui-core.BwVUYzUq.js",
+            "entryType": "resource",
+            "startTime": 68,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 26119,
+            "decodedBodySize": 93799
+          },
+          {
+            "name": "oxiquill:output-rendered:features__interactive-cells__python-controls",
+            "entryType": "mark",
+            "startTime": 1481.0999999940395,
+            "duration": 0
+          }
+        ]
+      },
+      "workers": [
+        {
+          "timeOrigin": 1788592998036.1,
+          "entries": [
+            {
+              "name": "oxiquill:worker-ready:python",
+              "entryType": "mark",
+              "startTime": 3.2999999970197678,
+              "duration": 0
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pyodide.mjs",
+              "entryType": "resource",
+              "startTime": 6.200000002980232,
+              "duration": 1.199999988079071,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 7156,
+              "decodedBodySize": 17931
+            },
+            {
+              "name": "oxiquill:initialization:python",
+              "entryType": "measure",
+              "startTime": 10.700000002980232,
+              "duration": 1370.5999999940395
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pyodide-lock.json",
+              "entryType": "resource",
+              "startTime": 10.899999991059303,
+              "duration": 1.6000000089406967,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 26534,
+              "decodedBodySize": 114440
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/python_stdlib.zip",
+              "entryType": "resource",
+              "startTime": 11.299999997019768,
+              "duration": 17,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 2503174,
+              "decodedBodySize": 2545564
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pyodide.asm.wasm",
+              "entryType": "resource",
+              "startTime": 11.5,
+              "duration": 89.20000000298023,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 3546129,
+              "decodedBodySize": 9598218
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pyodide.asm.mjs",
+              "entryType": "resource",
+              "startTime": 11.700000002980232,
+              "duration": 9.5,
+              "initiatorType": "script",
+              "transferSize": 0,
+              "encodedBodySize": 260107,
+              "decodedBodySize": 1250344
+            },
+            {
+              "name": "oxiquill:display-support:python",
+              "entryType": "measure",
+              "startTime": 1381.2999999970198,
+              "duration": 37.20000000298023
+            },
+            {
+              "name": "oxiquill:imports:features__interactive-cells__python-controls",
+              "entryType": "measure",
+              "startTime": 1418.7999999970198,
+              "duration": 2.2999999970197678
+            },
+            {
+              "name": "oxiquill:display-prepare:features__interactive-cells__python-controls",
+              "entryType": "measure",
+              "startTime": 1421.0999999940395,
+              "duration": 0.5
+            },
+            {
+              "name": "oxiquill:execution:features__interactive-cells__python-controls",
+              "entryType": "measure",
+              "startTime": 1421.7999999970198,
+              "duration": 3.0999999940395355
+            },
+            {
+              "name": "oxiquill:display-collect:features__interactive-cells__python-controls",
+              "entryType": "measure",
+              "startTime": 1425.5,
+              "duration": 0.29999999701976776
+            }
+          ]
+        }
+      ],
+      "observed": {
+        "requests": [
+          {
+            "requestId": 2,
+            "at": 1788592998039.0999
+          }
+        ],
+        "responses": [
+          {
+            "requestId": 2,
+            "at": 1788592999463,
+            "ok": true
+          }
+        ]
+      }
+    },
+    {
+      "example": "features/interactive-cells/",
+      "condition": "repeat",
+      "run": 1,
+      "triggerMs": 1523.699999988079,
+      "outputMs": 1686,
+      "latencyMs": 162.30000001192093,
+      "renderObserverDeltaMs": 0,
+      "main": {
+        "timeOrigin": 1788592997981.7,
+        "entries": [
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/index.DANjJwMU.css",
+            "entryType": "resource",
+            "startTime": 12.699999988079071,
+            "duration": 0,
+            "initiatorType": "link",
+            "transferSize": 0,
+            "encodedBodySize": 21609,
+            "decodedBodySize": 105367
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/page.B1wUxXOO.js",
+            "entryType": "resource",
+            "startTime": 12.699999988079071,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 1581,
+            "decodedBodySize": 3458
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/Search.astro_astro_type_script_index_0_lang.DzL-jWp_.js",
+            "entryType": "resource",
+            "startTime": 12.799999997019768,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 945,
+            "decodedBodySize": 1830
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/MobileTableOfContents.astro_astro_type_script_index_0_lang.BcSo_yiZ.js",
+            "entryType": "resource",
+            "startTime": 13,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 364,
+            "decodedBodySize": 622
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/TableOfContents.astro_astro_type_script_index_0_lang.Csloo1VZ.js",
+            "entryType": "resource",
+            "startTime": 13,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 56,
+            "decodedBodySize": 36
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/TwoColumnContent.astro_astro_type_script_index_0_lang.DPGAuL8N.js",
+            "entryType": "resource",
+            "startTime": 13.099999994039536,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 269,
+            "decodedBodySize": 452
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/PageFrame.astro_astro_type_script_index_0_lang.iwTubUja.js",
+            "entryType": "resource",
+            "startTime": 13.099999994039536,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 257,
+            "decodedBodySize": 392
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/print.ehPL0gv-.css",
+            "entryType": "resource",
+            "startTime": 17,
+            "duration": 0,
+            "initiatorType": "link",
+            "transferSize": 0,
+            "encodedBodySize": 996,
+            "decodedBodySize": 3318
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/preload-helper.BnKG7j8P.js",
+            "entryType": "resource",
+            "startTime": 23.099999994039536,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 737,
+            "decodedBodySize": 1351
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/starlight-toc.CTCQXEge.js",
+            "entryType": "resource",
+            "startTime": 23.299999997019768,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 951,
+            "decodedBodySize": 1981
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/persistent-toggle.t6KkBAiq.js",
+            "entryType": "resource",
+            "startTime": 23.399999991059303,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 705,
+            "decodedBodySize": 2082
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/runtime-client.CDKwXtrO.js",
+            "entryType": "resource",
+            "startTime": 36.69999998807907,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 9696,
+            "decodedBodySize": 29967
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/rolldown-runtime.hePW80VL.js",
+            "entryType": "resource",
+            "startTime": 37,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 430,
+            "decodedBodySize": 716
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/output-limits.BuPdYbfn.js",
+            "entryType": "resource",
+            "startTime": 37.099999994039536,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 584,
+            "decodedBodySize": 1017
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/InteractiveCell.Ccnnhmwl.js",
+            "entryType": "resource",
+            "startTime": 40.599999994039536,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 8135,
+            "decodedBodySize": 22927
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/client.BJAMOzhD.js",
+            "entryType": "resource",
+            "startTime": 40.8999999910593,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 814,
+            "decodedBodySize": 1412
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/preact.Bl7PEaKa.js",
+            "entryType": "resource",
+            "startTime": 43.5,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 4413,
+            "decodedBodySize": 10470
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/runtime-localization.vhNiaX9V.js",
+            "entryType": "resource",
+            "startTime": 43.69999998807907,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 3198,
+            "decodedBodySize": 8034
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/hooks.ClbWuNs9.js",
+            "entryType": "resource",
+            "startTime": 43.8999999910593,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 1153,
+            "decodedBodySize": 2677
+          },
+          {
+            "name": "oxiquill:worker-start:python",
+            "entryType": "mark",
+            "startTime": 44.19999998807907,
+            "duration": 0
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/favicon.svg",
+            "entryType": "resource",
+            "startTime": 44.599999994039536,
+            "duration": 2.5,
+            "initiatorType": "other",
+            "transferSize": 0,
+            "encodedBodySize": 259,
+            "decodedBodySize": 331
+          },
+          {
+            "name": "oxiquill:hydrated:features__interactive-cells__python-controls",
+            "entryType": "mark",
+            "startTime": 53.69999998807907,
+            "duration": 0
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/python-worker-DetX1Kyh.js",
+            "entryType": "resource",
+            "startTime": 56.19999998807907,
+            "duration": -9.199999988079071,
+            "initiatorType": "other",
+            "transferSize": 0,
+            "encodedBodySize": 13170,
+            "decodedBodySize": 48070
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/ui-core.BwVUYzUq.js",
+            "entryType": "resource",
+            "startTime": 68,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 26119,
+            "decodedBodySize": 93799
+          },
+          {
+            "name": "oxiquill:output-rendered:features__interactive-cells__python-controls",
+            "entryType": "mark",
+            "startTime": 1686,
+            "duration": 0
+          }
+        ]
+      },
+      "workers": [
+        {
+          "timeOrigin": 1788592998036.1,
+          "entries": [
+            {
+              "name": "oxiquill:worker-ready:python",
+              "entryType": "mark",
+              "startTime": 3.2999999970197678,
+              "duration": 0
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pyodide.mjs",
+              "entryType": "resource",
+              "startTime": 6.200000002980232,
+              "duration": 1.199999988079071,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 7156,
+              "decodedBodySize": 17931
+            },
+            {
+              "name": "oxiquill:initialization:python",
+              "entryType": "measure",
+              "startTime": 10.700000002980232,
+              "duration": 1370.5999999940395
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pyodide-lock.json",
+              "entryType": "resource",
+              "startTime": 10.899999991059303,
+              "duration": 1.6000000089406967,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 26534,
+              "decodedBodySize": 114440
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/python_stdlib.zip",
+              "entryType": "resource",
+              "startTime": 11.299999997019768,
+              "duration": 17,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 2503174,
+              "decodedBodySize": 2545564
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pyodide.asm.wasm",
+              "entryType": "resource",
+              "startTime": 11.5,
+              "duration": 89.20000000298023,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 3546129,
+              "decodedBodySize": 9598218
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pyodide.asm.mjs",
+              "entryType": "resource",
+              "startTime": 11.700000002980232,
+              "duration": 9.5,
+              "initiatorType": "script",
+              "transferSize": 0,
+              "encodedBodySize": 260107,
+              "decodedBodySize": 1250344
+            },
+            {
+              "name": "oxiquill:display-support:python",
+              "entryType": "measure",
+              "startTime": 1381.2999999970198,
+              "duration": 37.20000000298023
+            },
+            {
+              "name": "oxiquill:imports:features__interactive-cells__python-controls",
+              "entryType": "measure",
+              "startTime": 1628.0999999940395,
+              "duration": 0.7000000029802322
+            },
+            {
+              "name": "oxiquill:display-prepare:features__interactive-cells__python-controls",
+              "entryType": "measure",
+              "startTime": 1628.7999999970198,
+              "duration": 0.4000000059604645
+            },
+            {
+              "name": "oxiquill:execution:features__interactive-cells__python-controls",
+              "entryType": "measure",
+              "startTime": 1629.2999999970198,
+              "duration": 1.2000000029802322
+            },
+            {
+              "name": "oxiquill:display-collect:features__interactive-cells__python-controls",
+              "entryType": "measure",
+              "startTime": 1630.8999999910593,
+              "duration": 0.20000000298023224
+            }
+          ]
+        }
+      ],
+      "observed": {
+        "requests": [
+          {
+            "requestId": 2,
+            "at": 1788592998039.0999
+          },
+          {
+            "requestId": 3,
+            "at": 1788592999663.7
+          }
+        ],
+        "responses": [
+          {
+            "requestId": 2,
+            "at": 1788592999463,
+            "ok": true
+          },
+          {
+            "requestId": 3,
+            "at": 1788592999667.7,
+            "ok": true
+          }
+        ]
+      }
+    },
+    {
+      "example": "features/interactive-cells/",
+      "condition": "fresh",
+      "run": 2,
+      "triggerMs": 175.1000000089407,
+      "outputMs": 1564,
+      "latencyMs": 1564,
+      "renderObserverDeltaMs": 0,
+      "main": {
+        "timeOrigin": 1788592999729,
+        "entries": [
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/index.DANjJwMU.css",
+            "entryType": "resource",
+            "startTime": 6.300000011920929,
+            "duration": 2.3999999910593033,
+            "initiatorType": "link",
+            "transferSize": 21909,
+            "encodedBodySize": 21609,
+            "decodedBodySize": 105367
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/page.B1wUxXOO.js",
+            "entryType": "resource",
+            "startTime": 6.4000000059604645,
+            "duration": 7.799999997019768,
+            "initiatorType": "script",
+            "transferSize": 1881,
+            "encodedBodySize": 1581,
+            "decodedBodySize": 3458
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/Search.astro_astro_type_script_index_0_lang.DzL-jWp_.js",
+            "entryType": "resource",
+            "startTime": 6.5,
+            "duration": 8.200000002980232,
+            "initiatorType": "script",
+            "transferSize": 1245,
+            "encodedBodySize": 945,
+            "decodedBodySize": 1830
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/MobileTableOfContents.astro_astro_type_script_index_0_lang.BcSo_yiZ.js",
+            "entryType": "resource",
+            "startTime": 6.5,
+            "duration": 8.400000005960464,
+            "initiatorType": "script",
+            "transferSize": 664,
+            "encodedBodySize": 364,
+            "decodedBodySize": 622
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/TableOfContents.astro_astro_type_script_index_0_lang.Csloo1VZ.js",
+            "entryType": "resource",
+            "startTime": 6.5,
+            "duration": 8.400000005960464,
+            "initiatorType": "script",
+            "transferSize": 356,
+            "encodedBodySize": 56,
+            "decodedBodySize": 36
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/TwoColumnContent.astro_astro_type_script_index_0_lang.DPGAuL8N.js",
+            "entryType": "resource",
+            "startTime": 6.5,
+            "duration": 8.600000008940697,
+            "initiatorType": "script",
+            "transferSize": 569,
+            "encodedBodySize": 269,
+            "decodedBodySize": 452
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/PageFrame.astro_astro_type_script_index_0_lang.iwTubUja.js",
+            "entryType": "resource",
+            "startTime": 6.5,
+            "duration": 8.700000002980232,
+            "initiatorType": "script",
+            "transferSize": 557,
+            "encodedBodySize": 257,
+            "decodedBodySize": 392
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/print.ehPL0gv-.css",
+            "entryType": "resource",
+            "startTime": 11.800000011920929,
+            "duration": 5,
+            "initiatorType": "link",
+            "transferSize": 1296,
+            "encodedBodySize": 996,
+            "decodedBodySize": 3318
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/preload-helper.BnKG7j8P.js",
+            "entryType": "resource",
+            "startTime": 54.6000000089407,
+            "duration": 3.7000000029802322,
+            "initiatorType": "script",
+            "transferSize": 1037,
+            "encodedBodySize": 737,
+            "decodedBodySize": 1351
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/starlight-toc.CTCQXEge.js",
+            "entryType": "resource",
+            "startTime": 54.80000001192093,
+            "duration": 3.5999999940395355,
+            "initiatorType": "script",
+            "transferSize": 1251,
+            "encodedBodySize": 951,
+            "decodedBodySize": 1981
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/persistent-toggle.t6KkBAiq.js",
+            "entryType": "resource",
+            "startTime": 54.900000005960464,
+            "duration": 3.5999999940395355,
+            "initiatorType": "script",
+            "transferSize": 1005,
+            "encodedBodySize": 705,
+            "decodedBodySize": 2082
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/runtime-client.CDKwXtrO.js",
+            "entryType": "resource",
+            "startTime": 60.30000001192093,
+            "duration": 4,
+            "initiatorType": "script",
+            "transferSize": 9996,
+            "encodedBodySize": 9696,
+            "decodedBodySize": 29967
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/rolldown-runtime.hePW80VL.js",
+            "entryType": "resource",
+            "startTime": 60.400000005960464,
+            "duration": 3.7000000029802322,
+            "initiatorType": "script",
+            "transferSize": 730,
+            "encodedBodySize": 430,
+            "decodedBodySize": 716
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/output-limits.BuPdYbfn.js",
+            "entryType": "resource",
+            "startTime": 60.5,
+            "duration": 3.6000000089406967,
+            "initiatorType": "script",
+            "transferSize": 884,
+            "encodedBodySize": 584,
+            "decodedBodySize": 1017
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/favicon.svg",
+            "entryType": "resource",
+            "startTime": 67.20000000298023,
+            "duration": 2.4000000059604645,
+            "initiatorType": "other",
+            "transferSize": 559,
+            "encodedBodySize": 259,
+            "decodedBodySize": 331
+          },
+          {
+            "name": "oxiquill:worker-start:python",
+            "entryType": "mark",
+            "startTime": 67.70000000298023,
+            "duration": 0
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/python-worker-DetX1Kyh.js",
+            "entryType": "resource",
+            "startTime": 84.1000000089407,
+            "duration": -13.100000008940697,
+            "initiatorType": "other",
+            "transferSize": 13470,
+            "encodedBodySize": 13170,
+            "decodedBodySize": 48070
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/ui-core.BwVUYzUq.js",
+            "entryType": "resource",
+            "startTime": 92.30000001192093,
+            "duration": 2.5,
+            "initiatorType": "script",
+            "transferSize": 26419,
+            "encodedBodySize": 26119,
+            "decodedBodySize": 93799
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/InteractiveCell.Ccnnhmwl.js",
+            "entryType": "resource",
+            "startTime": 158.30000001192093,
+            "duration": 3.2999999970197678,
+            "initiatorType": "script",
+            "transferSize": 8435,
+            "encodedBodySize": 8135,
+            "decodedBodySize": 22927
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/client.BJAMOzhD.js",
+            "entryType": "resource",
+            "startTime": 158.40000000596046,
+            "duration": 3.0999999940395355,
+            "initiatorType": "script",
+            "transferSize": 1114,
+            "encodedBodySize": 814,
+            "decodedBodySize": 1412
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/preact.Bl7PEaKa.js",
+            "entryType": "resource",
+            "startTime": 162.1000000089407,
+            "duration": 4.5999999940395355,
+            "initiatorType": "script",
+            "transferSize": 4713,
+            "encodedBodySize": 4413,
+            "decodedBodySize": 10470
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/hooks.ClbWuNs9.js",
+            "entryType": "resource",
+            "startTime": 162.40000000596046,
+            "duration": 4.0999999940395355,
+            "initiatorType": "script",
+            "transferSize": 1453,
+            "encodedBodySize": 1153,
+            "decodedBodySize": 2677
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/runtime-localization.vhNiaX9V.js",
+            "entryType": "resource",
+            "startTime": 162.40000000596046,
+            "duration": 3.9000000059604645,
+            "initiatorType": "script",
+            "transferSize": 3498,
+            "encodedBodySize": 3198,
+            "decodedBodySize": 8034
+          },
+          {
+            "name": "oxiquill:hydrated:features__interactive-cells__python-controls",
+            "entryType": "mark",
+            "startTime": 170.70000000298023,
+            "duration": 0
+          },
+          {
+            "name": "oxiquill:output-rendered:features__interactive-cells__python-controls",
+            "entryType": "mark",
+            "startTime": 1564,
+            "duration": 0
+          }
+        ]
+      },
+      "workers": [
+        {
+          "timeOrigin": 1788592999811,
+          "entries": [
+            {
+              "name": "oxiquill:worker-ready:python",
+              "entryType": "mark",
+              "startTime": 3.800000011920929,
+              "duration": 0
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pyodide.mjs",
+              "entryType": "resource",
+              "startTime": 8.900000005960464,
+              "duration": 2.5999999940395355,
+              "initiatorType": "fetch",
+              "transferSize": 7456,
+              "encodedBodySize": 7156,
+              "decodedBodySize": 17931
+            },
+            {
+              "name": "oxiquill:initialization:python",
+              "entryType": "measure",
+              "startTime": 15.200000002980232,
+              "duration": 1423.9000000059605
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pyodide-lock.json",
+              "entryType": "resource",
+              "startTime": 15.5,
+              "duration": 6.9000000059604645,
+              "initiatorType": "fetch",
+              "transferSize": 26834,
+              "encodedBodySize": 26534,
+              "decodedBodySize": 114440
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/python_stdlib.zip",
+              "entryType": "resource",
+              "startTime": 16,
+              "duration": 27.400000005960464,
+              "initiatorType": "fetch",
+              "transferSize": 2503474,
+              "encodedBodySize": 2503174,
+              "decodedBodySize": 2545564
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pyodide.asm.wasm",
+              "entryType": "resource",
+              "startTime": 16.100000008940697,
+              "duration": 104.5,
+              "initiatorType": "fetch",
+              "transferSize": 3546429,
+              "encodedBodySize": 3546129,
+              "decodedBodySize": 9598218
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pyodide.asm.mjs",
+              "entryType": "resource",
+              "startTime": 16.30000001192093,
+              "duration": 15,
+              "initiatorType": "script",
+              "transferSize": 260407,
+              "encodedBodySize": 260107,
+              "decodedBodySize": 1250344
+            },
+            {
+              "name": "oxiquill:display-support:python",
+              "entryType": "measure",
+              "startTime": 1439.2000000029802,
+              "duration": 35.1000000089407
+            },
+            {
+              "name": "oxiquill:imports:features__interactive-cells__python-controls",
+              "entryType": "measure",
+              "startTime": 1474.5,
+              "duration": 0.800000011920929
+            },
+            {
+              "name": "oxiquill:display-prepare:features__interactive-cells__python-controls",
+              "entryType": "measure",
+              "startTime": 1475.300000011921,
+              "duration": 0.3999999910593033
+            },
+            {
+              "name": "oxiquill:execution:features__interactive-cells__python-controls",
+              "entryType": "measure",
+              "startTime": 1475.9000000059605,
+              "duration": 3.5
+            },
+            {
+              "name": "oxiquill:display-collect:features__interactive-cells__python-controls",
+              "entryType": "measure",
+              "startTime": 1479.9000000059605,
+              "duration": 0.20000000298023224
+            }
+          ]
+        }
+      ],
+      "observed": {
+        "requests": [
+          {
+            "requestId": 2,
+            "at": 1788592999903.7
+          }
+        ],
+        "responses": [
+          {
+            "requestId": 2,
+            "at": 1788593001293,
+            "ok": true
+          }
+        ]
+      }
+    },
+    {
+      "example": "features/interactive-cells/",
+      "condition": "reload",
+      "run": 2,
+      "triggerMs": 109.70000000298023,
+      "outputMs": 1437.2999999970198,
+      "latencyMs": 1437.2999999970198,
+      "renderObserverDeltaMs": -0.099853515625,
+      "main": {
+        "timeOrigin": 1788593001312.3,
+        "entries": [
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/index.DANjJwMU.css",
+            "entryType": "resource",
+            "startTime": 12.400000005960464,
+            "duration": 0,
+            "initiatorType": "link",
+            "transferSize": 0,
+            "encodedBodySize": 21609,
+            "decodedBodySize": 105367
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/page.B1wUxXOO.js",
+            "entryType": "resource",
+            "startTime": 12.5,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 1581,
+            "decodedBodySize": 3458
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/Search.astro_astro_type_script_index_0_lang.DzL-jWp_.js",
+            "entryType": "resource",
+            "startTime": 12.5,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 945,
+            "decodedBodySize": 1830
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/MobileTableOfContents.astro_astro_type_script_index_0_lang.BcSo_yiZ.js",
+            "entryType": "resource",
+            "startTime": 12.599999994039536,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 364,
+            "decodedBodySize": 622
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/TableOfContents.astro_astro_type_script_index_0_lang.Csloo1VZ.js",
+            "entryType": "resource",
+            "startTime": 12.700000002980232,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 56,
+            "decodedBodySize": 36
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/TwoColumnContent.astro_astro_type_script_index_0_lang.DPGAuL8N.js",
+            "entryType": "resource",
+            "startTime": 12.799999997019768,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 269,
+            "decodedBodySize": 452
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/PageFrame.astro_astro_type_script_index_0_lang.iwTubUja.js",
+            "entryType": "resource",
+            "startTime": 12.799999997019768,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 257,
+            "decodedBodySize": 392
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/print.ehPL0gv-.css",
+            "entryType": "resource",
+            "startTime": 17.200000002980232,
+            "duration": 0,
+            "initiatorType": "link",
+            "transferSize": 0,
+            "encodedBodySize": 996,
+            "decodedBodySize": 3318
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/preload-helper.BnKG7j8P.js",
+            "entryType": "resource",
+            "startTime": 22.799999997019768,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 737,
+            "decodedBodySize": 1351
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/starlight-toc.CTCQXEge.js",
+            "entryType": "resource",
+            "startTime": 23.599999994039536,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 951,
+            "decodedBodySize": 1981
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/persistent-toggle.t6KkBAiq.js",
+            "entryType": "resource",
+            "startTime": 23.700000002980232,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 705,
+            "decodedBodySize": 2082
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/runtime-client.CDKwXtrO.js",
+            "entryType": "resource",
+            "startTime": 24.299999997019768,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 9696,
+            "decodedBodySize": 29967
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/rolldown-runtime.hePW80VL.js",
+            "entryType": "resource",
+            "startTime": 24.5,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 430,
+            "decodedBodySize": 716
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/output-limits.BuPdYbfn.js",
+            "entryType": "resource",
+            "startTime": 24.5,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 584,
+            "decodedBodySize": 1017
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/InteractiveCell.Ccnnhmwl.js",
+            "entryType": "resource",
+            "startTime": 41.5,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 8135,
+            "decodedBodySize": 22927
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/client.BJAMOzhD.js",
+            "entryType": "resource",
+            "startTime": 41.599999994039536,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 814,
+            "decodedBodySize": 1412
+          },
+          {
+            "name": "oxiquill:worker-start:python",
+            "entryType": "mark",
+            "startTime": 42.29999999701977,
+            "duration": 0
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/preact.Bl7PEaKa.js",
+            "entryType": "resource",
+            "startTime": 43.900000005960464,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 4413,
+            "decodedBodySize": 10470
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/runtime-localization.vhNiaX9V.js",
+            "entryType": "resource",
+            "startTime": 44.099999994039536,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 3198,
+            "decodedBodySize": 8034
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/hooks.ClbWuNs9.js",
+            "entryType": "resource",
+            "startTime": 44.29999999701977,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 1153,
+            "decodedBodySize": 2677
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/favicon.svg",
+            "entryType": "resource",
+            "startTime": 45.20000000298023,
+            "duration": 1.8999999910593033,
+            "initiatorType": "other",
+            "transferSize": 0,
+            "encodedBodySize": 259,
+            "decodedBodySize": 331
+          },
+          {
+            "name": "oxiquill:hydrated:features__interactive-cells__python-controls",
+            "entryType": "mark",
+            "startTime": 53.900000005960464,
+            "duration": 0
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/python-worker-DetX1Kyh.js",
+            "entryType": "resource",
+            "startTime": 54.20000000298023,
+            "duration": -9.600000008940697,
+            "initiatorType": "other",
+            "transferSize": 0,
+            "encodedBodySize": 13170,
+            "decodedBodySize": 48070
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/ui-core.BwVUYzUq.js",
+            "entryType": "resource",
+            "startTime": 68.5,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 26119,
+            "decodedBodySize": 93799
+          },
+          {
+            "name": "oxiquill:output-rendered:features__interactive-cells__python-controls",
+            "entryType": "mark",
+            "startTime": 1437.2999999970198,
+            "duration": 0
+          }
+        ]
+      },
+      "workers": [
+        {
+          "timeOrigin": 1788593001364.9,
+          "entries": [
+            {
+              "name": "oxiquill:worker-ready:python",
+              "entryType": "mark",
+              "startTime": 3,
+              "duration": 0
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pyodide.mjs",
+              "entryType": "resource",
+              "startTime": 4.700000002980232,
+              "duration": 1.2000000029802322,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 7156,
+              "decodedBodySize": 17931
+            },
+            {
+              "name": "oxiquill:initialization:python",
+              "entryType": "measure",
+              "startTime": 8.900000005960464,
+              "duration": 1335
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pyodide-lock.json",
+              "entryType": "resource",
+              "startTime": 9.300000011920929,
+              "duration": 1.5,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 26534,
+              "decodedBodySize": 114440
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/python_stdlib.zip",
+              "entryType": "resource",
+              "startTime": 9.600000008940697,
+              "duration": 16.399999991059303,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 2503174,
+              "decodedBodySize": 2545564
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pyodide.asm.wasm",
+              "entryType": "resource",
+              "startTime": 9.800000011920929,
+              "duration": 88.5,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 3546129,
+              "decodedBodySize": 9598218
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pyodide.asm.mjs",
+              "entryType": "resource",
+              "startTime": 10,
+              "duration": 9.200000002980232,
+              "initiatorType": "script",
+              "transferSize": 0,
+              "encodedBodySize": 260107,
+              "decodedBodySize": 1250344
+            },
+            {
+              "name": "oxiquill:display-support:python",
+              "entryType": "measure",
+              "startTime": 1343.9000000059605,
+              "duration": 33.099999994039536
+            },
+            {
+              "name": "oxiquill:imports:features__interactive-cells__python-controls",
+              "entryType": "measure",
+              "startTime": 1377.2000000029802,
+              "duration": 1.2999999970197678
+            },
+            {
+              "name": "oxiquill:display-prepare:features__interactive-cells__python-controls",
+              "entryType": "measure",
+              "startTime": 1378.5,
+              "duration": 0.4000000059604645
+            },
+            {
+              "name": "oxiquill:execution:features__interactive-cells__python-controls",
+              "entryType": "measure",
+              "startTime": 1379.1000000089407,
+              "duration": 3.5
+            },
+            {
+              "name": "oxiquill:display-collect:features__interactive-cells__python-controls",
+              "entryType": "measure",
+              "startTime": 1383.300000011921,
+              "duration": 0.29999999701976776
+            }
+          ]
+        }
+      ],
+      "observed": {
+        "requests": [
+          {
+            "requestId": 2,
+            "at": 1788593001370.8
+          }
+        ],
+        "responses": [
+          {
+            "requestId": 2,
+            "at": 1788593002749.7,
+            "ok": true
+          }
+        ]
+      }
+    },
+    {
+      "example": "features/interactive-cells/",
+      "condition": "repeat",
+      "run": 2,
+      "triggerMs": 1476.2999999970198,
+      "outputMs": 1637.2000000029802,
+      "latencyMs": 160.90000000596046,
+      "renderObserverDeltaMs": -0.199951171875,
+      "main": {
+        "timeOrigin": 1788593001312.3,
+        "entries": [
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/index.DANjJwMU.css",
+            "entryType": "resource",
+            "startTime": 12.400000005960464,
+            "duration": 0,
+            "initiatorType": "link",
+            "transferSize": 0,
+            "encodedBodySize": 21609,
+            "decodedBodySize": 105367
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/page.B1wUxXOO.js",
+            "entryType": "resource",
+            "startTime": 12.5,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 1581,
+            "decodedBodySize": 3458
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/Search.astro_astro_type_script_index_0_lang.DzL-jWp_.js",
+            "entryType": "resource",
+            "startTime": 12.5,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 945,
+            "decodedBodySize": 1830
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/MobileTableOfContents.astro_astro_type_script_index_0_lang.BcSo_yiZ.js",
+            "entryType": "resource",
+            "startTime": 12.599999994039536,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 364,
+            "decodedBodySize": 622
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/TableOfContents.astro_astro_type_script_index_0_lang.Csloo1VZ.js",
+            "entryType": "resource",
+            "startTime": 12.700000002980232,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 56,
+            "decodedBodySize": 36
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/TwoColumnContent.astro_astro_type_script_index_0_lang.DPGAuL8N.js",
+            "entryType": "resource",
+            "startTime": 12.799999997019768,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 269,
+            "decodedBodySize": 452
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/PageFrame.astro_astro_type_script_index_0_lang.iwTubUja.js",
+            "entryType": "resource",
+            "startTime": 12.799999997019768,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 257,
+            "decodedBodySize": 392
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/print.ehPL0gv-.css",
+            "entryType": "resource",
+            "startTime": 17.200000002980232,
+            "duration": 0,
+            "initiatorType": "link",
+            "transferSize": 0,
+            "encodedBodySize": 996,
+            "decodedBodySize": 3318
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/preload-helper.BnKG7j8P.js",
+            "entryType": "resource",
+            "startTime": 22.799999997019768,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 737,
+            "decodedBodySize": 1351
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/starlight-toc.CTCQXEge.js",
+            "entryType": "resource",
+            "startTime": 23.599999994039536,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 951,
+            "decodedBodySize": 1981
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/persistent-toggle.t6KkBAiq.js",
+            "entryType": "resource",
+            "startTime": 23.700000002980232,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 705,
+            "decodedBodySize": 2082
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/runtime-client.CDKwXtrO.js",
+            "entryType": "resource",
+            "startTime": 24.299999997019768,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 9696,
+            "decodedBodySize": 29967
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/rolldown-runtime.hePW80VL.js",
+            "entryType": "resource",
+            "startTime": 24.5,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 430,
+            "decodedBodySize": 716
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/output-limits.BuPdYbfn.js",
+            "entryType": "resource",
+            "startTime": 24.5,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 584,
+            "decodedBodySize": 1017
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/InteractiveCell.Ccnnhmwl.js",
+            "entryType": "resource",
+            "startTime": 41.5,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 8135,
+            "decodedBodySize": 22927
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/client.BJAMOzhD.js",
+            "entryType": "resource",
+            "startTime": 41.599999994039536,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 814,
+            "decodedBodySize": 1412
+          },
+          {
+            "name": "oxiquill:worker-start:python",
+            "entryType": "mark",
+            "startTime": 42.29999999701977,
+            "duration": 0
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/preact.Bl7PEaKa.js",
+            "entryType": "resource",
+            "startTime": 43.900000005960464,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 4413,
+            "decodedBodySize": 10470
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/runtime-localization.vhNiaX9V.js",
+            "entryType": "resource",
+            "startTime": 44.099999994039536,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 3198,
+            "decodedBodySize": 8034
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/hooks.ClbWuNs9.js",
+            "entryType": "resource",
+            "startTime": 44.29999999701977,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 1153,
+            "decodedBodySize": 2677
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/favicon.svg",
+            "entryType": "resource",
+            "startTime": 45.20000000298023,
+            "duration": 1.8999999910593033,
+            "initiatorType": "other",
+            "transferSize": 0,
+            "encodedBodySize": 259,
+            "decodedBodySize": 331
+          },
+          {
+            "name": "oxiquill:hydrated:features__interactive-cells__python-controls",
+            "entryType": "mark",
+            "startTime": 53.900000005960464,
+            "duration": 0
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/python-worker-DetX1Kyh.js",
+            "entryType": "resource",
+            "startTime": 54.20000000298023,
+            "duration": -9.600000008940697,
+            "initiatorType": "other",
+            "transferSize": 0,
+            "encodedBodySize": 13170,
+            "decodedBodySize": 48070
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/ui-core.BwVUYzUq.js",
+            "entryType": "resource",
+            "startTime": 68.5,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 26119,
+            "decodedBodySize": 93799
+          },
+          {
+            "name": "oxiquill:output-rendered:features__interactive-cells__python-controls",
+            "entryType": "mark",
+            "startTime": 1637.2000000029802,
+            "duration": 0
+          }
+        ]
+      },
+      "workers": [
+        {
+          "timeOrigin": 1788593001364.9,
+          "entries": [
+            {
+              "name": "oxiquill:worker-ready:python",
+              "entryType": "mark",
+              "startTime": 3,
+              "duration": 0
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pyodide.mjs",
+              "entryType": "resource",
+              "startTime": 4.700000002980232,
+              "duration": 1.2000000029802322,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 7156,
+              "decodedBodySize": 17931
+            },
+            {
+              "name": "oxiquill:initialization:python",
+              "entryType": "measure",
+              "startTime": 8.900000005960464,
+              "duration": 1335
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pyodide-lock.json",
+              "entryType": "resource",
+              "startTime": 9.300000011920929,
+              "duration": 1.5,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 26534,
+              "decodedBodySize": 114440
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/python_stdlib.zip",
+              "entryType": "resource",
+              "startTime": 9.600000008940697,
+              "duration": 16.399999991059303,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 2503174,
+              "decodedBodySize": 2545564
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pyodide.asm.wasm",
+              "entryType": "resource",
+              "startTime": 9.800000011920929,
+              "duration": 88.5,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 3546129,
+              "decodedBodySize": 9598218
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pyodide.asm.mjs",
+              "entryType": "resource",
+              "startTime": 10,
+              "duration": 9.200000002980232,
+              "initiatorType": "script",
+              "transferSize": 0,
+              "encodedBodySize": 260107,
+              "decodedBodySize": 1250344
+            },
+            {
+              "name": "oxiquill:display-support:python",
+              "entryType": "measure",
+              "startTime": 1343.9000000059605,
+              "duration": 33.099999994039536
+            },
+            {
+              "name": "oxiquill:imports:features__interactive-cells__python-controls",
+              "entryType": "measure",
+              "startTime": 1580.7000000029802,
+              "duration": 0.7000000029802322
+            },
+            {
+              "name": "oxiquill:display-prepare:features__interactive-cells__python-controls",
+              "entryType": "measure",
+              "startTime": 1581.5,
+              "duration": 0.4000000059604645
+            },
+            {
+              "name": "oxiquill:execution:features__interactive-cells__python-controls",
+              "entryType": "measure",
+              "startTime": 1582,
+              "duration": 1.5
+            },
+            {
+              "name": "oxiquill:display-collect:features__interactive-cells__python-controls",
+              "entryType": "measure",
+              "startTime": 1583.800000011921,
+              "duration": 0.29999999701976776
+            }
+          ]
+        }
+      ],
+      "observed": {
+        "requests": [
+          {
+            "requestId": 2,
+            "at": 1788593001370.8
+          },
+          {
+            "requestId": 3,
+            "at": 1788593002945.4001
+          }
+        ],
+        "responses": [
+          {
+            "requestId": 2,
+            "at": 1788593002749.7,
+            "ok": true
+          },
+          {
+            "requestId": 3,
+            "at": 1788593002949.7,
+            "ok": true
+          }
+        ]
+      }
+    },
+    {
+      "example": "features/interactive-cells/",
+      "condition": "fresh",
+      "run": 3,
+      "triggerMs": 159.40000000596046,
+      "outputMs": 1538.7000000029802,
+      "latencyMs": 1538.7000000029802,
+      "renderObserverDeltaMs": -0.199951171875,
+      "main": {
+        "timeOrigin": 1788593003010.9,
+        "entries": [
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/index.DANjJwMU.css",
+            "entryType": "resource",
+            "startTime": 6.100000008940697,
+            "duration": 2.2999999970197678,
+            "initiatorType": "link",
+            "transferSize": 21909,
+            "encodedBodySize": 21609,
+            "decodedBodySize": 105367
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/page.B1wUxXOO.js",
+            "entryType": "resource",
+            "startTime": 6.300000011920929,
+            "duration": 7.5999999940395355,
+            "initiatorType": "script",
+            "transferSize": 1881,
+            "encodedBodySize": 1581,
+            "decodedBodySize": 3458
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/MobileTableOfContents.astro_astro_type_script_index_0_lang.BcSo_yiZ.js",
+            "entryType": "resource",
+            "startTime": 6.4000000059604645,
+            "duration": 8.099999994039536,
+            "initiatorType": "script",
+            "transferSize": 664,
+            "encodedBodySize": 364,
+            "decodedBodySize": 622
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/Search.astro_astro_type_script_index_0_lang.DzL-jWp_.js",
+            "entryType": "resource",
+            "startTime": 6.4000000059604645,
+            "duration": 8,
+            "initiatorType": "script",
+            "transferSize": 1245,
+            "encodedBodySize": 945,
+            "decodedBodySize": 1830
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/TableOfContents.astro_astro_type_script_index_0_lang.Csloo1VZ.js",
+            "entryType": "resource",
+            "startTime": 6.5,
+            "duration": 8.100000008940697,
+            "initiatorType": "script",
+            "transferSize": 356,
+            "encodedBodySize": 56,
+            "decodedBodySize": 36
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/TwoColumnContent.astro_astro_type_script_index_0_lang.DPGAuL8N.js",
+            "entryType": "resource",
+            "startTime": 6.5,
+            "duration": 8.400000005960464,
+            "initiatorType": "script",
+            "transferSize": 569,
+            "encodedBodySize": 269,
+            "decodedBodySize": 452
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/PageFrame.astro_astro_type_script_index_0_lang.iwTubUja.js",
+            "entryType": "resource",
+            "startTime": 6.5,
+            "duration": 8.700000002980232,
+            "initiatorType": "script",
+            "transferSize": 557,
+            "encodedBodySize": 257,
+            "decodedBodySize": 392
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/print.ehPL0gv-.css",
+            "entryType": "resource",
+            "startTime": 11.100000008940697,
+            "duration": 5.5,
+            "initiatorType": "link",
+            "transferSize": 1296,
+            "encodedBodySize": 996,
+            "decodedBodySize": 3318
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/preload-helper.BnKG7j8P.js",
+            "entryType": "resource",
+            "startTime": 55.5,
+            "duration": 3.7000000029802322,
+            "initiatorType": "script",
+            "transferSize": 1037,
+            "encodedBodySize": 737,
+            "decodedBodySize": 1351
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/persistent-toggle.t6KkBAiq.js",
+            "entryType": "resource",
+            "startTime": 55.6000000089407,
+            "duration": 3.8999999910593033,
+            "initiatorType": "script",
+            "transferSize": 1005,
+            "encodedBodySize": 705,
+            "decodedBodySize": 2082
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/starlight-toc.CTCQXEge.js",
+            "entryType": "resource",
+            "startTime": 55.6000000089407,
+            "duration": 3.7999999970197678,
+            "initiatorType": "script",
+            "transferSize": 1251,
+            "encodedBodySize": 951,
+            "decodedBodySize": 1981
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/runtime-client.CDKwXtrO.js",
+            "entryType": "resource",
+            "startTime": 61.30000001192093,
+            "duration": 5.5,
+            "initiatorType": "script",
+            "transferSize": 9996,
+            "encodedBodySize": 9696,
+            "decodedBodySize": 29967
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/rolldown-runtime.hePW80VL.js",
+            "entryType": "resource",
+            "startTime": 61.6000000089407,
+            "duration": 4.799999997019768,
+            "initiatorType": "script",
+            "transferSize": 730,
+            "encodedBodySize": 430,
+            "decodedBodySize": 716
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/output-limits.BuPdYbfn.js",
+            "entryType": "resource",
+            "startTime": 62,
+            "duration": 4.600000008940697,
+            "initiatorType": "script",
+            "transferSize": 884,
+            "encodedBodySize": 584,
+            "decodedBodySize": 1017
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/favicon.svg",
+            "entryType": "resource",
+            "startTime": 70.1000000089407,
+            "duration": 2.2000000029802322,
+            "initiatorType": "other",
+            "transferSize": 559,
+            "encodedBodySize": 259,
+            "decodedBodySize": 331
+          },
+          {
+            "name": "oxiquill:worker-start:python",
+            "entryType": "mark",
+            "startTime": 70.6000000089407,
+            "duration": 0
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/python-worker-DetX1Kyh.js",
+            "entryType": "resource",
+            "startTime": 82.1000000089407,
+            "duration": -8.100000008940697,
+            "initiatorType": "other",
+            "transferSize": 13470,
+            "encodedBodySize": 13170,
+            "decodedBodySize": 48070
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/ui-core.BwVUYzUq.js",
+            "entryType": "resource",
+            "startTime": 106.90000000596046,
+            "duration": 3.5999999940395355,
+            "initiatorType": "script",
+            "transferSize": 26419,
+            "encodedBodySize": 26119,
+            "decodedBodySize": 93799
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/InteractiveCell.Ccnnhmwl.js",
+            "entryType": "resource",
+            "startTime": 142.80000001192093,
+            "duration": 3.8999999910593033,
+            "initiatorType": "script",
+            "transferSize": 8435,
+            "encodedBodySize": 8135,
+            "decodedBodySize": 22927
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/client.BJAMOzhD.js",
+            "entryType": "resource",
+            "startTime": 142.90000000596046,
+            "duration": 3.5999999940395355,
+            "initiatorType": "script",
+            "transferSize": 1114,
+            "encodedBodySize": 814,
+            "decodedBodySize": 1412
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/preact.Bl7PEaKa.js",
+            "entryType": "resource",
+            "startTime": 147.6000000089407,
+            "duration": 4.200000002980232,
+            "initiatorType": "script",
+            "transferSize": 4713,
+            "encodedBodySize": 4413,
+            "decodedBodySize": 10470
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/runtime-localization.vhNiaX9V.js",
+            "entryType": "resource",
+            "startTime": 147.70000000298023,
+            "duration": 3.7999999970197678,
+            "initiatorType": "script",
+            "transferSize": 3498,
+            "encodedBodySize": 3198,
+            "decodedBodySize": 8034
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/hooks.ClbWuNs9.js",
+            "entryType": "resource",
+            "startTime": 147.80000001192093,
+            "duration": 3.7999999970197678,
+            "initiatorType": "script",
+            "transferSize": 1453,
+            "encodedBodySize": 1153,
+            "decodedBodySize": 2677
+          },
+          {
+            "name": "oxiquill:hydrated:features__interactive-cells__python-controls",
+            "entryType": "mark",
+            "startTime": 155.5,
+            "duration": 0
+          },
+          {
+            "name": "oxiquill:output-rendered:features__interactive-cells__python-controls",
+            "entryType": "mark",
+            "startTime": 1538.7000000029802,
+            "duration": 0
+          }
+        ]
+      },
+      "workers": [
+        {
+          "timeOrigin": 1788593003091.1,
+          "entries": [
+            {
+              "name": "oxiquill:worker-ready:python",
+              "entryType": "mark",
+              "startTime": 3.5,
+              "duration": 0
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pyodide.mjs",
+              "entryType": "resource",
+              "startTime": 4.9000000059604645,
+              "duration": 1.8999999910593033,
+              "initiatorType": "fetch",
+              "transferSize": 7456,
+              "encodedBodySize": 7156,
+              "decodedBodySize": 17931
+            },
+            {
+              "name": "oxiquill:initialization:python",
+              "entryType": "measure",
+              "startTime": 10.100000008940697,
+              "duration": 1405.199999988079
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pyodide-lock.json",
+              "entryType": "resource",
+              "startTime": 10.5,
+              "duration": 5.600000008940697,
+              "initiatorType": "fetch",
+              "transferSize": 26834,
+              "encodedBodySize": 26534,
+              "decodedBodySize": 114440
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/python_stdlib.zip",
+              "entryType": "resource",
+              "startTime": 10.799999997019768,
+              "duration": 26.30000001192093,
+              "initiatorType": "fetch",
+              "transferSize": 2503474,
+              "encodedBodySize": 2503174,
+              "decodedBodySize": 2545564
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pyodide.asm.wasm",
+              "entryType": "resource",
+              "startTime": 11,
+              "duration": 103,
+              "initiatorType": "fetch",
+              "transferSize": 3546429,
+              "encodedBodySize": 3546129,
+              "decodedBodySize": 9598218
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pyodide.asm.mjs",
+              "entryType": "resource",
+              "startTime": 11.200000002980232,
+              "duration": 12.799999997019768,
+              "initiatorType": "script",
+              "transferSize": 260407,
+              "encodedBodySize": 260107,
+              "decodedBodySize": 1250344
+            },
+            {
+              "name": "oxiquill:display-support:python",
+              "entryType": "measure",
+              "startTime": 1415.2999999970198,
+              "duration": 34.5
+            },
+            {
+              "name": "oxiquill:imports:features__interactive-cells__python-controls",
+              "entryType": "measure",
+              "startTime": 1450.1000000089407,
+              "duration": 1
+            },
+            {
+              "name": "oxiquill:display-prepare:features__interactive-cells__python-controls",
+              "entryType": "measure",
+              "startTime": 1451.1000000089407,
+              "duration": 0.5
+            },
+            {
+              "name": "oxiquill:execution:features__interactive-cells__python-controls",
+              "entryType": "measure",
+              "startTime": 1451.7999999970198,
+              "duration": 4.100000008940697
+            },
+            {
+              "name": "oxiquill:display-collect:features__interactive-cells__python-controls",
+              "entryType": "measure",
+              "startTime": 1456.5,
+              "duration": 0.20000000298023224
+            }
+          ]
+        }
+      ],
+      "observed": {
+        "requests": [
+          {
+            "requestId": 2,
+            "at": 1788593003170
+          }
+        ],
+        "responses": [
+          {
+            "requestId": 2,
+            "at": 1788593004549.7998,
+            "ok": true
+          }
+        ]
+      }
+    },
+    {
+      "example": "features/interactive-cells/",
+      "condition": "reload",
+      "run": 3,
+      "triggerMs": 108.70000000298023,
+      "outputMs": 1411.2000000029802,
+      "latencyMs": 1411.2000000029802,
+      "renderObserverDeltaMs": -0.10009765625,
+      "main": {
+        "timeOrigin": 1788593004563.2,
+        "entries": [
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/index.DANjJwMU.css",
+            "entryType": "resource",
+            "startTime": 12,
+            "duration": 0,
+            "initiatorType": "link",
+            "transferSize": 0,
+            "encodedBodySize": 21609,
+            "decodedBodySize": 105367
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/page.B1wUxXOO.js",
+            "entryType": "resource",
+            "startTime": 12.099999994039536,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 1581,
+            "decodedBodySize": 3458
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/Search.astro_astro_type_script_index_0_lang.DzL-jWp_.js",
+            "entryType": "resource",
+            "startTime": 12.099999994039536,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 945,
+            "decodedBodySize": 1830
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/MobileTableOfContents.astro_astro_type_script_index_0_lang.BcSo_yiZ.js",
+            "entryType": "resource",
+            "startTime": 12.200000002980232,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 364,
+            "decodedBodySize": 622
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/TableOfContents.astro_astro_type_script_index_0_lang.Csloo1VZ.js",
+            "entryType": "resource",
+            "startTime": 12.200000002980232,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 56,
+            "decodedBodySize": 36
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/TwoColumnContent.astro_astro_type_script_index_0_lang.DPGAuL8N.js",
+            "entryType": "resource",
+            "startTime": 12.299999997019768,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 269,
+            "decodedBodySize": 452
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/PageFrame.astro_astro_type_script_index_0_lang.iwTubUja.js",
+            "entryType": "resource",
+            "startTime": 12.400000005960464,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 257,
+            "decodedBodySize": 392
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/print.ehPL0gv-.css",
+            "entryType": "resource",
+            "startTime": 16,
+            "duration": 0,
+            "initiatorType": "link",
+            "transferSize": 0,
+            "encodedBodySize": 996,
+            "decodedBodySize": 3318
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/preload-helper.BnKG7j8P.js",
+            "entryType": "resource",
+            "startTime": 21.700000002980232,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 737,
+            "decodedBodySize": 1351
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/starlight-toc.CTCQXEge.js",
+            "entryType": "resource",
+            "startTime": 22.400000005960464,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 951,
+            "decodedBodySize": 1981
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/persistent-toggle.t6KkBAiq.js",
+            "entryType": "resource",
+            "startTime": 22.599999994039536,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 705,
+            "decodedBodySize": 2082
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/runtime-client.CDKwXtrO.js",
+            "entryType": "resource",
+            "startTime": 23,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 9696,
+            "decodedBodySize": 29967
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/rolldown-runtime.hePW80VL.js",
+            "entryType": "resource",
+            "startTime": 23.200000002980232,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 430,
+            "decodedBodySize": 716
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/output-limits.BuPdYbfn.js",
+            "entryType": "resource",
+            "startTime": 23.299999997019768,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 584,
+            "decodedBodySize": 1017
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/InteractiveCell.Ccnnhmwl.js",
+            "entryType": "resource",
+            "startTime": 40.20000000298023,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 8135,
+            "decodedBodySize": 22927
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/client.BJAMOzhD.js",
+            "entryType": "resource",
+            "startTime": 40.29999999701977,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 814,
+            "decodedBodySize": 1412
+          },
+          {
+            "name": "oxiquill:worker-start:python",
+            "entryType": "mark",
+            "startTime": 40.79999999701977,
+            "duration": 0
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/preact.Bl7PEaKa.js",
+            "entryType": "resource",
+            "startTime": 41.20000000298023,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 4413,
+            "decodedBodySize": 10470
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/runtime-localization.vhNiaX9V.js",
+            "entryType": "resource",
+            "startTime": 41.29999999701977,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 3198,
+            "decodedBodySize": 8034
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/hooks.ClbWuNs9.js",
+            "entryType": "resource",
+            "startTime": 41.400000005960464,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 1153,
+            "decodedBodySize": 2677
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/favicon.svg",
+            "entryType": "resource",
+            "startTime": 42.400000005960464,
+            "duration": 1.5,
+            "initiatorType": "other",
+            "transferSize": 0,
+            "encodedBodySize": 259,
+            "decodedBodySize": 331
+          },
+          {
+            "name": "oxiquill:hydrated:features__interactive-cells__python-controls",
+            "entryType": "mark",
+            "startTime": 44.400000005960464,
+            "duration": 0
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/python-worker-DetX1Kyh.js",
+            "entryType": "resource",
+            "startTime": 54.599999994039536,
+            "duration": -11.899999991059303,
+            "initiatorType": "other",
+            "transferSize": 0,
+            "encodedBodySize": 13170,
+            "decodedBodySize": 48070
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/ui-core.BwVUYzUq.js",
+            "entryType": "resource",
+            "startTime": 65.40000000596046,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 26119,
+            "decodedBodySize": 93799
+          },
+          {
+            "name": "oxiquill:output-rendered:features__interactive-cells__python-controls",
+            "entryType": "mark",
+            "startTime": 1411.2000000029802,
+            "duration": 0
+          }
+        ]
+      },
+      "workers": [
+        {
+          "timeOrigin": 1788593004616.2,
+          "entries": [
+            {
+              "name": "oxiquill:worker-ready:python",
+              "entryType": "mark",
+              "startTime": 3.0999999940395355,
+              "duration": 0
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pyodide.mjs",
+              "entryType": "resource",
+              "startTime": 5.5999999940395355,
+              "duration": 1.2999999970197678,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 7156,
+              "decodedBodySize": 17931
+            },
+            {
+              "name": "oxiquill:initialization:python",
+              "entryType": "measure",
+              "startTime": 11.299999997019768,
+              "duration": 1305.2000000029802
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pyodide-lock.json",
+              "entryType": "resource",
+              "startTime": 11.599999994039536,
+              "duration": 1.9000000059604645,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 26534,
+              "decodedBodySize": 114440
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/python_stdlib.zip",
+              "entryType": "resource",
+              "startTime": 12,
+              "duration": 18,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 2503174,
+              "decodedBodySize": 2545564
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pyodide.asm.wasm",
+              "entryType": "resource",
+              "startTime": 12.299999997019768,
+              "duration": 89.8999999910593,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 3546129,
+              "decodedBodySize": 9598218
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pyodide.asm.mjs",
+              "entryType": "resource",
+              "startTime": 12.5,
+              "duration": 10.099999994039536,
+              "initiatorType": "script",
+              "transferSize": 0,
+              "encodedBodySize": 260107,
+              "decodedBodySize": 1250344
+            },
+            {
+              "name": "oxiquill:display-support:python",
+              "entryType": "measure",
+              "startTime": 1316.5,
+              "duration": 34.599999994039536
+            },
+            {
+              "name": "oxiquill:imports:features__interactive-cells__python-controls",
+              "entryType": "measure",
+              "startTime": 1351.3999999910593,
+              "duration": 1.1000000089406967
+            },
+            {
+              "name": "oxiquill:display-prepare:features__interactive-cells__python-controls",
+              "entryType": "measure",
+              "startTime": 1352.5,
+              "duration": 0.5
+            },
+            {
+              "name": "oxiquill:execution:features__interactive-cells__python-controls",
+              "entryType": "measure",
+              "startTime": 1353.0999999940395,
+              "duration": 3.4000000059604645
+            },
+            {
+              "name": "oxiquill:display-collect:features__interactive-cells__python-controls",
+              "entryType": "measure",
+              "startTime": 1357.0999999940395,
+              "duration": 0.29999999701976776
+            }
+          ]
+        }
+      ],
+      "observed": {
+        "requests": [
+          {
+            "requestId": 2,
+            "at": 1788593004621.7
+          }
+        ],
+        "responses": [
+          {
+            "requestId": 2,
+            "at": 1788593005974.5,
+            "ok": true
+          }
+        ]
+      }
+    },
+    {
+      "example": "features/interactive-cells/",
+      "condition": "repeat",
+      "run": 3,
+      "triggerMs": 1459,
+      "outputMs": 1621.7000000029802,
+      "latencyMs": 162.70000000298023,
+      "renderObserverDeltaMs": -0.10009765625,
+      "main": {
+        "timeOrigin": 1788593004563.2,
+        "entries": [
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/index.DANjJwMU.css",
+            "entryType": "resource",
+            "startTime": 12,
+            "duration": 0,
+            "initiatorType": "link",
+            "transferSize": 0,
+            "encodedBodySize": 21609,
+            "decodedBodySize": 105367
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/page.B1wUxXOO.js",
+            "entryType": "resource",
+            "startTime": 12.099999994039536,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 1581,
+            "decodedBodySize": 3458
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/Search.astro_astro_type_script_index_0_lang.DzL-jWp_.js",
+            "entryType": "resource",
+            "startTime": 12.099999994039536,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 945,
+            "decodedBodySize": 1830
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/MobileTableOfContents.astro_astro_type_script_index_0_lang.BcSo_yiZ.js",
+            "entryType": "resource",
+            "startTime": 12.200000002980232,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 364,
+            "decodedBodySize": 622
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/TableOfContents.astro_astro_type_script_index_0_lang.Csloo1VZ.js",
+            "entryType": "resource",
+            "startTime": 12.200000002980232,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 56,
+            "decodedBodySize": 36
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/TwoColumnContent.astro_astro_type_script_index_0_lang.DPGAuL8N.js",
+            "entryType": "resource",
+            "startTime": 12.299999997019768,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 269,
+            "decodedBodySize": 452
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/PageFrame.astro_astro_type_script_index_0_lang.iwTubUja.js",
+            "entryType": "resource",
+            "startTime": 12.400000005960464,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 257,
+            "decodedBodySize": 392
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/print.ehPL0gv-.css",
+            "entryType": "resource",
+            "startTime": 16,
+            "duration": 0,
+            "initiatorType": "link",
+            "transferSize": 0,
+            "encodedBodySize": 996,
+            "decodedBodySize": 3318
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/preload-helper.BnKG7j8P.js",
+            "entryType": "resource",
+            "startTime": 21.700000002980232,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 737,
+            "decodedBodySize": 1351
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/starlight-toc.CTCQXEge.js",
+            "entryType": "resource",
+            "startTime": 22.400000005960464,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 951,
+            "decodedBodySize": 1981
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/persistent-toggle.t6KkBAiq.js",
+            "entryType": "resource",
+            "startTime": 22.599999994039536,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 705,
+            "decodedBodySize": 2082
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/runtime-client.CDKwXtrO.js",
+            "entryType": "resource",
+            "startTime": 23,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 9696,
+            "decodedBodySize": 29967
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/rolldown-runtime.hePW80VL.js",
+            "entryType": "resource",
+            "startTime": 23.200000002980232,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 430,
+            "decodedBodySize": 716
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/output-limits.BuPdYbfn.js",
+            "entryType": "resource",
+            "startTime": 23.299999997019768,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 584,
+            "decodedBodySize": 1017
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/InteractiveCell.Ccnnhmwl.js",
+            "entryType": "resource",
+            "startTime": 40.20000000298023,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 8135,
+            "decodedBodySize": 22927
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/client.BJAMOzhD.js",
+            "entryType": "resource",
+            "startTime": 40.29999999701977,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 814,
+            "decodedBodySize": 1412
+          },
+          {
+            "name": "oxiquill:worker-start:python",
+            "entryType": "mark",
+            "startTime": 40.79999999701977,
+            "duration": 0
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/preact.Bl7PEaKa.js",
+            "entryType": "resource",
+            "startTime": 41.20000000298023,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 4413,
+            "decodedBodySize": 10470
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/runtime-localization.vhNiaX9V.js",
+            "entryType": "resource",
+            "startTime": 41.29999999701977,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 3198,
+            "decodedBodySize": 8034
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/hooks.ClbWuNs9.js",
+            "entryType": "resource",
+            "startTime": 41.400000005960464,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 1153,
+            "decodedBodySize": 2677
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/favicon.svg",
+            "entryType": "resource",
+            "startTime": 42.400000005960464,
+            "duration": 1.5,
+            "initiatorType": "other",
+            "transferSize": 0,
+            "encodedBodySize": 259,
+            "decodedBodySize": 331
+          },
+          {
+            "name": "oxiquill:hydrated:features__interactive-cells__python-controls",
+            "entryType": "mark",
+            "startTime": 44.400000005960464,
+            "duration": 0
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/python-worker-DetX1Kyh.js",
+            "entryType": "resource",
+            "startTime": 54.599999994039536,
+            "duration": -11.899999991059303,
+            "initiatorType": "other",
+            "transferSize": 0,
+            "encodedBodySize": 13170,
+            "decodedBodySize": 48070
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/ui-core.BwVUYzUq.js",
+            "entryType": "resource",
+            "startTime": 65.40000000596046,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 26119,
+            "decodedBodySize": 93799
+          },
+          {
+            "name": "oxiquill:output-rendered:features__interactive-cells__python-controls",
+            "entryType": "mark",
+            "startTime": 1621.7000000029802,
+            "duration": 0
+          }
+        ]
+      },
+      "workers": [
+        {
+          "timeOrigin": 1788593004616.2,
+          "entries": [
+            {
+              "name": "oxiquill:worker-ready:python",
+              "entryType": "mark",
+              "startTime": 3.0999999940395355,
+              "duration": 0
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pyodide.mjs",
+              "entryType": "resource",
+              "startTime": 5.5999999940395355,
+              "duration": 1.2999999970197678,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 7156,
+              "decodedBodySize": 17931
+            },
+            {
+              "name": "oxiquill:initialization:python",
+              "entryType": "measure",
+              "startTime": 11.299999997019768,
+              "duration": 1305.2000000029802
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pyodide-lock.json",
+              "entryType": "resource",
+              "startTime": 11.599999994039536,
+              "duration": 1.9000000059604645,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 26534,
+              "decodedBodySize": 114440
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/python_stdlib.zip",
+              "entryType": "resource",
+              "startTime": 12,
+              "duration": 18,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 2503174,
+              "decodedBodySize": 2545564
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pyodide.asm.wasm",
+              "entryType": "resource",
+              "startTime": 12.299999997019768,
+              "duration": 89.8999999910593,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 3546129,
+              "decodedBodySize": 9598218
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pyodide.asm.mjs",
+              "entryType": "resource",
+              "startTime": 12.5,
+              "duration": 10.099999994039536,
+              "initiatorType": "script",
+              "transferSize": 0,
+              "encodedBodySize": 260107,
+              "decodedBodySize": 1250344
+            },
+            {
+              "name": "oxiquill:display-support:python",
+              "entryType": "measure",
+              "startTime": 1316.5,
+              "duration": 34.599999994039536
+            },
+            {
+              "name": "oxiquill:imports:features__interactive-cells__python-controls",
+              "entryType": "measure",
+              "startTime": 1565,
+              "duration": 0.8999999910593033
+            },
+            {
+              "name": "oxiquill:display-prepare:features__interactive-cells__python-controls",
+              "entryType": "measure",
+              "startTime": 1565.8999999910593,
+              "duration": 0.5
+            },
+            {
+              "name": "oxiquill:execution:features__interactive-cells__python-controls",
+              "entryType": "measure",
+              "startTime": 1566.5,
+              "duration": 1.199999988079071
+            },
+            {
+              "name": "oxiquill:display-collect:features__interactive-cells__python-controls",
+              "entryType": "measure",
+              "startTime": 1568,
+              "duration": 0.3999999910593033
+            }
+          ]
+        }
+      ],
+      "observed": {
+        "requests": [
+          {
+            "requestId": 2,
+            "at": 1788593004621.7
+          },
+          {
+            "requestId": 3,
+            "at": 1788593006180.7
+          }
+        ],
+        "responses": [
+          {
+            "requestId": 2,
+            "at": 1788593005974.5,
+            "ok": true
+          },
+          {
+            "requestId": 3,
+            "at": 1788593006185,
+            "ok": true
+          }
+        ]
+      }
+    },
+    {
+      "example": "features/interactive-cells/",
+      "condition": "fresh",
+      "run": 4,
+      "triggerMs": 170.90000000596046,
+      "outputMs": 1538.6000000089407,
+      "latencyMs": 1538.6000000089407,
+      "renderObserverDeltaMs": -0.099853515625,
+      "main": {
+        "timeOrigin": 1788593006249.9,
+        "entries": [
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/index.DANjJwMU.css",
+            "entryType": "resource",
+            "startTime": 5.800000011920929,
+            "duration": 3,
+            "initiatorType": "link",
+            "transferSize": 21909,
+            "encodedBodySize": 21609,
+            "decodedBodySize": 105367
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/page.B1wUxXOO.js",
+            "entryType": "resource",
+            "startTime": 6,
+            "duration": 8.400000005960464,
+            "initiatorType": "script",
+            "transferSize": 1881,
+            "encodedBodySize": 1581,
+            "decodedBodySize": 3458
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/Search.astro_astro_type_script_index_0_lang.DzL-jWp_.js",
+            "entryType": "resource",
+            "startTime": 6.100000008940697,
+            "duration": 8.599999994039536,
+            "initiatorType": "script",
+            "transferSize": 1245,
+            "encodedBodySize": 945,
+            "decodedBodySize": 1830
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/TableOfContents.astro_astro_type_script_index_0_lang.Csloo1VZ.js",
+            "entryType": "resource",
+            "startTime": 6.200000002980232,
+            "duration": 8.799999997019768,
+            "initiatorType": "script",
+            "transferSize": 356,
+            "encodedBodySize": 56,
+            "decodedBodySize": 36
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/MobileTableOfContents.astro_astro_type_script_index_0_lang.BcSo_yiZ.js",
+            "entryType": "resource",
+            "startTime": 6.200000002980232,
+            "duration": 8.700000002980232,
+            "initiatorType": "script",
+            "transferSize": 664,
+            "encodedBodySize": 364,
+            "decodedBodySize": 622
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/TwoColumnContent.astro_astro_type_script_index_0_lang.DPGAuL8N.js",
+            "entryType": "resource",
+            "startTime": 6.200000002980232,
+            "duration": 8.900000005960464,
+            "initiatorType": "script",
+            "transferSize": 569,
+            "encodedBodySize": 269,
+            "decodedBodySize": 452
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/PageFrame.astro_astro_type_script_index_0_lang.iwTubUja.js",
+            "entryType": "resource",
+            "startTime": 6.200000002980232,
+            "duration": 9.100000008940697,
+            "initiatorType": "script",
+            "transferSize": 557,
+            "encodedBodySize": 257,
+            "decodedBodySize": 392
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/print.ehPL0gv-.css",
+            "entryType": "resource",
+            "startTime": 11.200000002980232,
+            "duration": 5.299999997019768,
+            "initiatorType": "link",
+            "transferSize": 1296,
+            "encodedBodySize": 996,
+            "decodedBodySize": 3318
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/preload-helper.BnKG7j8P.js",
+            "entryType": "resource",
+            "startTime": 54,
+            "duration": 3.300000011920929,
+            "initiatorType": "script",
+            "transferSize": 1037,
+            "encodedBodySize": 737,
+            "decodedBodySize": 1351
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/starlight-toc.CTCQXEge.js",
+            "entryType": "resource",
+            "startTime": 54.20000000298023,
+            "duration": 3.5,
+            "initiatorType": "script",
+            "transferSize": 1251,
+            "encodedBodySize": 951,
+            "decodedBodySize": 1981
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/persistent-toggle.t6KkBAiq.js",
+            "entryType": "resource",
+            "startTime": 54.20000000298023,
+            "duration": 3.7000000029802322,
+            "initiatorType": "script",
+            "transferSize": 1005,
+            "encodedBodySize": 705,
+            "decodedBodySize": 2082
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/runtime-client.CDKwXtrO.js",
+            "entryType": "resource",
+            "startTime": 59.30000001192093,
+            "duration": 4.199999988079071,
+            "initiatorType": "script",
+            "transferSize": 9996,
+            "encodedBodySize": 9696,
+            "decodedBodySize": 29967
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/rolldown-runtime.hePW80VL.js",
+            "entryType": "resource",
+            "startTime": 59.5,
+            "duration": 3.800000011920929,
+            "initiatorType": "script",
+            "transferSize": 730,
+            "encodedBodySize": 430,
+            "decodedBodySize": 716
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/output-limits.BuPdYbfn.js",
+            "entryType": "resource",
+            "startTime": 59.6000000089407,
+            "duration": 3.7999999970197678,
+            "initiatorType": "script",
+            "transferSize": 884,
+            "encodedBodySize": 584,
+            "decodedBodySize": 1017
+          },
+          {
+            "name": "oxiquill:worker-start:python",
+            "entryType": "mark",
+            "startTime": 66.30000001192093,
+            "duration": 0
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/favicon.svg",
+            "entryType": "resource",
+            "startTime": 67.30000001192093,
+            "duration": 2.8999999910593033,
+            "initiatorType": "other",
+            "transferSize": 559,
+            "encodedBodySize": 259,
+            "decodedBodySize": 331
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/python-worker-DetX1Kyh.js",
+            "entryType": "resource",
+            "startTime": 81.6000000089407,
+            "duration": -10.900000005960464,
+            "initiatorType": "other",
+            "transferSize": 13470,
+            "encodedBodySize": 13170,
+            "decodedBodySize": 48070
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/ui-core.BwVUYzUq.js",
+            "entryType": "resource",
+            "startTime": 92.80000001192093,
+            "duration": 5.699999988079071,
+            "initiatorType": "script",
+            "transferSize": 26419,
+            "encodedBodySize": 26119,
+            "decodedBodySize": 93799
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/InteractiveCell.Ccnnhmwl.js",
+            "entryType": "resource",
+            "startTime": 153.90000000596046,
+            "duration": 4.0999999940395355,
+            "initiatorType": "script",
+            "transferSize": 8435,
+            "encodedBodySize": 8135,
+            "decodedBodySize": 22927
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/client.BJAMOzhD.js",
+            "entryType": "resource",
+            "startTime": 154,
+            "duration": 3.9000000059604645,
+            "initiatorType": "script",
+            "transferSize": 1114,
+            "encodedBodySize": 814,
+            "decodedBodySize": 1412
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/preact.Bl7PEaKa.js",
+            "entryType": "resource",
+            "startTime": 159.30000001192093,
+            "duration": 5.5,
+            "initiatorType": "script",
+            "transferSize": 4713,
+            "encodedBodySize": 4413,
+            "decodedBodySize": 10470
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/runtime-localization.vhNiaX9V.js",
+            "entryType": "resource",
+            "startTime": 159.70000000298023,
+            "duration": 4.799999997019768,
+            "initiatorType": "script",
+            "transferSize": 3498,
+            "encodedBodySize": 3198,
+            "decodedBodySize": 8034
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/hooks.ClbWuNs9.js",
+            "entryType": "resource",
+            "startTime": 159.70000000298023,
+            "duration": 5,
+            "initiatorType": "script",
+            "transferSize": 1453,
+            "encodedBodySize": 1153,
+            "decodedBodySize": 2677
+          },
+          {
+            "name": "oxiquill:hydrated:features__interactive-cells__python-controls",
+            "entryType": "mark",
+            "startTime": 168.90000000596046,
+            "duration": 0
+          },
+          {
+            "name": "oxiquill:output-rendered:features__interactive-cells__python-controls",
+            "entryType": "mark",
+            "startTime": 1538.6000000089407,
+            "duration": 0
+          }
+        ]
+      },
+      "workers": [
+        {
+          "timeOrigin": 1788593006329.6,
+          "entries": [
+            {
+              "name": "oxiquill:worker-ready:python",
+              "entryType": "mark",
+              "startTime": 3.5999999940395355,
+              "duration": 0
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pyodide.mjs",
+              "entryType": "resource",
+              "startTime": 4.5999999940395355,
+              "duration": 1.7000000029802322,
+              "initiatorType": "fetch",
+              "transferSize": 7456,
+              "encodedBodySize": 7156,
+              "decodedBodySize": 17931
+            },
+            {
+              "name": "oxiquill:initialization:python",
+              "entryType": "measure",
+              "startTime": 9.5,
+              "duration": 1405.5999999940395
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pyodide-lock.json",
+              "entryType": "resource",
+              "startTime": 9.799999997019768,
+              "duration": 4.700000002980232,
+              "initiatorType": "fetch",
+              "transferSize": 26834,
+              "encodedBodySize": 26534,
+              "decodedBodySize": 114440
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/python_stdlib.zip",
+              "entryType": "resource",
+              "startTime": 10.200000002980232,
+              "duration": 25.799999997019768,
+              "initiatorType": "fetch",
+              "transferSize": 2503474,
+              "encodedBodySize": 2503174,
+              "decodedBodySize": 2545564
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pyodide.asm.wasm",
+              "entryType": "resource",
+              "startTime": 10.399999991059303,
+              "duration": 102.6000000089407,
+              "initiatorType": "fetch",
+              "transferSize": 3546429,
+              "encodedBodySize": 3546129,
+              "decodedBodySize": 9598218
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pyodide.asm.mjs",
+              "entryType": "resource",
+              "startTime": 10.5,
+              "duration": 16.099999994039536,
+              "initiatorType": "script",
+              "transferSize": 260407,
+              "encodedBodySize": 260107,
+              "decodedBodySize": 1250344
+            },
+            {
+              "name": "oxiquill:display-support:python",
+              "entryType": "measure",
+              "startTime": 1415.0999999940395,
+              "duration": 35.400000005960464
+            },
+            {
+              "name": "oxiquill:imports:features__interactive-cells__python-controls",
+              "entryType": "measure",
+              "startTime": 1450.7999999970198,
+              "duration": 1.2000000029802322
+            },
+            {
+              "name": "oxiquill:display-prepare:features__interactive-cells__python-controls",
+              "entryType": "measure",
+              "startTime": 1452,
+              "duration": 0.5
+            },
+            {
+              "name": "oxiquill:execution:features__interactive-cells__python-controls",
+              "entryType": "measure",
+              "startTime": 1452.5999999940395,
+              "duration": 3.7000000029802322
+            },
+            {
+              "name": "oxiquill:display-collect:features__interactive-cells__python-controls",
+              "entryType": "measure",
+              "startTime": 1456.8999999910593,
+              "duration": 0.4000000059604645
+            }
+          ]
+        }
+      ],
+      "observed": {
+        "requests": [
+          {
+            "requestId": 2,
+            "at": 1788593006420.5
+          }
+        ],
+        "responses": [
+          {
+            "requestId": 2,
+            "at": 1788593007788.5999,
+            "ok": true
+          }
+        ]
+      }
+    },
+    {
+      "example": "features/interactive-cells/",
+      "condition": "reload",
+      "run": 4,
+      "triggerMs": 108.3999999910593,
+      "outputMs": 1429.2999999970198,
+      "latencyMs": 1429.2999999970198,
+      "renderObserverDeltaMs": -0.199951171875,
+      "main": {
+        "timeOrigin": 1788593007813,
+        "entries": [
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/index.DANjJwMU.css",
+            "entryType": "resource",
+            "startTime": 12.599999994039536,
+            "duration": 0,
+            "initiatorType": "link",
+            "transferSize": 0,
+            "encodedBodySize": 21609,
+            "decodedBodySize": 105367
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/page.B1wUxXOO.js",
+            "entryType": "resource",
+            "startTime": 12.799999997019768,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 1581,
+            "decodedBodySize": 3458
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/Search.astro_astro_type_script_index_0_lang.DzL-jWp_.js",
+            "entryType": "resource",
+            "startTime": 12.899999991059303,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 945,
+            "decodedBodySize": 1830
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/MobileTableOfContents.astro_astro_type_script_index_0_lang.BcSo_yiZ.js",
+            "entryType": "resource",
+            "startTime": 13,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 364,
+            "decodedBodySize": 622
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/TableOfContents.astro_astro_type_script_index_0_lang.Csloo1VZ.js",
+            "entryType": "resource",
+            "startTime": 13,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 56,
+            "decodedBodySize": 36
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/TwoColumnContent.astro_astro_type_script_index_0_lang.DPGAuL8N.js",
+            "entryType": "resource",
+            "startTime": 13.099999994039536,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 269,
+            "decodedBodySize": 452
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/PageFrame.astro_astro_type_script_index_0_lang.iwTubUja.js",
+            "entryType": "resource",
+            "startTime": 13.099999994039536,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 257,
+            "decodedBodySize": 392
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/print.ehPL0gv-.css",
+            "entryType": "resource",
+            "startTime": 16.299999997019768,
+            "duration": 0,
+            "initiatorType": "link",
+            "transferSize": 0,
+            "encodedBodySize": 996,
+            "decodedBodySize": 3318
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/preload-helper.BnKG7j8P.js",
+            "entryType": "resource",
+            "startTime": 21.5,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 737,
+            "decodedBodySize": 1351
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/starlight-toc.CTCQXEge.js",
+            "entryType": "resource",
+            "startTime": 22.200000002980232,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 951,
+            "decodedBodySize": 1981
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/persistent-toggle.t6KkBAiq.js",
+            "entryType": "resource",
+            "startTime": 22.399999991059303,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 705,
+            "decodedBodySize": 2082
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/runtime-client.CDKwXtrO.js",
+            "entryType": "resource",
+            "startTime": 22.799999997019768,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 9696,
+            "decodedBodySize": 29967
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/rolldown-runtime.hePW80VL.js",
+            "entryType": "resource",
+            "startTime": 22.899999991059303,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 430,
+            "decodedBodySize": 716
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/output-limits.BuPdYbfn.js",
+            "entryType": "resource",
+            "startTime": 23,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 584,
+            "decodedBodySize": 1017
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/InteractiveCell.Ccnnhmwl.js",
+            "entryType": "resource",
+            "startTime": 41.3999999910593,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 8135,
+            "decodedBodySize": 22927
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/client.BJAMOzhD.js",
+            "entryType": "resource",
+            "startTime": 41.599999994039536,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 814,
+            "decodedBodySize": 1412
+          },
+          {
+            "name": "oxiquill:worker-start:python",
+            "entryType": "mark",
+            "startTime": 43.8999999910593,
+            "duration": 0
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/preact.Bl7PEaKa.js",
+            "entryType": "resource",
+            "startTime": 44.3999999910593,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 4413,
+            "decodedBodySize": 10470
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/runtime-localization.vhNiaX9V.js",
+            "entryType": "resource",
+            "startTime": 44.70000000298023,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 3198,
+            "decodedBodySize": 8034
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/hooks.ClbWuNs9.js",
+            "entryType": "resource",
+            "startTime": 44.79999999701977,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 1153,
+            "decodedBodySize": 2677
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/favicon.svg",
+            "entryType": "resource",
+            "startTime": 45.5,
+            "duration": 2.5999999940395355,
+            "initiatorType": "other",
+            "transferSize": 0,
+            "encodedBodySize": 259,
+            "decodedBodySize": 331
+          },
+          {
+            "name": "oxiquill:hydrated:features__interactive-cells__python-controls",
+            "entryType": "mark",
+            "startTime": 56,
+            "duration": 0
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/python-worker-DetX1Kyh.js",
+            "entryType": "resource",
+            "startTime": 58.099999994039536,
+            "duration": -10.799999997019768,
+            "initiatorType": "other",
+            "transferSize": 0,
+            "encodedBodySize": 13170,
+            "decodedBodySize": 48070
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/ui-core.BwVUYzUq.js",
+            "entryType": "resource",
+            "startTime": 69.8999999910593,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 26119,
+            "decodedBodySize": 93799
+          },
+          {
+            "name": "oxiquill:output-rendered:features__interactive-cells__python-controls",
+            "entryType": "mark",
+            "startTime": 1429.2999999970198,
+            "duration": 0
+          }
+        ]
+      },
+      "workers": [
+        {
+          "timeOrigin": 1788593007869.5,
+          "entries": [
+            {
+              "name": "oxiquill:worker-ready:python",
+              "entryType": "mark",
+              "startTime": 2.8999999910593033,
+              "duration": 0
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pyodide.mjs",
+              "entryType": "resource",
+              "startTime": 5.5999999940395355,
+              "duration": 1.2000000029802322,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 7156,
+              "decodedBodySize": 17931
+            },
+            {
+              "name": "oxiquill:initialization:python",
+              "entryType": "measure",
+              "startTime": 9.799999997019768,
+              "duration": 1322.7999999970198
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pyodide-lock.json",
+              "entryType": "resource",
+              "startTime": 10.200000002980232,
+              "duration": 1.8999999910593033,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 26534,
+              "decodedBodySize": 114440
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/python_stdlib.zip",
+              "entryType": "resource",
+              "startTime": 10.599999994039536,
+              "duration": 16.100000008940697,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 2503174,
+              "decodedBodySize": 2545564
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pyodide.asm.wasm",
+              "entryType": "resource",
+              "startTime": 10.700000002980232,
+              "duration": 87.79999999701977,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 3546129,
+              "decodedBodySize": 9598218
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pyodide.asm.mjs",
+              "entryType": "resource",
+              "startTime": 11,
+              "duration": 9.200000002980232,
+              "initiatorType": "script",
+              "transferSize": 0,
+              "encodedBodySize": 260107,
+              "decodedBodySize": 1250344
+            },
+            {
+              "name": "oxiquill:display-support:python",
+              "entryType": "measure",
+              "startTime": 1332.7000000029802,
+              "duration": 33
+            },
+            {
+              "name": "oxiquill:imports:features__interactive-cells__python-controls",
+              "entryType": "measure",
+              "startTime": 1365.7999999970198,
+              "duration": 0.7999999970197678
+            },
+            {
+              "name": "oxiquill:display-prepare:features__interactive-cells__python-controls",
+              "entryType": "measure",
+              "startTime": 1366.5999999940395,
+              "duration": 0.6000000089406967
+            },
+            {
+              "name": "oxiquill:execution:features__interactive-cells__python-controls",
+              "entryType": "measure",
+              "startTime": 1367.3999999910593,
+              "duration": 3.1000000089406967
+            },
+            {
+              "name": "oxiquill:display-collect:features__interactive-cells__python-controls",
+              "entryType": "measure",
+              "startTime": 1371.2000000029802,
+              "duration": 0.3999999910593033
+            }
+          ]
+        }
+      ],
+      "observed": {
+        "requests": [
+          {
+            "requestId": 2,
+            "at": 1788593007874.3
+          }
+        ],
+        "responses": [
+          {
+            "requestId": 2,
+            "at": 1788593009242.5,
+            "ok": true
+          }
+        ]
+      }
+    },
+    {
+      "example": "features/interactive-cells/",
+      "condition": "repeat",
+      "run": 4,
+      "triggerMs": 1476.2999999970198,
+      "outputMs": 1637.7000000029802,
+      "latencyMs": 161.40000000596046,
+      "renderObserverDeltaMs": -0.10009765625,
+      "main": {
+        "timeOrigin": 1788593007813,
+        "entries": [
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/index.DANjJwMU.css",
+            "entryType": "resource",
+            "startTime": 12.599999994039536,
+            "duration": 0,
+            "initiatorType": "link",
+            "transferSize": 0,
+            "encodedBodySize": 21609,
+            "decodedBodySize": 105367
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/page.B1wUxXOO.js",
+            "entryType": "resource",
+            "startTime": 12.799999997019768,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 1581,
+            "decodedBodySize": 3458
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/Search.astro_astro_type_script_index_0_lang.DzL-jWp_.js",
+            "entryType": "resource",
+            "startTime": 12.899999991059303,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 945,
+            "decodedBodySize": 1830
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/MobileTableOfContents.astro_astro_type_script_index_0_lang.BcSo_yiZ.js",
+            "entryType": "resource",
+            "startTime": 13,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 364,
+            "decodedBodySize": 622
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/TableOfContents.astro_astro_type_script_index_0_lang.Csloo1VZ.js",
+            "entryType": "resource",
+            "startTime": 13,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 56,
+            "decodedBodySize": 36
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/TwoColumnContent.astro_astro_type_script_index_0_lang.DPGAuL8N.js",
+            "entryType": "resource",
+            "startTime": 13.099999994039536,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 269,
+            "decodedBodySize": 452
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/PageFrame.astro_astro_type_script_index_0_lang.iwTubUja.js",
+            "entryType": "resource",
+            "startTime": 13.099999994039536,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 257,
+            "decodedBodySize": 392
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/print.ehPL0gv-.css",
+            "entryType": "resource",
+            "startTime": 16.299999997019768,
+            "duration": 0,
+            "initiatorType": "link",
+            "transferSize": 0,
+            "encodedBodySize": 996,
+            "decodedBodySize": 3318
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/preload-helper.BnKG7j8P.js",
+            "entryType": "resource",
+            "startTime": 21.5,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 737,
+            "decodedBodySize": 1351
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/starlight-toc.CTCQXEge.js",
+            "entryType": "resource",
+            "startTime": 22.200000002980232,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 951,
+            "decodedBodySize": 1981
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/persistent-toggle.t6KkBAiq.js",
+            "entryType": "resource",
+            "startTime": 22.399999991059303,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 705,
+            "decodedBodySize": 2082
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/runtime-client.CDKwXtrO.js",
+            "entryType": "resource",
+            "startTime": 22.799999997019768,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 9696,
+            "decodedBodySize": 29967
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/rolldown-runtime.hePW80VL.js",
+            "entryType": "resource",
+            "startTime": 22.899999991059303,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 430,
+            "decodedBodySize": 716
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/output-limits.BuPdYbfn.js",
+            "entryType": "resource",
+            "startTime": 23,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 584,
+            "decodedBodySize": 1017
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/InteractiveCell.Ccnnhmwl.js",
+            "entryType": "resource",
+            "startTime": 41.3999999910593,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 8135,
+            "decodedBodySize": 22927
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/client.BJAMOzhD.js",
+            "entryType": "resource",
+            "startTime": 41.599999994039536,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 814,
+            "decodedBodySize": 1412
+          },
+          {
+            "name": "oxiquill:worker-start:python",
+            "entryType": "mark",
+            "startTime": 43.8999999910593,
+            "duration": 0
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/preact.Bl7PEaKa.js",
+            "entryType": "resource",
+            "startTime": 44.3999999910593,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 4413,
+            "decodedBodySize": 10470
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/runtime-localization.vhNiaX9V.js",
+            "entryType": "resource",
+            "startTime": 44.70000000298023,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 3198,
+            "decodedBodySize": 8034
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/hooks.ClbWuNs9.js",
+            "entryType": "resource",
+            "startTime": 44.79999999701977,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 1153,
+            "decodedBodySize": 2677
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/favicon.svg",
+            "entryType": "resource",
+            "startTime": 45.5,
+            "duration": 2.5999999940395355,
+            "initiatorType": "other",
+            "transferSize": 0,
+            "encodedBodySize": 259,
+            "decodedBodySize": 331
+          },
+          {
+            "name": "oxiquill:hydrated:features__interactive-cells__python-controls",
+            "entryType": "mark",
+            "startTime": 56,
+            "duration": 0
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/python-worker-DetX1Kyh.js",
+            "entryType": "resource",
+            "startTime": 58.099999994039536,
+            "duration": -10.799999997019768,
+            "initiatorType": "other",
+            "transferSize": 0,
+            "encodedBodySize": 13170,
+            "decodedBodySize": 48070
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/ui-core.BwVUYzUq.js",
+            "entryType": "resource",
+            "startTime": 69.8999999910593,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 26119,
+            "decodedBodySize": 93799
+          },
+          {
+            "name": "oxiquill:output-rendered:features__interactive-cells__python-controls",
+            "entryType": "mark",
+            "startTime": 1637.7000000029802,
+            "duration": 0
+          }
+        ]
+      },
+      "workers": [
+        {
+          "timeOrigin": 1788593007869.5,
+          "entries": [
+            {
+              "name": "oxiquill:worker-ready:python",
+              "entryType": "mark",
+              "startTime": 2.8999999910593033,
+              "duration": 0
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pyodide.mjs",
+              "entryType": "resource",
+              "startTime": 5.5999999940395355,
+              "duration": 1.2000000029802322,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 7156,
+              "decodedBodySize": 17931
+            },
+            {
+              "name": "oxiquill:initialization:python",
+              "entryType": "measure",
+              "startTime": 9.799999997019768,
+              "duration": 1322.7999999970198
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pyodide-lock.json",
+              "entryType": "resource",
+              "startTime": 10.200000002980232,
+              "duration": 1.8999999910593033,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 26534,
+              "decodedBodySize": 114440
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/python_stdlib.zip",
+              "entryType": "resource",
+              "startTime": 10.599999994039536,
+              "duration": 16.100000008940697,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 2503174,
+              "decodedBodySize": 2545564
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pyodide.asm.wasm",
+              "entryType": "resource",
+              "startTime": 10.700000002980232,
+              "duration": 87.79999999701977,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 3546129,
+              "decodedBodySize": 9598218
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pyodide.asm.mjs",
+              "entryType": "resource",
+              "startTime": 11,
+              "duration": 9.200000002980232,
+              "initiatorType": "script",
+              "transferSize": 0,
+              "encodedBodySize": 260107,
+              "decodedBodySize": 1250344
+            },
+            {
+              "name": "oxiquill:display-support:python",
+              "entryType": "measure",
+              "startTime": 1332.7000000029802,
+              "duration": 33
+            },
+            {
+              "name": "oxiquill:imports:features__interactive-cells__python-controls",
+              "entryType": "measure",
+              "startTime": 1577.7000000029802,
+              "duration": 0.5999999940395355
+            },
+            {
+              "name": "oxiquill:display-prepare:features__interactive-cells__python-controls",
+              "entryType": "measure",
+              "startTime": 1578.5,
+              "duration": 0.29999999701976776
+            },
+            {
+              "name": "oxiquill:execution:features__interactive-cells__python-controls",
+              "entryType": "measure",
+              "startTime": 1578.8999999910593,
+              "duration": 1.2000000029802322
+            },
+            {
+              "name": "oxiquill:display-collect:features__interactive-cells__python-controls",
+              "entryType": "measure",
+              "startTime": 1580.3999999910593,
+              "duration": 0.30000001192092896
+            }
+          ]
+        }
+      ],
+      "observed": {
+        "requests": [
+          {
+            "requestId": 2,
+            "at": 1788593007874.3
+          },
+          {
+            "requestId": 3,
+            "at": 1788593009446.8
+          }
+        ],
+        "responses": [
+          {
+            "requestId": 2,
+            "at": 1788593009242.5,
+            "ok": true
+          },
+          {
+            "requestId": 3,
+            "at": 1788593009450.8,
+            "ok": true
+          }
+        ]
+      }
+    },
+    {
+      "example": "features/interactive-cells/",
+      "condition": "fresh",
+      "run": 5,
+      "triggerMs": 174.5,
+      "outputMs": 1480,
+      "latencyMs": 1480,
+      "renderObserverDeltaMs": -0.199951171875,
+      "main": {
+        "timeOrigin": 1788593009512.5,
+        "entries": [
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/index.DANjJwMU.css",
+            "entryType": "resource",
+            "startTime": 5.799999997019768,
+            "duration": 2.6000000089406967,
+            "initiatorType": "link",
+            "transferSize": 21909,
+            "encodedBodySize": 21609,
+            "decodedBodySize": 105367
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/page.B1wUxXOO.js",
+            "entryType": "resource",
+            "startTime": 6.100000008940697,
+            "duration": 8,
+            "initiatorType": "script",
+            "transferSize": 1881,
+            "encodedBodySize": 1581,
+            "decodedBodySize": 3458
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/Search.astro_astro_type_script_index_0_lang.DzL-jWp_.js",
+            "entryType": "resource",
+            "startTime": 6.200000002980232,
+            "duration": 8.299999997019768,
+            "initiatorType": "script",
+            "transferSize": 1245,
+            "encodedBodySize": 945,
+            "decodedBodySize": 1830
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/MobileTableOfContents.astro_astro_type_script_index_0_lang.BcSo_yiZ.js",
+            "entryType": "resource",
+            "startTime": 6.200000002980232,
+            "duration": 8.400000005960464,
+            "initiatorType": "script",
+            "transferSize": 664,
+            "encodedBodySize": 364,
+            "decodedBodySize": 622
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/TableOfContents.astro_astro_type_script_index_0_lang.Csloo1VZ.js",
+            "entryType": "resource",
+            "startTime": 6.299999997019768,
+            "duration": 8.400000005960464,
+            "initiatorType": "script",
+            "transferSize": 356,
+            "encodedBodySize": 56,
+            "decodedBodySize": 36
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/TwoColumnContent.astro_astro_type_script_index_0_lang.DPGAuL8N.js",
+            "entryType": "resource",
+            "startTime": 6.299999997019768,
+            "duration": 8.600000008940697,
+            "initiatorType": "script",
+            "transferSize": 569,
+            "encodedBodySize": 269,
+            "decodedBodySize": 452
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/PageFrame.astro_astro_type_script_index_0_lang.iwTubUja.js",
+            "entryType": "resource",
+            "startTime": 6.299999997019768,
+            "duration": 8.800000011920929,
+            "initiatorType": "script",
+            "transferSize": 557,
+            "encodedBodySize": 257,
+            "decodedBodySize": 392
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/print.ehPL0gv-.css",
+            "entryType": "resource",
+            "startTime": 10.700000002980232,
+            "duration": 5.700000002980232,
+            "initiatorType": "link",
+            "transferSize": 1296,
+            "encodedBodySize": 996,
+            "decodedBodySize": 3318
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/preload-helper.BnKG7j8P.js",
+            "entryType": "resource",
+            "startTime": 55.20000000298023,
+            "duration": 3.2999999970197678,
+            "initiatorType": "script",
+            "transferSize": 1037,
+            "encodedBodySize": 737,
+            "decodedBodySize": 1351
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/starlight-toc.CTCQXEge.js",
+            "entryType": "resource",
+            "startTime": 55.400000005960464,
+            "duration": 3.2999999970197678,
+            "initiatorType": "script",
+            "transferSize": 1251,
+            "encodedBodySize": 951,
+            "decodedBodySize": 1981
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/persistent-toggle.t6KkBAiq.js",
+            "entryType": "resource",
+            "startTime": 55.400000005960464,
+            "duration": 3.3999999910593033,
+            "initiatorType": "script",
+            "transferSize": 1005,
+            "encodedBodySize": 705,
+            "decodedBodySize": 2082
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/runtime-client.CDKwXtrO.js",
+            "entryType": "resource",
+            "startTime": 60.70000000298023,
+            "duration": 4.299999997019768,
+            "initiatorType": "script",
+            "transferSize": 9996,
+            "encodedBodySize": 9696,
+            "decodedBodySize": 29967
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/rolldown-runtime.hePW80VL.js",
+            "entryType": "resource",
+            "startTime": 60.79999999701977,
+            "duration": 4,
+            "initiatorType": "script",
+            "transferSize": 730,
+            "encodedBodySize": 430,
+            "decodedBodySize": 716
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/output-limits.BuPdYbfn.js",
+            "entryType": "resource",
+            "startTime": 61,
+            "duration": 4,
+            "initiatorType": "script",
+            "transferSize": 884,
+            "encodedBodySize": 584,
+            "decodedBodySize": 1017
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/favicon.svg",
+            "entryType": "resource",
+            "startTime": 68.6000000089407,
+            "duration": 2.5,
+            "initiatorType": "other",
+            "transferSize": 559,
+            "encodedBodySize": 259,
+            "decodedBodySize": 331
+          },
+          {
+            "name": "oxiquill:worker-start:python",
+            "entryType": "mark",
+            "startTime": 69.1000000089407,
+            "duration": 0
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/python-worker-DetX1Kyh.js",
+            "entryType": "resource",
+            "startTime": 87.40000000596046,
+            "duration": -14.700000002980232,
+            "initiatorType": "other",
+            "transferSize": 13470,
+            "encodedBodySize": 13170,
+            "decodedBodySize": 48070
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/ui-core.BwVUYzUq.js",
+            "entryType": "resource",
+            "startTime": 95.70000000298023,
+            "duration": 2.7999999970197678,
+            "initiatorType": "script",
+            "transferSize": 26419,
+            "encodedBodySize": 26119,
+            "decodedBodySize": 93799
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/InteractiveCell.Ccnnhmwl.js",
+            "entryType": "resource",
+            "startTime": 157.5,
+            "duration": 3.4000000059604645,
+            "initiatorType": "script",
+            "transferSize": 8435,
+            "encodedBodySize": 8135,
+            "decodedBodySize": 22927
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/client.BJAMOzhD.js",
+            "entryType": "resource",
+            "startTime": 157.6000000089407,
+            "duration": 3,
+            "initiatorType": "script",
+            "transferSize": 1114,
+            "encodedBodySize": 814,
+            "decodedBodySize": 1412
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/preact.Bl7PEaKa.js",
+            "entryType": "resource",
+            "startTime": 162.29999999701977,
+            "duration": 6.100000008940697,
+            "initiatorType": "script",
+            "transferSize": 4713,
+            "encodedBodySize": 4413,
+            "decodedBodySize": 10470
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/runtime-localization.vhNiaX9V.js",
+            "entryType": "resource",
+            "startTime": 162.79999999701977,
+            "duration": 5.4000000059604645,
+            "initiatorType": "script",
+            "transferSize": 3498,
+            "encodedBodySize": 3198,
+            "decodedBodySize": 8034
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/hooks.ClbWuNs9.js",
+            "entryType": "resource",
+            "startTime": 162.90000000596046,
+            "duration": 5.5,
+            "initiatorType": "script",
+            "transferSize": 1453,
+            "encodedBodySize": 1153,
+            "decodedBodySize": 2677
+          },
+          {
+            "name": "oxiquill:hydrated:features__interactive-cells__python-controls",
+            "entryType": "mark",
+            "startTime": 172.70000000298023,
+            "duration": 0
+          },
+          {
+            "name": "oxiquill:output-rendered:features__interactive-cells__python-controls",
+            "entryType": "mark",
+            "startTime": 1480,
+            "duration": 0
+          }
+        ]
+      },
+      "workers": [
+        {
+          "timeOrigin": 1788593009598.2,
+          "entries": [
+            {
+              "name": "oxiquill:worker-ready:python",
+              "entryType": "mark",
+              "startTime": 3.2999999970197678,
+              "duration": 0
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pyodide.mjs",
+              "entryType": "resource",
+              "startTime": 5.699999988079071,
+              "duration": 1.9000000059604645,
+              "initiatorType": "fetch",
+              "transferSize": 7456,
+              "encodedBodySize": 7156,
+              "decodedBodySize": 17931
+            },
+            {
+              "name": "oxiquill:initialization:python",
+              "entryType": "measure",
+              "startTime": 11,
+              "duration": 1340.199999988079
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pyodide-lock.json",
+              "entryType": "resource",
+              "startTime": 11.299999997019768,
+              "duration": 7,
+              "initiatorType": "fetch",
+              "transferSize": 26834,
+              "encodedBodySize": 26534,
+              "decodedBodySize": 114440
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/python_stdlib.zip",
+              "entryType": "resource",
+              "startTime": 11.899999991059303,
+              "duration": 25.100000008940697,
+              "initiatorType": "fetch",
+              "transferSize": 2503474,
+              "encodedBodySize": 2503174,
+              "decodedBodySize": 2545564
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pyodide.asm.wasm",
+              "entryType": "resource",
+              "startTime": 12.099999994039536,
+              "duration": 100.5,
+              "initiatorType": "fetch",
+              "transferSize": 3546429,
+              "encodedBodySize": 3546129,
+              "decodedBodySize": 9598218
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pyodide.asm.mjs",
+              "entryType": "resource",
+              "startTime": 12.399999991059303,
+              "duration": 13.900000005960464,
+              "initiatorType": "script",
+              "transferSize": 260407,
+              "encodedBodySize": 260107,
+              "decodedBodySize": 1250344
+            },
+            {
+              "name": "oxiquill:display-support:python",
+              "entryType": "measure",
+              "startTime": 1351.2999999970198,
+              "duration": 35.79999999701977
+            },
+            {
+              "name": "oxiquill:imports:features__interactive-cells__python-controls",
+              "entryType": "measure",
+              "startTime": 1387.3999999910593,
+              "duration": 0.9000000059604645
+            },
+            {
+              "name": "oxiquill:display-prepare:features__interactive-cells__python-controls",
+              "entryType": "measure",
+              "startTime": 1388.2999999970198,
+              "duration": 0.3999999910593033
+            },
+            {
+              "name": "oxiquill:execution:features__interactive-cells__python-controls",
+              "entryType": "measure",
+              "startTime": 1389,
+              "duration": 2.8999999910593033
+            },
+            {
+              "name": "oxiquill:display-collect:features__interactive-cells__python-controls",
+              "entryType": "measure",
+              "startTime": 1392.3999999910593,
+              "duration": 0.29999999701976776
+            }
+          ]
+        }
+      ],
+      "observed": {
+        "requests": [
+          {
+            "requestId": 2,
+            "at": 1788593009686.6
+          }
+        ],
+        "responses": [
+          {
+            "requestId": 2,
+            "at": 1788593010992.7,
+            "ok": true
+          }
+        ]
+      }
+    },
+    {
+      "example": "features/interactive-cells/",
+      "condition": "reload",
+      "run": 5,
+      "triggerMs": 109.20000000298023,
+      "outputMs": 1428.7000000029802,
+      "latencyMs": 1428.7000000029802,
+      "renderObserverDeltaMs": -0.10009765625,
+      "main": {
+        "timeOrigin": 1788593011012.4,
+        "entries": [
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/index.DANjJwMU.css",
+            "entryType": "resource",
+            "startTime": 12.5,
+            "duration": 0,
+            "initiatorType": "link",
+            "transferSize": 0,
+            "encodedBodySize": 21609,
+            "decodedBodySize": 105367
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/page.B1wUxXOO.js",
+            "entryType": "resource",
+            "startTime": 12.600000008940697,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 1581,
+            "decodedBodySize": 3458
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/Search.astro_astro_type_script_index_0_lang.DzL-jWp_.js",
+            "entryType": "resource",
+            "startTime": 12.600000008940697,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 945,
+            "decodedBodySize": 1830
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/MobileTableOfContents.astro_astro_type_script_index_0_lang.BcSo_yiZ.js",
+            "entryType": "resource",
+            "startTime": 12.700000002980232,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 364,
+            "decodedBodySize": 622
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/TableOfContents.astro_astro_type_script_index_0_lang.Csloo1VZ.js",
+            "entryType": "resource",
+            "startTime": 12.800000011920929,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 56,
+            "decodedBodySize": 36
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/TwoColumnContent.astro_astro_type_script_index_0_lang.DPGAuL8N.js",
+            "entryType": "resource",
+            "startTime": 12.900000005960464,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 269,
+            "decodedBodySize": 452
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/PageFrame.astro_astro_type_script_index_0_lang.iwTubUja.js",
+            "entryType": "resource",
+            "startTime": 12.900000005960464,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 257,
+            "decodedBodySize": 392
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/print.ehPL0gv-.css",
+            "entryType": "resource",
+            "startTime": 16.5,
+            "duration": 0,
+            "initiatorType": "link",
+            "transferSize": 0,
+            "encodedBodySize": 996,
+            "decodedBodySize": 3318
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/preload-helper.BnKG7j8P.js",
+            "entryType": "resource",
+            "startTime": 22.100000008940697,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 737,
+            "decodedBodySize": 1351
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/starlight-toc.CTCQXEge.js",
+            "entryType": "resource",
+            "startTime": 22.30000001192093,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 951,
+            "decodedBodySize": 1981
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/persistent-toggle.t6KkBAiq.js",
+            "entryType": "resource",
+            "startTime": 22.400000005960464,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 705,
+            "decodedBodySize": 2082
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/runtime-client.CDKwXtrO.js",
+            "entryType": "resource",
+            "startTime": 36,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 9696,
+            "decodedBodySize": 29967
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/rolldown-runtime.hePW80VL.js",
+            "entryType": "resource",
+            "startTime": 36.1000000089407,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 430,
+            "decodedBodySize": 716
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/output-limits.BuPdYbfn.js",
+            "entryType": "resource",
+            "startTime": 36.20000000298023,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 584,
+            "decodedBodySize": 1017
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/InteractiveCell.Ccnnhmwl.js",
+            "entryType": "resource",
+            "startTime": 39.1000000089407,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 8135,
+            "decodedBodySize": 22927
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/client.BJAMOzhD.js",
+            "entryType": "resource",
+            "startTime": 39.20000000298023,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 814,
+            "decodedBodySize": 1412
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/preact.Bl7PEaKa.js",
+            "entryType": "resource",
+            "startTime": 41.30000001192093,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 4413,
+            "decodedBodySize": 10470
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/runtime-localization.vhNiaX9V.js",
+            "entryType": "resource",
+            "startTime": 41.400000005960464,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 3198,
+            "decodedBodySize": 8034
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/hooks.ClbWuNs9.js",
+            "entryType": "resource",
+            "startTime": 41.5,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 1153,
+            "decodedBodySize": 2677
+          },
+          {
+            "name": "oxiquill:worker-start:python",
+            "entryType": "mark",
+            "startTime": 41.80000001192093,
+            "duration": 0
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/favicon.svg",
+            "entryType": "resource",
+            "startTime": 42.20000000298023,
+            "duration": 1.2000000029802322,
+            "initiatorType": "other",
+            "transferSize": 0,
+            "encodedBodySize": 259,
+            "decodedBodySize": 331
+          },
+          {
+            "name": "oxiquill:hydrated:features__interactive-cells__python-controls",
+            "entryType": "mark",
+            "startTime": 43.80000001192093,
+            "duration": 0
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/python-worker-DetX1Kyh.js",
+            "entryType": "resource",
+            "startTime": 54.6000000089407,
+            "duration": -9.200000002980232,
+            "initiatorType": "other",
+            "transferSize": 0,
+            "encodedBodySize": 13170,
+            "decodedBodySize": 48070
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/ui-core.BwVUYzUq.js",
+            "entryType": "resource",
+            "startTime": 65.6000000089407,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 26119,
+            "decodedBodySize": 93799
+          },
+          {
+            "name": "oxiquill:output-rendered:features__interactive-cells__python-controls",
+            "entryType": "mark",
+            "startTime": 1428.7000000029802,
+            "duration": 0
+          }
+        ]
+      },
+      "workers": [
+        {
+          "timeOrigin": 1788593011065.4,
+          "entries": [
+            {
+              "name": "oxiquill:worker-ready:python",
+              "entryType": "mark",
+              "startTime": 3,
+              "duration": 0
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pyodide.mjs",
+              "entryType": "resource",
+              "startTime": 5.100000008940697,
+              "duration": 1.2000000029802322,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 7156,
+              "decodedBodySize": 17931
+            },
+            {
+              "name": "oxiquill:initialization:python",
+              "entryType": "measure",
+              "startTime": 9.400000005960464,
+              "duration": 1323.7999999970198
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pyodide-lock.json",
+              "entryType": "resource",
+              "startTime": 9.600000008940697,
+              "duration": 1.5999999940395355,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 26534,
+              "decodedBodySize": 114440
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/python_stdlib.zip",
+              "entryType": "resource",
+              "startTime": 10.100000008940697,
+              "duration": 17.099999994039536,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 2503174,
+              "decodedBodySize": 2545564
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pyodide.asm.wasm",
+              "entryType": "resource",
+              "startTime": 10.300000011920929,
+              "duration": 90.29999999701977,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 3546129,
+              "decodedBodySize": 9598218
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pyodide.asm.mjs",
+              "entryType": "resource",
+              "startTime": 10.400000005960464,
+              "duration": 10.099999994039536,
+              "initiatorType": "script",
+              "transferSize": 0,
+              "encodedBodySize": 260107,
+              "decodedBodySize": 1250344
+            },
+            {
+              "name": "oxiquill:display-support:python",
+              "entryType": "measure",
+              "startTime": 1333.300000011921,
+              "duration": 33
+            },
+            {
+              "name": "oxiquill:imports:features__interactive-cells__python-controls",
+              "entryType": "measure",
+              "startTime": 1366.5,
+              "duration": 1
+            },
+            {
+              "name": "oxiquill:display-prepare:features__interactive-cells__python-controls",
+              "entryType": "measure",
+              "startTime": 1367.5,
+              "duration": 0.5
+            },
+            {
+              "name": "oxiquill:execution:features__interactive-cells__python-controls",
+              "entryType": "measure",
+              "startTime": 1368.2000000029802,
+              "duration": 5.4000000059604645
+            },
+            {
+              "name": "oxiquill:display-collect:features__interactive-cells__python-controls",
+              "entryType": "measure",
+              "startTime": 1374.2000000029802,
+              "duration": 0.29999999701976776
+            }
+          ]
+        }
+      ],
+      "observed": {
+        "requests": [
+          {
+            "requestId": 2,
+            "at": 1788593011069.5999
+          }
+        ],
+        "responses": [
+          {
+            "requestId": 2,
+            "at": 1788593012441.2,
+            "ok": true
+          }
+        ]
+      }
+    },
+    {
+      "example": "features/interactive-cells/",
+      "condition": "repeat",
+      "run": 5,
+      "triggerMs": 1475.9000000059605,
+      "outputMs": 1636.7000000029802,
+      "latencyMs": 160.79999999701977,
+      "renderObserverDeltaMs": -0.199951171875,
+      "main": {
+        "timeOrigin": 1788593011012.4,
+        "entries": [
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/index.DANjJwMU.css",
+            "entryType": "resource",
+            "startTime": 12.5,
+            "duration": 0,
+            "initiatorType": "link",
+            "transferSize": 0,
+            "encodedBodySize": 21609,
+            "decodedBodySize": 105367
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/page.B1wUxXOO.js",
+            "entryType": "resource",
+            "startTime": 12.600000008940697,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 1581,
+            "decodedBodySize": 3458
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/Search.astro_astro_type_script_index_0_lang.DzL-jWp_.js",
+            "entryType": "resource",
+            "startTime": 12.600000008940697,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 945,
+            "decodedBodySize": 1830
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/MobileTableOfContents.astro_astro_type_script_index_0_lang.BcSo_yiZ.js",
+            "entryType": "resource",
+            "startTime": 12.700000002980232,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 364,
+            "decodedBodySize": 622
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/TableOfContents.astro_astro_type_script_index_0_lang.Csloo1VZ.js",
+            "entryType": "resource",
+            "startTime": 12.800000011920929,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 56,
+            "decodedBodySize": 36
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/TwoColumnContent.astro_astro_type_script_index_0_lang.DPGAuL8N.js",
+            "entryType": "resource",
+            "startTime": 12.900000005960464,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 269,
+            "decodedBodySize": 452
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/PageFrame.astro_astro_type_script_index_0_lang.iwTubUja.js",
+            "entryType": "resource",
+            "startTime": 12.900000005960464,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 257,
+            "decodedBodySize": 392
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/print.ehPL0gv-.css",
+            "entryType": "resource",
+            "startTime": 16.5,
+            "duration": 0,
+            "initiatorType": "link",
+            "transferSize": 0,
+            "encodedBodySize": 996,
+            "decodedBodySize": 3318
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/preload-helper.BnKG7j8P.js",
+            "entryType": "resource",
+            "startTime": 22.100000008940697,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 737,
+            "decodedBodySize": 1351
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/starlight-toc.CTCQXEge.js",
+            "entryType": "resource",
+            "startTime": 22.30000001192093,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 951,
+            "decodedBodySize": 1981
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/persistent-toggle.t6KkBAiq.js",
+            "entryType": "resource",
+            "startTime": 22.400000005960464,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 705,
+            "decodedBodySize": 2082
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/runtime-client.CDKwXtrO.js",
+            "entryType": "resource",
+            "startTime": 36,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 9696,
+            "decodedBodySize": 29967
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/rolldown-runtime.hePW80VL.js",
+            "entryType": "resource",
+            "startTime": 36.1000000089407,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 430,
+            "decodedBodySize": 716
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/output-limits.BuPdYbfn.js",
+            "entryType": "resource",
+            "startTime": 36.20000000298023,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 584,
+            "decodedBodySize": 1017
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/InteractiveCell.Ccnnhmwl.js",
+            "entryType": "resource",
+            "startTime": 39.1000000089407,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 8135,
+            "decodedBodySize": 22927
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/client.BJAMOzhD.js",
+            "entryType": "resource",
+            "startTime": 39.20000000298023,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 814,
+            "decodedBodySize": 1412
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/preact.Bl7PEaKa.js",
+            "entryType": "resource",
+            "startTime": 41.30000001192093,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 4413,
+            "decodedBodySize": 10470
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/runtime-localization.vhNiaX9V.js",
+            "entryType": "resource",
+            "startTime": 41.400000005960464,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 3198,
+            "decodedBodySize": 8034
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/hooks.ClbWuNs9.js",
+            "entryType": "resource",
+            "startTime": 41.5,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 1153,
+            "decodedBodySize": 2677
+          },
+          {
+            "name": "oxiquill:worker-start:python",
+            "entryType": "mark",
+            "startTime": 41.80000001192093,
+            "duration": 0
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/favicon.svg",
+            "entryType": "resource",
+            "startTime": 42.20000000298023,
+            "duration": 1.2000000029802322,
+            "initiatorType": "other",
+            "transferSize": 0,
+            "encodedBodySize": 259,
+            "decodedBodySize": 331
+          },
+          {
+            "name": "oxiquill:hydrated:features__interactive-cells__python-controls",
+            "entryType": "mark",
+            "startTime": 43.80000001192093,
+            "duration": 0
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/python-worker-DetX1Kyh.js",
+            "entryType": "resource",
+            "startTime": 54.6000000089407,
+            "duration": -9.200000002980232,
+            "initiatorType": "other",
+            "transferSize": 0,
+            "encodedBodySize": 13170,
+            "decodedBodySize": 48070
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/ui-core.BwVUYzUq.js",
+            "entryType": "resource",
+            "startTime": 65.6000000089407,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 26119,
+            "decodedBodySize": 93799
+          },
+          {
+            "name": "oxiquill:output-rendered:features__interactive-cells__python-controls",
+            "entryType": "mark",
+            "startTime": 1636.7000000029802,
+            "duration": 0
+          }
+        ]
+      },
+      "workers": [
+        {
+          "timeOrigin": 1788593011065.4,
+          "entries": [
+            {
+              "name": "oxiquill:worker-ready:python",
+              "entryType": "mark",
+              "startTime": 3,
+              "duration": 0
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pyodide.mjs",
+              "entryType": "resource",
+              "startTime": 5.100000008940697,
+              "duration": 1.2000000029802322,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 7156,
+              "decodedBodySize": 17931
+            },
+            {
+              "name": "oxiquill:initialization:python",
+              "entryType": "measure",
+              "startTime": 9.400000005960464,
+              "duration": 1323.7999999970198
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pyodide-lock.json",
+              "entryType": "resource",
+              "startTime": 9.600000008940697,
+              "duration": 1.5999999940395355,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 26534,
+              "decodedBodySize": 114440
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/python_stdlib.zip",
+              "entryType": "resource",
+              "startTime": 10.100000008940697,
+              "duration": 17.099999994039536,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 2503174,
+              "decodedBodySize": 2545564
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pyodide.asm.wasm",
+              "entryType": "resource",
+              "startTime": 10.300000011920929,
+              "duration": 90.29999999701977,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 3546129,
+              "decodedBodySize": 9598218
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pyodide.asm.mjs",
+              "entryType": "resource",
+              "startTime": 10.400000005960464,
+              "duration": 10.099999994039536,
+              "initiatorType": "script",
+              "transferSize": 0,
+              "encodedBodySize": 260107,
+              "decodedBodySize": 1250344
+            },
+            {
+              "name": "oxiquill:display-support:python",
+              "entryType": "measure",
+              "startTime": 1333.300000011921,
+              "duration": 33
+            },
+            {
+              "name": "oxiquill:imports:features__interactive-cells__python-controls",
+              "entryType": "measure",
+              "startTime": 1580,
+              "duration": 0.7000000029802322
+            },
+            {
+              "name": "oxiquill:display-prepare:features__interactive-cells__python-controls",
+              "entryType": "measure",
+              "startTime": 1580.7000000029802,
+              "duration": 0.4000000059604645
+            },
+            {
+              "name": "oxiquill:execution:features__interactive-cells__python-controls",
+              "entryType": "measure",
+              "startTime": 1581.2000000029802,
+              "duration": 1.2999999970197678
+            },
+            {
+              "name": "oxiquill:display-collect:features__interactive-cells__python-controls",
+              "entryType": "measure",
+              "startTime": 1582.9000000059605,
+              "duration": 0.29999999701976776
+            }
+          ]
+        }
+      ],
+      "observed": {
+        "requests": [
+          {
+            "requestId": 2,
+            "at": 1788593011069.5999
+          },
+          {
+            "requestId": 3,
+            "at": 1788593012645
+          }
+        ],
+        "responses": [
+          {
+            "requestId": 2,
+            "at": 1788593012441.2,
+            "ok": true
+          },
+          {
+            "requestId": 3,
+            "at": 1788593012649.2998,
+            "ok": true
+          }
+        ]
+      }
+    },
+    {
+      "example": "features/rich-output/",
+      "condition": "fresh",
+      "run": 1,
+      "triggerMs": 177.29999999701977,
+      "outputMs": 5801.70000000298,
+      "latencyMs": 5801.70000000298,
+      "renderObserverDeltaMs": -3.199951171875,
+      "main": {
+        "timeOrigin": 1788593012709.8,
+        "entries": [
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/index.DANjJwMU.css",
+            "entryType": "resource",
+            "startTime": 7.9000000059604645,
+            "duration": 2.8999999910593033,
+            "initiatorType": "link",
+            "transferSize": 21909,
+            "encodedBodySize": 21609,
+            "decodedBodySize": 105367
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/ec.w36nc.css",
+            "entryType": "resource",
+            "startTime": 8.200000002980232,
+            "duration": 9.299999997019768,
+            "initiatorType": "link",
+            "transferSize": 4246,
+            "encodedBodySize": 3946,
+            "decodedBodySize": 18292
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/page.B1wUxXOO.js",
+            "entryType": "resource",
+            "startTime": 8.200000002980232,
+            "duration": 9.5,
+            "initiatorType": "script",
+            "transferSize": 1881,
+            "encodedBodySize": 1581,
+            "decodedBodySize": 3458
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/MobileTableOfContents.astro_astro_type_script_index_0_lang.BcSo_yiZ.js",
+            "entryType": "resource",
+            "startTime": 8.200000002980232,
+            "duration": 9.599999994039536,
+            "initiatorType": "script",
+            "transferSize": 664,
+            "encodedBodySize": 364,
+            "decodedBodySize": 622
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/Search.astro_astro_type_script_index_0_lang.DzL-jWp_.js",
+            "entryType": "resource",
+            "startTime": 8.200000002980232,
+            "duration": 9.5,
+            "initiatorType": "script",
+            "transferSize": 1245,
+            "encodedBodySize": 945,
+            "decodedBodySize": 1830
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/TableOfContents.astro_astro_type_script_index_0_lang.Csloo1VZ.js",
+            "entryType": "resource",
+            "startTime": 8.200000002980232,
+            "duration": 9.799999997019768,
+            "initiatorType": "script",
+            "transferSize": 356,
+            "encodedBodySize": 56,
+            "decodedBodySize": 36
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/ec.0vx5m.js",
+            "entryType": "resource",
+            "startTime": 8.299999997019768,
+            "duration": 9.799999997019768,
+            "initiatorType": "script",
+            "transferSize": 1468,
+            "encodedBodySize": 1168,
+            "decodedBodySize": 2523
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/TwoColumnContent.astro_astro_type_script_index_0_lang.DPGAuL8N.js",
+            "entryType": "resource",
+            "startTime": 8.299999997019768,
+            "duration": 13.400000005960464,
+            "initiatorType": "script",
+            "transferSize": 569,
+            "encodedBodySize": 269,
+            "decodedBodySize": 452
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/PageFrame.astro_astro_type_script_index_0_lang.iwTubUja.js",
+            "entryType": "resource",
+            "startTime": 8.299999997019768,
+            "duration": 13.600000008940697,
+            "initiatorType": "script",
+            "transferSize": 557,
+            "encodedBodySize": 257,
+            "decodedBodySize": 392
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/print.ehPL0gv-.css",
+            "entryType": "resource",
+            "startTime": 12.099999994039536,
+            "duration": 9.900000005960464,
+            "initiatorType": "link",
+            "transferSize": 1296,
+            "encodedBodySize": 996,
+            "decodedBodySize": 3318
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/starlight-toc.CTCQXEge.js",
+            "entryType": "resource",
+            "startTime": 60.599999994039536,
+            "duration": 3.6000000089406967,
+            "initiatorType": "script",
+            "transferSize": 1251,
+            "encodedBodySize": 951,
+            "decodedBodySize": 1981
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/preload-helper.BnKG7j8P.js",
+            "entryType": "resource",
+            "startTime": 60.599999994039536,
+            "duration": 3.4000000059604645,
+            "initiatorType": "script",
+            "transferSize": 1037,
+            "encodedBodySize": 737,
+            "decodedBodySize": 1351
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/persistent-toggle.t6KkBAiq.js",
+            "entryType": "resource",
+            "startTime": 60.70000000298023,
+            "duration": 3.7000000029802322,
+            "initiatorType": "script",
+            "transferSize": 1005,
+            "encodedBodySize": 705,
+            "decodedBodySize": 2082
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/runtime-client.CDKwXtrO.js",
+            "entryType": "resource",
+            "startTime": 66,
+            "duration": 4.0999999940395355,
+            "initiatorType": "script",
+            "transferSize": 9996,
+            "encodedBodySize": 9696,
+            "decodedBodySize": 29967
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/rolldown-runtime.hePW80VL.js",
+            "entryType": "resource",
+            "startTime": 66.29999999701977,
+            "duration": 3.5,
+            "initiatorType": "script",
+            "transferSize": 730,
+            "encodedBodySize": 430,
+            "decodedBodySize": 716
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/output-limits.BuPdYbfn.js",
+            "entryType": "resource",
+            "startTime": 66.40000000596046,
+            "duration": 3.699999988079071,
+            "initiatorType": "script",
+            "transferSize": 884,
+            "encodedBodySize": 584,
+            "decodedBodySize": 1017
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/favicon.svg",
+            "entryType": "resource",
+            "startTime": 73.20000000298023,
+            "duration": 2.2000000029802322,
+            "initiatorType": "other",
+            "transferSize": 559,
+            "encodedBodySize": 259,
+            "decodedBodySize": 331
+          },
+          {
+            "name": "oxiquill:worker-start:python",
+            "entryType": "mark",
+            "startTime": 73.70000000298023,
+            "duration": 0
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/python-worker-DetX1Kyh.js",
+            "entryType": "resource",
+            "startTime": 84.70000000298023,
+            "duration": -7.700000002980232,
+            "initiatorType": "other",
+            "transferSize": 13470,
+            "encodedBodySize": 13170,
+            "decodedBodySize": 48070
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/ui-core.BwVUYzUq.js",
+            "entryType": "resource",
+            "startTime": 110.40000000596046,
+            "duration": 3.699999988079071,
+            "initiatorType": "script",
+            "transferSize": 26419,
+            "encodedBodySize": 26119,
+            "decodedBodySize": 93799
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/InteractiveCell.Ccnnhmwl.js",
+            "entryType": "resource",
+            "startTime": 160.40000000596046,
+            "duration": 3.2999999970197678,
+            "initiatorType": "script",
+            "transferSize": 8435,
+            "encodedBodySize": 8135,
+            "decodedBodySize": 22927
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/client.BJAMOzhD.js",
+            "entryType": "resource",
+            "startTime": 160.59999999403954,
+            "duration": 2.9000000059604645,
+            "initiatorType": "script",
+            "transferSize": 1114,
+            "encodedBodySize": 814,
+            "decodedBodySize": 1412
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/preact.Bl7PEaKa.js",
+            "entryType": "resource",
+            "startTime": 164.5,
+            "duration": 4.799999997019768,
+            "initiatorType": "script",
+            "transferSize": 4713,
+            "encodedBodySize": 4413,
+            "decodedBodySize": 10470
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/runtime-localization.vhNiaX9V.js",
+            "entryType": "resource",
+            "startTime": 164.59999999403954,
+            "duration": 4.4000000059604645,
+            "initiatorType": "script",
+            "transferSize": 3498,
+            "encodedBodySize": 3198,
+            "decodedBodySize": 8034
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/hooks.ClbWuNs9.js",
+            "entryType": "resource",
+            "startTime": 164.70000000298023,
+            "duration": 4.5,
+            "initiatorType": "script",
+            "transferSize": 1453,
+            "encodedBodySize": 1153,
+            "decodedBodySize": 2677
+          },
+          {
+            "name": "oxiquill:hydrated:features__rich-output__python-rich-outputs",
+            "entryType": "mark",
+            "startTime": 172.59999999403954,
+            "duration": 0
+          },
+          {
+            "name": "oxiquill:output-rendered:features__rich-output__python-rich-outputs",
+            "entryType": "mark",
+            "startTime": 5801.70000000298,
+            "duration": 0
+          }
+        ]
+      },
+      "workers": [
+        {
+          "timeOrigin": 1788593012792.8,
+          "entries": [
+            {
+              "name": "oxiquill:worker-ready:python",
+              "entryType": "mark",
+              "startTime": 3.2000000029802322,
+              "duration": 0
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pyodide.mjs",
+              "entryType": "resource",
+              "startTime": 4.4000000059604645,
+              "duration": 1.8999999910593033,
+              "initiatorType": "fetch",
+              "transferSize": 7456,
+              "encodedBodySize": 7156,
+              "decodedBodySize": 17931
+            },
+            {
+              "name": "oxiquill:initialization:python",
+              "entryType": "measure",
+              "startTime": 9.299999997019768,
+              "duration": 2288
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pyodide-lock.json",
+              "entryType": "resource",
+              "startTime": 9.599999994039536,
+              "duration": 6.5,
+              "initiatorType": "fetch",
+              "transferSize": 26834,
+              "encodedBodySize": 26534,
+              "decodedBodySize": 114440
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/python_stdlib.zip",
+              "entryType": "resource",
+              "startTime": 10,
+              "duration": 27.400000005960464,
+              "initiatorType": "fetch",
+              "transferSize": 2503474,
+              "encodedBodySize": 2503174,
+              "decodedBodySize": 2545564
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pyodide.asm.wasm",
+              "entryType": "resource",
+              "startTime": 10.200000002980232,
+              "duration": 111.09999999403954,
+              "initiatorType": "fetch",
+              "transferSize": 3546429,
+              "encodedBodySize": 3546129,
+              "decodedBodySize": 9598218
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pyodide.asm.mjs",
+              "entryType": "resource",
+              "startTime": 10.400000005960464,
+              "duration": 14.299999997019768,
+              "initiatorType": "script",
+              "transferSize": 260407,
+              "encodedBodySize": 260107,
+              "decodedBodySize": 1250344
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/matplotlib-3.10.8-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 91.59999999403954,
+              "duration": 1708.6000000089407,
+              "initiatorType": "fetch",
+              "transferSize": 6867585,
+              "encodedBodySize": 6867285,
+              "decodedBodySize": 6982033
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/contourpy-1.3.3-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 91.79999999701977,
+              "duration": 9.900000005960464,
+              "initiatorType": "fetch",
+              "transferSize": 117420,
+              "encodedBodySize": 117120,
+              "decodedBodySize": 118875
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/numpy-2.4.6-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 92,
+              "duration": 1399.2000000029802,
+              "initiatorType": "fetch",
+              "transferSize": 2882982,
+              "encodedBodySize": 2882682,
+              "decodedBodySize": 2918760
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/cycler-0.12.1-py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 92.09999999403954,
+              "duration": 8.600000008940697,
+              "initiatorType": "fetch",
+              "transferSize": 8094,
+              "encodedBodySize": 7794,
+              "decodedBodySize": 8321
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/six-1.17.0-py2.py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 92.20000000298023,
+              "duration": 8.599999994039536,
+              "initiatorType": "fetch",
+              "transferSize": 10940,
+              "encodedBodySize": 10640,
+              "decodedBodySize": 11050
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/fonttools-4.62.1-py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 92.40000000596046,
+              "duration": 120,
+              "initiatorType": "fetch",
+              "transferSize": 1124839,
+              "encodedBodySize": 1124539,
+              "decodedBodySize": 1152647
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/kiwisolver-1.5.0-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 92.5,
+              "duration": 67.59999999403954,
+              "initiatorType": "fetch",
+              "transferSize": 36187,
+              "encodedBodySize": 35887,
+              "decodedBodySize": 36616
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/packaging-26.1-py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 92.59999999403954,
+              "duration": 70.80000001192093,
+              "initiatorType": "fetch",
+              "transferSize": 94497,
+              "encodedBodySize": 94197,
+              "decodedBodySize": 95852
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pillow-12.2.0-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 92.79999999701977,
+              "duration": 95.40000000596046,
+              "initiatorType": "fetch",
+              "transferSize": 1029476,
+              "encodedBodySize": 1029176,
+              "decodedBodySize": 1037807
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pyparsing-3.3.2-py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 92.79999999701977,
+              "duration": 122.70000000298023,
+              "initiatorType": "fetch",
+              "transferSize": 121460,
+              "encodedBodySize": 121160,
+              "decodedBodySize": 122781
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/python_dateutil-2.9.0.post0-py2.py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 93.70000000298023,
+              "duration": 266.8999999910593,
+              "initiatorType": "fetch",
+              "transferSize": 228538,
+              "encodedBodySize": 228238,
+              "decodedBodySize": 229892
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pytz-2026.1.post1-py2.py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 93.79999999701977,
+              "duration": 278.5,
+              "initiatorType": "fetch",
+              "transferSize": 377948,
+              "encodedBodySize": 377648,
+              "decodedBodySize": 510489
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pandas-3.0.2-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 94,
+              "duration": 1417.7000000029802,
+              "initiatorType": "fetch",
+              "transferSize": 4141966,
+              "encodedBodySize": 4141666,
+              "decodedBodySize": 4177814
+            },
+            {
+              "name": "oxiquill:display-support:python",
+              "entryType": "measure",
+              "startTime": 2297.4000000059605,
+              "duration": 21.69999998807907
+            },
+            {
+              "name": "oxiquill:imports:features__rich-output__python-rich-outputs",
+              "entryType": "measure",
+              "startTime": 2319.2999999970198,
+              "duration": 1.7000000029802322
+            },
+            {
+              "name": "oxiquill:display-prepare:features__rich-output__python-rich-outputs",
+              "entryType": "measure",
+              "startTime": 2321,
+              "duration": 0.5
+            },
+            {
+              "name": "oxiquill:execution:features__rich-output__python-rich-outputs",
+              "entryType": "measure",
+              "startTime": 2321.7000000029802,
+              "duration": 3266.8999999910593
+            },
+            {
+              "name": "oxiquill:display-collect:features__rich-output__python-rich-outputs",
+              "entryType": "measure",
+              "startTime": 5589.5,
+              "duration": 114.59999999403954
+            }
+          ]
+        }
+      ],
+      "observed": {
+        "requests": [
+          {
+            "requestId": 2,
+            "at": 1788593013158.5
+          }
+        ],
+        "responses": [
+          {
+            "requestId": 2,
+            "at": 1788593018514.7,
+            "ok": true
+          }
+        ]
+      }
+    },
+    {
+      "example": "features/rich-output/",
+      "condition": "reload",
+      "run": 1,
+      "triggerMs": 124.09999999403954,
+      "outputMs": 5569.5999999940395,
+      "latencyMs": 5569.5999999940395,
+      "renderObserverDeltaMs": -2.7998046875,
+      "main": {
+        "timeOrigin": 1788593018530.6,
+        "entries": [
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/index.DANjJwMU.css",
+            "entryType": "resource",
+            "startTime": 14.799999997019768,
+            "duration": 0,
+            "initiatorType": "link",
+            "transferSize": 0,
+            "encodedBodySize": 21609,
+            "decodedBodySize": 105367
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/page.B1wUxXOO.js",
+            "entryType": "resource",
+            "startTime": 14.899999991059303,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 1581,
+            "decodedBodySize": 3458
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/Search.astro_astro_type_script_index_0_lang.DzL-jWp_.js",
+            "entryType": "resource",
+            "startTime": 15,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 945,
+            "decodedBodySize": 1830
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/MobileTableOfContents.astro_astro_type_script_index_0_lang.BcSo_yiZ.js",
+            "entryType": "resource",
+            "startTime": 15,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 364,
+            "decodedBodySize": 622
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/TableOfContents.astro_astro_type_script_index_0_lang.Csloo1VZ.js",
+            "entryType": "resource",
+            "startTime": 15.099999994039536,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 56,
+            "decodedBodySize": 36
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/ec.w36nc.css",
+            "entryType": "resource",
+            "startTime": 15.099999994039536,
+            "duration": 0,
+            "initiatorType": "link",
+            "transferSize": 0,
+            "encodedBodySize": 3946,
+            "decodedBodySize": 18292
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/ec.0vx5m.js",
+            "entryType": "resource",
+            "startTime": 15.199999988079071,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 1168,
+            "decodedBodySize": 2523
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/TwoColumnContent.astro_astro_type_script_index_0_lang.DPGAuL8N.js",
+            "entryType": "resource",
+            "startTime": 15.299999997019768,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 269,
+            "decodedBodySize": 452
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/PageFrame.astro_astro_type_script_index_0_lang.iwTubUja.js",
+            "entryType": "resource",
+            "startTime": 15.399999991059303,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 257,
+            "decodedBodySize": 392
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/print.ehPL0gv-.css",
+            "entryType": "resource",
+            "startTime": 19,
+            "duration": 0,
+            "initiatorType": "link",
+            "transferSize": 0,
+            "encodedBodySize": 996,
+            "decodedBodySize": 3318
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/preload-helper.BnKG7j8P.js",
+            "entryType": "resource",
+            "startTime": 24.5,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 737,
+            "decodedBodySize": 1351
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/starlight-toc.CTCQXEge.js",
+            "entryType": "resource",
+            "startTime": 24.69999998807907,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 951,
+            "decodedBodySize": 1981
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/persistent-toggle.t6KkBAiq.js",
+            "entryType": "resource",
+            "startTime": 24.799999997019768,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 705,
+            "decodedBodySize": 2082
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/runtime-client.CDKwXtrO.js",
+            "entryType": "resource",
+            "startTime": 50.099999994039536,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 9696,
+            "decodedBodySize": 29967
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/rolldown-runtime.hePW80VL.js",
+            "entryType": "resource",
+            "startTime": 50.19999998807907,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 430,
+            "decodedBodySize": 716
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/output-limits.BuPdYbfn.js",
+            "entryType": "resource",
+            "startTime": 50.29999999701977,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 584,
+            "decodedBodySize": 1017
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/InteractiveCell.Ccnnhmwl.js",
+            "entryType": "resource",
+            "startTime": 54.29999999701977,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 8135,
+            "decodedBodySize": 22927
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/client.BJAMOzhD.js",
+            "entryType": "resource",
+            "startTime": 54.3999999910593,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 814,
+            "decodedBodySize": 1412
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/preact.Bl7PEaKa.js",
+            "entryType": "resource",
+            "startTime": 56.8999999910593,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 4413,
+            "decodedBodySize": 10470
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/runtime-localization.vhNiaX9V.js",
+            "entryType": "resource",
+            "startTime": 57,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 3198,
+            "decodedBodySize": 8034
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/hooks.ClbWuNs9.js",
+            "entryType": "resource",
+            "startTime": 57,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 1153,
+            "decodedBodySize": 2677
+          },
+          {
+            "name": "oxiquill:worker-start:python",
+            "entryType": "mark",
+            "startTime": 57.3999999910593,
+            "duration": 0
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/favicon.svg",
+            "entryType": "resource",
+            "startTime": 57.79999999701977,
+            "duration": 1.8999999910593033,
+            "initiatorType": "other",
+            "transferSize": 0,
+            "encodedBodySize": 259,
+            "decodedBodySize": 331
+          },
+          {
+            "name": "oxiquill:hydrated:features__rich-output__python-rich-outputs",
+            "entryType": "mark",
+            "startTime": 66.59999999403954,
+            "duration": 0
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/python-worker-DetX1Kyh.js",
+            "entryType": "resource",
+            "startTime": 70.29999999701977,
+            "duration": -9.600000008940697,
+            "initiatorType": "other",
+            "transferSize": 0,
+            "encodedBodySize": 13170,
+            "decodedBodySize": 48070
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/ui-core.BwVUYzUq.js",
+            "entryType": "resource",
+            "startTime": 83.59999999403954,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 26119,
+            "decodedBodySize": 93799
+          },
+          {
+            "name": "oxiquill:output-rendered:features__rich-output__python-rich-outputs",
+            "entryType": "mark",
+            "startTime": 5569.5999999940395,
+            "duration": 0
+          }
+        ]
+      },
+      "workers": [
+        {
+          "timeOrigin": 1788593018599.3,
+          "entries": [
+            {
+              "name": "oxiquill:worker-ready:python",
+              "entryType": "mark",
+              "startTime": 3.0999999940395355,
+              "duration": 0
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pyodide.mjs",
+              "entryType": "resource",
+              "startTime": 5.200000002980232,
+              "duration": 1.2999999970197678,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 7156,
+              "decodedBodySize": 17931
+            },
+            {
+              "name": "oxiquill:initialization:python",
+              "entryType": "measure",
+              "startTime": 9.700000002980232,
+              "duration": 2170.8999999910593
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pyodide-lock.json",
+              "entryType": "resource",
+              "startTime": 10,
+              "duration": 2,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 26534,
+              "decodedBodySize": 114440
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/python_stdlib.zip",
+              "entryType": "resource",
+              "startTime": 10.599999994039536,
+              "duration": 16.30000001192093,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 2503174,
+              "decodedBodySize": 2545564
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pyodide.asm.wasm",
+              "entryType": "resource",
+              "startTime": 10.799999997019768,
+              "duration": 146.5,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 3546129,
+              "decodedBodySize": 9598218
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pyodide.asm.mjs",
+              "entryType": "resource",
+              "startTime": 11,
+              "duration": 9.400000005960464,
+              "initiatorType": "script",
+              "transferSize": 0,
+              "encodedBodySize": 260107,
+              "decodedBodySize": 1250344
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/matplotlib-3.10.8-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 79.40000000596046,
+              "duration": 84.79999999701977,
+              "initiatorType": "fetch",
+              "transferSize": 6867585,
+              "encodedBodySize": 6867285,
+              "decodedBodySize": 6982033
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/contourpy-1.3.3-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 79.59999999403954,
+              "duration": 18.700000002980232,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 117120,
+              "decodedBodySize": 118875
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/numpy-2.4.6-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 79.70000000298023,
+              "duration": 58.79999999701977,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 2882682,
+              "decodedBodySize": 2918760
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/cycler-0.12.1-py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 79.90000000596046,
+              "duration": 13.299999997019768,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 7794,
+              "decodedBodySize": 8321
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/six-1.17.0-py2.py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 80,
+              "duration": 16.599999994039536,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 10640,
+              "decodedBodySize": 11050
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/fonttools-4.62.1-py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 80.09999999403954,
+              "duration": 40.400000005960464,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 1124539,
+              "decodedBodySize": 1152647
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/kiwisolver-1.5.0-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 80.29999999701977,
+              "duration": 18.200000002980232,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 35887,
+              "decodedBodySize": 36616
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/packaging-26.1-py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 80.29999999701977,
+              "duration": 19.299999997019768,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 94197,
+              "decodedBodySize": 95852
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pillow-12.2.0-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 80.5,
+              "duration": 38,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 1029176,
+              "decodedBodySize": 1037807
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pyparsing-3.3.2-py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 80.70000000298023,
+              "duration": 20.200000002980232,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 121160,
+              "decodedBodySize": 122781
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/python_dateutil-2.9.0.post0-py2.py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 80.79999999701977,
+              "duration": 23.200000002980232,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 228238,
+              "decodedBodySize": 229892
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pytz-2026.1.post1-py2.py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 80.90000000596046,
+              "duration": 26.599999994039536,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 377648,
+              "decodedBodySize": 510489
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pandas-3.0.2-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 81.09999999403954,
+              "duration": 66.70000000298023,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 4141666,
+              "decodedBodySize": 4177814
+            },
+            {
+              "name": "oxiquill:display-support:python",
+              "entryType": "measure",
+              "startTime": 2180.5999999940395,
+              "duration": 20.30000001192093
+            },
+            {
+              "name": "oxiquill:imports:features__rich-output__python-rich-outputs",
+              "entryType": "measure",
+              "startTime": 2201,
+              "duration": 1.5
+            },
+            {
+              "name": "oxiquill:display-prepare:features__rich-output__python-rich-outputs",
+              "entryType": "measure",
+              "startTime": 2202.5,
+              "duration": 0.5
+            },
+            {
+              "name": "oxiquill:execution:features__rich-output__python-rich-outputs",
+              "entryType": "measure",
+              "startTime": 2203.2000000029802,
+              "duration": 3162
+            },
+            {
+              "name": "oxiquill:display-collect:features__rich-output__python-rich-outputs",
+              "entryType": "measure",
+              "startTime": 5366.29999999702,
+              "duration": 129.70000000298023
+            }
+          ]
+        }
+      ],
+      "observed": {
+        "requests": [
+          {
+            "requestId": 2,
+            "at": 1788593018690.3
+          }
+        ],
+        "responses": [
+          {
+            "requestId": 2,
+            "at": 1788593024103,
+            "ok": true
+          }
+        ]
+      }
+    },
+    {
+      "example": "features/rich-output/",
+      "condition": "repeat",
+      "run": 1,
+      "triggerMs": 5624.29999999702,
+      "outputMs": 5746.79999999702,
+      "latencyMs": 122.5,
+      "renderObserverDeltaMs": -2.300048828125,
+      "main": {
+        "timeOrigin": 1788593018530.6,
+        "entries": [
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/index.DANjJwMU.css",
+            "entryType": "resource",
+            "startTime": 14.799999997019768,
+            "duration": 0,
+            "initiatorType": "link",
+            "transferSize": 0,
+            "encodedBodySize": 21609,
+            "decodedBodySize": 105367
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/page.B1wUxXOO.js",
+            "entryType": "resource",
+            "startTime": 14.899999991059303,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 1581,
+            "decodedBodySize": 3458
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/Search.astro_astro_type_script_index_0_lang.DzL-jWp_.js",
+            "entryType": "resource",
+            "startTime": 15,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 945,
+            "decodedBodySize": 1830
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/MobileTableOfContents.astro_astro_type_script_index_0_lang.BcSo_yiZ.js",
+            "entryType": "resource",
+            "startTime": 15,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 364,
+            "decodedBodySize": 622
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/TableOfContents.astro_astro_type_script_index_0_lang.Csloo1VZ.js",
+            "entryType": "resource",
+            "startTime": 15.099999994039536,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 56,
+            "decodedBodySize": 36
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/ec.w36nc.css",
+            "entryType": "resource",
+            "startTime": 15.099999994039536,
+            "duration": 0,
+            "initiatorType": "link",
+            "transferSize": 0,
+            "encodedBodySize": 3946,
+            "decodedBodySize": 18292
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/ec.0vx5m.js",
+            "entryType": "resource",
+            "startTime": 15.199999988079071,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 1168,
+            "decodedBodySize": 2523
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/TwoColumnContent.astro_astro_type_script_index_0_lang.DPGAuL8N.js",
+            "entryType": "resource",
+            "startTime": 15.299999997019768,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 269,
+            "decodedBodySize": 452
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/PageFrame.astro_astro_type_script_index_0_lang.iwTubUja.js",
+            "entryType": "resource",
+            "startTime": 15.399999991059303,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 257,
+            "decodedBodySize": 392
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/print.ehPL0gv-.css",
+            "entryType": "resource",
+            "startTime": 19,
+            "duration": 0,
+            "initiatorType": "link",
+            "transferSize": 0,
+            "encodedBodySize": 996,
+            "decodedBodySize": 3318
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/preload-helper.BnKG7j8P.js",
+            "entryType": "resource",
+            "startTime": 24.5,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 737,
+            "decodedBodySize": 1351
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/starlight-toc.CTCQXEge.js",
+            "entryType": "resource",
+            "startTime": 24.69999998807907,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 951,
+            "decodedBodySize": 1981
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/persistent-toggle.t6KkBAiq.js",
+            "entryType": "resource",
+            "startTime": 24.799999997019768,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 705,
+            "decodedBodySize": 2082
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/runtime-client.CDKwXtrO.js",
+            "entryType": "resource",
+            "startTime": 50.099999994039536,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 9696,
+            "decodedBodySize": 29967
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/rolldown-runtime.hePW80VL.js",
+            "entryType": "resource",
+            "startTime": 50.19999998807907,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 430,
+            "decodedBodySize": 716
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/output-limits.BuPdYbfn.js",
+            "entryType": "resource",
+            "startTime": 50.29999999701977,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 584,
+            "decodedBodySize": 1017
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/InteractiveCell.Ccnnhmwl.js",
+            "entryType": "resource",
+            "startTime": 54.29999999701977,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 8135,
+            "decodedBodySize": 22927
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/client.BJAMOzhD.js",
+            "entryType": "resource",
+            "startTime": 54.3999999910593,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 814,
+            "decodedBodySize": 1412
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/preact.Bl7PEaKa.js",
+            "entryType": "resource",
+            "startTime": 56.8999999910593,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 4413,
+            "decodedBodySize": 10470
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/runtime-localization.vhNiaX9V.js",
+            "entryType": "resource",
+            "startTime": 57,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 3198,
+            "decodedBodySize": 8034
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/hooks.ClbWuNs9.js",
+            "entryType": "resource",
+            "startTime": 57,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 1153,
+            "decodedBodySize": 2677
+          },
+          {
+            "name": "oxiquill:worker-start:python",
+            "entryType": "mark",
+            "startTime": 57.3999999910593,
+            "duration": 0
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/favicon.svg",
+            "entryType": "resource",
+            "startTime": 57.79999999701977,
+            "duration": 1.8999999910593033,
+            "initiatorType": "other",
+            "transferSize": 0,
+            "encodedBodySize": 259,
+            "decodedBodySize": 331
+          },
+          {
+            "name": "oxiquill:hydrated:features__rich-output__python-rich-outputs",
+            "entryType": "mark",
+            "startTime": 66.59999999403954,
+            "duration": 0
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/python-worker-DetX1Kyh.js",
+            "entryType": "resource",
+            "startTime": 70.29999999701977,
+            "duration": -9.600000008940697,
+            "initiatorType": "other",
+            "transferSize": 0,
+            "encodedBodySize": 13170,
+            "decodedBodySize": 48070
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/ui-core.BwVUYzUq.js",
+            "entryType": "resource",
+            "startTime": 83.59999999403954,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 26119,
+            "decodedBodySize": 93799
+          },
+          {
+            "name": "oxiquill:output-rendered:features__rich-output__python-rich-outputs",
+            "entryType": "mark",
+            "startTime": 5746.79999999702,
+            "duration": 0
+          }
+        ]
+      },
+      "workers": [
+        {
+          "timeOrigin": 1788593018599.3,
+          "entries": [
+            {
+              "name": "oxiquill:worker-ready:python",
+              "entryType": "mark",
+              "startTime": 3.0999999940395355,
+              "duration": 0
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pyodide.mjs",
+              "entryType": "resource",
+              "startTime": 5.200000002980232,
+              "duration": 1.2999999970197678,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 7156,
+              "decodedBodySize": 17931
+            },
+            {
+              "name": "oxiquill:initialization:python",
+              "entryType": "measure",
+              "startTime": 9.700000002980232,
+              "duration": 2170.8999999910593
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pyodide-lock.json",
+              "entryType": "resource",
+              "startTime": 10,
+              "duration": 2,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 26534,
+              "decodedBodySize": 114440
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/python_stdlib.zip",
+              "entryType": "resource",
+              "startTime": 10.599999994039536,
+              "duration": 16.30000001192093,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 2503174,
+              "decodedBodySize": 2545564
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pyodide.asm.wasm",
+              "entryType": "resource",
+              "startTime": 10.799999997019768,
+              "duration": 146.5,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 3546129,
+              "decodedBodySize": 9598218
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pyodide.asm.mjs",
+              "entryType": "resource",
+              "startTime": 11,
+              "duration": 9.400000005960464,
+              "initiatorType": "script",
+              "transferSize": 0,
+              "encodedBodySize": 260107,
+              "decodedBodySize": 1250344
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/matplotlib-3.10.8-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 79.40000000596046,
+              "duration": 84.79999999701977,
+              "initiatorType": "fetch",
+              "transferSize": 6867585,
+              "encodedBodySize": 6867285,
+              "decodedBodySize": 6982033
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/contourpy-1.3.3-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 79.59999999403954,
+              "duration": 18.700000002980232,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 117120,
+              "decodedBodySize": 118875
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/numpy-2.4.6-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 79.70000000298023,
+              "duration": 58.79999999701977,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 2882682,
+              "decodedBodySize": 2918760
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/cycler-0.12.1-py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 79.90000000596046,
+              "duration": 13.299999997019768,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 7794,
+              "decodedBodySize": 8321
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/six-1.17.0-py2.py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 80,
+              "duration": 16.599999994039536,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 10640,
+              "decodedBodySize": 11050
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/fonttools-4.62.1-py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 80.09999999403954,
+              "duration": 40.400000005960464,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 1124539,
+              "decodedBodySize": 1152647
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/kiwisolver-1.5.0-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 80.29999999701977,
+              "duration": 18.200000002980232,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 35887,
+              "decodedBodySize": 36616
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/packaging-26.1-py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 80.29999999701977,
+              "duration": 19.299999997019768,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 94197,
+              "decodedBodySize": 95852
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pillow-12.2.0-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 80.5,
+              "duration": 38,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 1029176,
+              "decodedBodySize": 1037807
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pyparsing-3.3.2-py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 80.70000000298023,
+              "duration": 20.200000002980232,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 121160,
+              "decodedBodySize": 122781
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/python_dateutil-2.9.0.post0-py2.py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 80.79999999701977,
+              "duration": 23.200000002980232,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 228238,
+              "decodedBodySize": 229892
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pytz-2026.1.post1-py2.py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 80.90000000596046,
+              "duration": 26.599999994039536,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 377648,
+              "decodedBodySize": 510489
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pandas-3.0.2-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 81.09999999403954,
+              "duration": 66.70000000298023,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 4141666,
+              "decodedBodySize": 4177814
+            },
+            {
+              "name": "oxiquill:display-support:python",
+              "entryType": "measure",
+              "startTime": 2180.5999999940395,
+              "duration": 20.30000001192093
+            },
+            {
+              "name": "oxiquill:imports:features__rich-output__python-rich-outputs",
+              "entryType": "measure",
+              "startTime": 5589.5,
+              "duration": 0.7000000029802322
+            },
+            {
+              "name": "oxiquill:display-prepare:features__rich-output__python-rich-outputs",
+              "entryType": "measure",
+              "startTime": 5590.29999999702,
+              "duration": 0.29999999701976776
+            },
+            {
+              "name": "oxiquill:execution:features__rich-output__python-rich-outputs",
+              "entryType": "measure",
+              "startTime": 5590.70000000298,
+              "duration": 12.899999991059303
+            },
+            {
+              "name": "oxiquill:display-collect:features__rich-output__python-rich-outputs",
+              "entryType": "measure",
+              "startTime": 5604.20000000298,
+              "duration": 72.09999999403954
+            }
+          ]
+        }
+      ],
+      "observed": {
+        "requests": [
+          {
+            "requestId": 2,
+            "at": 1788593018690.3
+          },
+          {
+            "requestId": 3,
+            "at": 1788593024188.4001
+          }
+        ],
+        "responses": [
+          {
+            "requestId": 2,
+            "at": 1788593024103,
+            "ok": true
+          },
+          {
+            "requestId": 3,
+            "at": 1788593024279.7002,
+            "ok": true
+          }
+        ]
+      }
+    },
+    {
+      "example": "features/rich-output/",
+      "condition": "fresh",
+      "run": 2,
+      "triggerMs": 173.29999999701977,
+      "outputMs": 5643.70000000298,
+      "latencyMs": 5643.70000000298,
+      "renderObserverDeltaMs": -2.5,
+      "main": {
+        "timeOrigin": 1788593024346.4,
+        "entries": [
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/index.DANjJwMU.css",
+            "entryType": "resource",
+            "startTime": 5.5999999940395355,
+            "duration": 2.6000000089406967,
+            "initiatorType": "link",
+            "transferSize": 21909,
+            "encodedBodySize": 21609,
+            "decodedBodySize": 105367
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/page.B1wUxXOO.js",
+            "entryType": "resource",
+            "startTime": 5.799999997019768,
+            "duration": 8.700000002980232,
+            "initiatorType": "script",
+            "transferSize": 1881,
+            "encodedBodySize": 1581,
+            "decodedBodySize": 3458
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/Search.astro_astro_type_script_index_0_lang.DzL-jWp_.js",
+            "entryType": "resource",
+            "startTime": 5.799999997019768,
+            "duration": 8.799999997019768,
+            "initiatorType": "script",
+            "transferSize": 1245,
+            "encodedBodySize": 945,
+            "decodedBodySize": 1830
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/ec.w36nc.css",
+            "entryType": "resource",
+            "startTime": 5.9000000059604645,
+            "duration": 8.299999997019768,
+            "initiatorType": "link",
+            "transferSize": 4246,
+            "encodedBodySize": 3946,
+            "decodedBodySize": 18292
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/MobileTableOfContents.astro_astro_type_script_index_0_lang.BcSo_yiZ.js",
+            "entryType": "resource",
+            "startTime": 5.9000000059604645,
+            "duration": 8.799999997019768,
+            "initiatorType": "script",
+            "transferSize": 664,
+            "encodedBodySize": 364,
+            "decodedBodySize": 622
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/TableOfContents.astro_astro_type_script_index_0_lang.Csloo1VZ.js",
+            "entryType": "resource",
+            "startTime": 5.9000000059604645,
+            "duration": 9,
+            "initiatorType": "script",
+            "transferSize": 356,
+            "encodedBodySize": 56,
+            "decodedBodySize": 36
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/ec.0vx5m.js",
+            "entryType": "resource",
+            "startTime": 5.9000000059604645,
+            "duration": 9.099999994039536,
+            "initiatorType": "script",
+            "transferSize": 1468,
+            "encodedBodySize": 1168,
+            "decodedBodySize": 2523
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/TwoColumnContent.astro_astro_type_script_index_0_lang.DPGAuL8N.js",
+            "entryType": "resource",
+            "startTime": 6,
+            "duration": 13,
+            "initiatorType": "script",
+            "transferSize": 569,
+            "encodedBodySize": 269,
+            "decodedBodySize": 452
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/PageFrame.astro_astro_type_script_index_0_lang.iwTubUja.js",
+            "entryType": "resource",
+            "startTime": 6.0999999940395355,
+            "duration": 13.200000002980232,
+            "initiatorType": "script",
+            "transferSize": 557,
+            "encodedBodySize": 257,
+            "decodedBodySize": 392
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/print.ehPL0gv-.css",
+            "entryType": "resource",
+            "startTime": 10.400000005960464,
+            "duration": 9.099999994039536,
+            "initiatorType": "link",
+            "transferSize": 1296,
+            "encodedBodySize": 996,
+            "decodedBodySize": 3318
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/preload-helper.BnKG7j8P.js",
+            "entryType": "resource",
+            "startTime": 41.5,
+            "duration": 2.9000000059604645,
+            "initiatorType": "script",
+            "transferSize": 1037,
+            "encodedBodySize": 737,
+            "decodedBodySize": 1351
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/starlight-toc.CTCQXEge.js",
+            "entryType": "resource",
+            "startTime": 41.70000000298023,
+            "duration": 2.7999999970197678,
+            "initiatorType": "script",
+            "transferSize": 1251,
+            "encodedBodySize": 951,
+            "decodedBodySize": 1981
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/persistent-toggle.t6KkBAiq.js",
+            "entryType": "resource",
+            "startTime": 59.5,
+            "duration": 2,
+            "initiatorType": "script",
+            "transferSize": 1005,
+            "encodedBodySize": 705,
+            "decodedBodySize": 2082
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/runtime-client.CDKwXtrO.js",
+            "entryType": "resource",
+            "startTime": 60.900000005960464,
+            "duration": 5.199999988079071,
+            "initiatorType": "script",
+            "transferSize": 9996,
+            "encodedBodySize": 9696,
+            "decodedBodySize": 29967
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/rolldown-runtime.hePW80VL.js",
+            "entryType": "resource",
+            "startTime": 61.099999994039536,
+            "duration": 4.700000002980232,
+            "initiatorType": "script",
+            "transferSize": 730,
+            "encodedBodySize": 430,
+            "decodedBodySize": 716
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/output-limits.BuPdYbfn.js",
+            "entryType": "resource",
+            "startTime": 61.29999999701977,
+            "duration": 4.600000008940697,
+            "initiatorType": "script",
+            "transferSize": 884,
+            "encodedBodySize": 584,
+            "decodedBodySize": 1017
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/favicon.svg",
+            "entryType": "resource",
+            "startTime": 68.20000000298023,
+            "duration": 1.5999999940395355,
+            "initiatorType": "other",
+            "transferSize": 559,
+            "encodedBodySize": 259,
+            "decodedBodySize": 331
+          },
+          {
+            "name": "oxiquill:worker-start:python",
+            "entryType": "mark",
+            "startTime": 68.70000000298023,
+            "duration": 0
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/python-worker-DetX1Kyh.js",
+            "entryType": "resource",
+            "startTime": 83.29999999701977,
+            "duration": -11.5,
+            "initiatorType": "other",
+            "transferSize": 13470,
+            "encodedBodySize": 13170,
+            "decodedBodySize": 48070
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/ui-core.BwVUYzUq.js",
+            "entryType": "resource",
+            "startTime": 93.5,
+            "duration": 2.2999999970197678,
+            "initiatorType": "script",
+            "transferSize": 26419,
+            "encodedBodySize": 26119,
+            "decodedBodySize": 93799
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/InteractiveCell.Ccnnhmwl.js",
+            "entryType": "resource",
+            "startTime": 156.40000000596046,
+            "duration": 3.3999999910593033,
+            "initiatorType": "script",
+            "transferSize": 8435,
+            "encodedBodySize": 8135,
+            "decodedBodySize": 22927
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/client.BJAMOzhD.js",
+            "entryType": "resource",
+            "startTime": 156.5,
+            "duration": 3.2000000029802322,
+            "initiatorType": "script",
+            "transferSize": 1114,
+            "encodedBodySize": 814,
+            "decodedBodySize": 1412
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/preact.Bl7PEaKa.js",
+            "entryType": "resource",
+            "startTime": 160.79999999701977,
+            "duration": 4.9000000059604645,
+            "initiatorType": "script",
+            "transferSize": 4713,
+            "encodedBodySize": 4413,
+            "decodedBodySize": 10470
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/runtime-localization.vhNiaX9V.js",
+            "entryType": "resource",
+            "startTime": 160.90000000596046,
+            "duration": 4.5,
+            "initiatorType": "script",
+            "transferSize": 3498,
+            "encodedBodySize": 3198,
+            "decodedBodySize": 8034
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/hooks.ClbWuNs9.js",
+            "entryType": "resource",
+            "startTime": 160.90000000596046,
+            "duration": 4.699999988079071,
+            "initiatorType": "script",
+            "transferSize": 1453,
+            "encodedBodySize": 1153,
+            "decodedBodySize": 2677
+          },
+          {
+            "name": "oxiquill:hydrated:features__rich-output__python-rich-outputs",
+            "entryType": "mark",
+            "startTime": 168.79999999701977,
+            "duration": 0
+          },
+          {
+            "name": "oxiquill:output-rendered:features__rich-output__python-rich-outputs",
+            "entryType": "mark",
+            "startTime": 5643.70000000298,
+            "duration": 0
+          }
+        ]
+      },
+      "workers": [
+        {
+          "timeOrigin": 1788593024427.6,
+          "entries": [
+            {
+              "name": "oxiquill:worker-ready:python",
+              "entryType": "mark",
+              "startTime": 3.7000000029802322,
+              "duration": 0
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pyodide.mjs",
+              "entryType": "resource",
+              "startTime": 7.899999991059303,
+              "duration": 1.6000000089406967,
+              "initiatorType": "fetch",
+              "transferSize": 7456,
+              "encodedBodySize": 7156,
+              "decodedBodySize": 17931
+            },
+            {
+              "name": "oxiquill:initialization:python",
+              "entryType": "measure",
+              "startTime": 12.399999991059303,
+              "duration": 2241.2000000029802
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pyodide-lock.json",
+              "entryType": "resource",
+              "startTime": 12.799999997019768,
+              "duration": 7.700000002980232,
+              "initiatorType": "fetch",
+              "transferSize": 26834,
+              "encodedBodySize": 26534,
+              "decodedBodySize": 114440
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/python_stdlib.zip",
+              "entryType": "resource",
+              "startTime": 13.299999997019768,
+              "duration": 25.700000002980232,
+              "initiatorType": "fetch",
+              "transferSize": 2503474,
+              "encodedBodySize": 2503174,
+              "decodedBodySize": 2545564
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pyodide.asm.wasm",
+              "entryType": "resource",
+              "startTime": 13.399999991059303,
+              "duration": 182.70000000298023,
+              "initiatorType": "fetch",
+              "transferSize": 3546429,
+              "encodedBodySize": 3546129,
+              "decodedBodySize": 9598218
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pyodide.asm.mjs",
+              "entryType": "resource",
+              "startTime": 13.599999994039536,
+              "duration": 14.600000008940697,
+              "initiatorType": "script",
+              "transferSize": 260407,
+              "encodedBodySize": 260107,
+              "decodedBodySize": 1250344
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/matplotlib-3.10.8-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 94.09999999403954,
+              "duration": 110.29999999701977,
+              "initiatorType": "fetch",
+              "transferSize": 6867585,
+              "encodedBodySize": 6867285,
+              "decodedBodySize": 6982033
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/contourpy-1.3.3-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 94.3999999910593,
+              "duration": 9.5,
+              "initiatorType": "fetch",
+              "transferSize": 117420,
+              "encodedBodySize": 117120,
+              "decodedBodySize": 118875
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/numpy-2.4.6-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 94.5,
+              "duration": 73.8999999910593,
+              "initiatorType": "fetch",
+              "transferSize": 2882982,
+              "encodedBodySize": 2882682,
+              "decodedBodySize": 2918760
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/cycler-0.12.1-py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 94.70000000298023,
+              "duration": 11,
+              "initiatorType": "fetch",
+              "transferSize": 8094,
+              "encodedBodySize": 7794,
+              "decodedBodySize": 8321
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/six-1.17.0-py2.py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 94.70000000298023,
+              "duration": 11.5,
+              "initiatorType": "fetch",
+              "transferSize": 10940,
+              "encodedBodySize": 10640,
+              "decodedBodySize": 11050
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/fonttools-4.62.1-py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 94.70000000298023,
+              "duration": 47.19999998807907,
+              "initiatorType": "fetch",
+              "transferSize": 1124839,
+              "encodedBodySize": 1124539,
+              "decodedBodySize": 1152647
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/kiwisolver-1.5.0-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 94.8999999910593,
+              "duration": 17.900000005960464,
+              "initiatorType": "fetch",
+              "transferSize": 36187,
+              "encodedBodySize": 35887,
+              "decodedBodySize": 36616
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/packaging-26.1-py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 95,
+              "duration": 19.200000002980232,
+              "initiatorType": "fetch",
+              "transferSize": 94497,
+              "encodedBodySize": 94197,
+              "decodedBodySize": 95852
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pillow-12.2.0-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 95.20000000298023,
+              "duration": 49.19999998807907,
+              "initiatorType": "fetch",
+              "transferSize": 1029476,
+              "encodedBodySize": 1029176,
+              "decodedBodySize": 1037807
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pyparsing-3.3.2-py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 95.3999999910593,
+              "duration": 26,
+              "initiatorType": "fetch",
+              "transferSize": 121460,
+              "encodedBodySize": 121160,
+              "decodedBodySize": 122781
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/python_dateutil-2.9.0.post0-py2.py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 95.5,
+              "duration": 35.3999999910593,
+              "initiatorType": "fetch",
+              "transferSize": 228538,
+              "encodedBodySize": 228238,
+              "decodedBodySize": 229892
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pytz-2026.1.post1-py2.py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 95.59999999403954,
+              "duration": 51.79999999701977,
+              "initiatorType": "fetch",
+              "transferSize": 377948,
+              "encodedBodySize": 377648,
+              "decodedBodySize": 510489
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pandas-3.0.2-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 95.70000000298023,
+              "duration": 103,
+              "initiatorType": "fetch",
+              "transferSize": 4141966,
+              "encodedBodySize": 4141666,
+              "decodedBodySize": 4177814
+            },
+            {
+              "name": "oxiquill:display-support:python",
+              "entryType": "measure",
+              "startTime": 2253.5999999940395,
+              "duration": 21.100000008940697
+            },
+            {
+              "name": "oxiquill:imports:features__rich-output__python-rich-outputs",
+              "entryType": "measure",
+              "startTime": 2274.8999999910593,
+              "duration": 1.4000000059604645
+            },
+            {
+              "name": "oxiquill:display-prepare:features__rich-output__python-rich-outputs",
+              "entryType": "measure",
+              "startTime": 2276.2999999970198,
+              "duration": 0.5
+            },
+            {
+              "name": "oxiquill:execution:features__rich-output__python-rich-outputs",
+              "entryType": "measure",
+              "startTime": 2277,
+              "duration": 3162.5
+            },
+            {
+              "name": "oxiquill:display-collect:features__rich-output__python-rich-outputs",
+              "entryType": "measure",
+              "startTime": 5440.5,
+              "duration": 108.59999999403954
+            }
+          ]
+        }
+      ],
+      "observed": {
+        "requests": [
+          {
+            "requestId": 2,
+            "at": 1788593024556.7
+          }
+        ],
+        "responses": [
+          {
+            "requestId": 2,
+            "at": 1788593029992.5999,
+            "ok": true
+          }
+        ]
+      }
+    },
+    {
+      "example": "features/rich-output/",
+      "condition": "reload",
+      "run": 2,
+      "triggerMs": 127.29999999701977,
+      "outputMs": 5620.5999999940395,
+      "latencyMs": 5620.5999999940395,
+      "renderObserverDeltaMs": -2.699951171875,
+      "main": {
+        "timeOrigin": 1788593030009.7,
+        "entries": [
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/index.DANjJwMU.css",
+            "entryType": "resource",
+            "startTime": 14.699999988079071,
+            "duration": 0,
+            "initiatorType": "link",
+            "transferSize": 0,
+            "encodedBodySize": 21609,
+            "decodedBodySize": 105367
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/page.B1wUxXOO.js",
+            "entryType": "resource",
+            "startTime": 14.899999991059303,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 1581,
+            "decodedBodySize": 3458
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/Search.astro_astro_type_script_index_0_lang.DzL-jWp_.js",
+            "entryType": "resource",
+            "startTime": 15,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 945,
+            "decodedBodySize": 1830
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/MobileTableOfContents.astro_astro_type_script_index_0_lang.BcSo_yiZ.js",
+            "entryType": "resource",
+            "startTime": 15,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 364,
+            "decodedBodySize": 622
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/TableOfContents.astro_astro_type_script_index_0_lang.Csloo1VZ.js",
+            "entryType": "resource",
+            "startTime": 15,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 56,
+            "decodedBodySize": 36
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/ec.w36nc.css",
+            "entryType": "resource",
+            "startTime": 15.099999994039536,
+            "duration": 0,
+            "initiatorType": "link",
+            "transferSize": 0,
+            "encodedBodySize": 3946,
+            "decodedBodySize": 18292
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/ec.0vx5m.js",
+            "entryType": "resource",
+            "startTime": 15.199999988079071,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 1168,
+            "decodedBodySize": 2523
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/TwoColumnContent.astro_astro_type_script_index_0_lang.DPGAuL8N.js",
+            "entryType": "resource",
+            "startTime": 15.199999988079071,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 269,
+            "decodedBodySize": 452
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/PageFrame.astro_astro_type_script_index_0_lang.iwTubUja.js",
+            "entryType": "resource",
+            "startTime": 15.299999997019768,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 257,
+            "decodedBodySize": 392
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/print.ehPL0gv-.css",
+            "entryType": "resource",
+            "startTime": 19.099999994039536,
+            "duration": 0,
+            "initiatorType": "link",
+            "transferSize": 0,
+            "encodedBodySize": 996,
+            "decodedBodySize": 3318
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/preload-helper.BnKG7j8P.js",
+            "entryType": "resource",
+            "startTime": 27.19999998807907,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 737,
+            "decodedBodySize": 1351
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/starlight-toc.CTCQXEge.js",
+            "entryType": "resource",
+            "startTime": 27.299999997019768,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 951,
+            "decodedBodySize": 1981
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/persistent-toggle.t6KkBAiq.js",
+            "entryType": "resource",
+            "startTime": 27.599999994039536,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 705,
+            "decodedBodySize": 2082
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/runtime-client.CDKwXtrO.js",
+            "entryType": "resource",
+            "startTime": 50.29999999701977,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 9696,
+            "decodedBodySize": 29967
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/rolldown-runtime.hePW80VL.js",
+            "entryType": "resource",
+            "startTime": 50.5,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 430,
+            "decodedBodySize": 716
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/output-limits.BuPdYbfn.js",
+            "entryType": "resource",
+            "startTime": 50.599999994039536,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 584,
+            "decodedBodySize": 1017
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/InteractiveCell.Ccnnhmwl.js",
+            "entryType": "resource",
+            "startTime": 54.79999999701977,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 8135,
+            "decodedBodySize": 22927
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/client.BJAMOzhD.js",
+            "entryType": "resource",
+            "startTime": 55,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 814,
+            "decodedBodySize": 1412
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/preact.Bl7PEaKa.js",
+            "entryType": "resource",
+            "startTime": 57.29999999701977,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 4413,
+            "decodedBodySize": 10470
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/runtime-localization.vhNiaX9V.js",
+            "entryType": "resource",
+            "startTime": 57.3999999910593,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 3198,
+            "decodedBodySize": 8034
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/hooks.ClbWuNs9.js",
+            "entryType": "resource",
+            "startTime": 57.5,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 1153,
+            "decodedBodySize": 2677
+          },
+          {
+            "name": "oxiquill:worker-start:python",
+            "entryType": "mark",
+            "startTime": 57.69999998807907,
+            "duration": 0
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/favicon.svg",
+            "entryType": "resource",
+            "startTime": 58,
+            "duration": 1.5,
+            "initiatorType": "other",
+            "transferSize": 0,
+            "encodedBodySize": 259,
+            "decodedBodySize": 331
+          },
+          {
+            "name": "oxiquill:hydrated:features__rich-output__python-rich-outputs",
+            "entryType": "mark",
+            "startTime": 65.5,
+            "duration": 0
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/python-worker-DetX1Kyh.js",
+            "entryType": "resource",
+            "startTime": 70.29999999701977,
+            "duration": -9.799999997019768,
+            "initiatorType": "other",
+            "transferSize": 0,
+            "encodedBodySize": 13170,
+            "decodedBodySize": 48070
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/ui-core.BwVUYzUq.js",
+            "entryType": "resource",
+            "startTime": 80.3999999910593,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 26119,
+            "decodedBodySize": 93799
+          },
+          {
+            "name": "oxiquill:output-rendered:features__rich-output__python-rich-outputs",
+            "entryType": "mark",
+            "startTime": 5620.5999999940395,
+            "duration": 0
+          }
+        ]
+      },
+      "workers": [
+        {
+          "timeOrigin": 1788593030078.1,
+          "entries": [
+            {
+              "name": "oxiquill:worker-ready:python",
+              "entryType": "mark",
+              "startTime": 3.5,
+              "duration": 0
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pyodide.mjs",
+              "entryType": "resource",
+              "startTime": 6.399999991059303,
+              "duration": 1.1000000089406967,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 7156,
+              "decodedBodySize": 17931
+            },
+            {
+              "name": "oxiquill:initialization:python",
+              "entryType": "measure",
+              "startTime": 10.399999991059303,
+              "duration": 2195.800000011921
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pyodide-lock.json",
+              "entryType": "resource",
+              "startTime": 10.700000002980232,
+              "duration": 1.5999999940395355,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 26534,
+              "decodedBodySize": 114440
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/python_stdlib.zip",
+              "entryType": "resource",
+              "startTime": 11.099999994039536,
+              "duration": 16.400000005960464,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 2503174,
+              "decodedBodySize": 2545564
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pyodide.asm.wasm",
+              "entryType": "resource",
+              "startTime": 11.200000002980232,
+              "duration": 144.09999999403954,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 3546129,
+              "decodedBodySize": 9598218
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pyodide.asm.mjs",
+              "entryType": "resource",
+              "startTime": 11.5,
+              "duration": 9.399999991059303,
+              "initiatorType": "script",
+              "transferSize": 0,
+              "encodedBodySize": 260107,
+              "decodedBodySize": 1250344
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/matplotlib-3.10.8-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 80.3999999910593,
+              "duration": 81,
+              "initiatorType": "fetch",
+              "transferSize": 6867585,
+              "encodedBodySize": 6867285,
+              "decodedBodySize": 6982033
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/contourpy-1.3.3-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 80.70000000298023,
+              "duration": 16.399999991059303,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 117120,
+              "decodedBodySize": 118875
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/numpy-2.4.6-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 80.70000000298023,
+              "duration": 55.099999994039536,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 2882682,
+              "decodedBodySize": 2918760
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/cycler-0.12.1-py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 80.8999999910593,
+              "duration": 11.600000008940697,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 7794,
+              "decodedBodySize": 8321
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/six-1.17.0-py2.py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 81,
+              "duration": 15,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 10640,
+              "decodedBodySize": 11050
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/fonttools-4.62.1-py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 81.09999999403954,
+              "duration": 37.5,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 1124539,
+              "decodedBodySize": 1152647
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/kiwisolver-1.5.0-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 81.20000000298023,
+              "duration": 16.19999998807907,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 35887,
+              "decodedBodySize": 36616
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/packaging-26.1-py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 81.29999999701977,
+              "duration": 17.099999994039536,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 94197,
+              "decodedBodySize": 95852
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pillow-12.2.0-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 81.3999999910593,
+              "duration": 35.1000000089407,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 1029176,
+              "decodedBodySize": 1037807
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pyparsing-3.3.2-py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 81.59999999403954,
+              "duration": 17.900000005960464,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 121160,
+              "decodedBodySize": 122781
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/python_dateutil-2.9.0.post0-py2.py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 81.70000000298023,
+              "duration": 20.5,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 228238,
+              "decodedBodySize": 229892
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pytz-2026.1.post1-py2.py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 81.79999999701977,
+              "duration": 23.599999994039536,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 377648,
+              "decodedBodySize": 510489
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pandas-3.0.2-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 81.8999999910593,
+              "duration": 63.1000000089407,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 4141666,
+              "decodedBodySize": 4177814
+            },
+            {
+              "name": "oxiquill:display-support:python",
+              "entryType": "measure",
+              "startTime": 2206.2999999970198,
+              "duration": 20.900000005960464
+            },
+            {
+              "name": "oxiquill:imports:features__rich-output__python-rich-outputs",
+              "entryType": "measure",
+              "startTime": 2227.2999999970198,
+              "duration": 1.4000000059604645
+            },
+            {
+              "name": "oxiquill:display-prepare:features__rich-output__python-rich-outputs",
+              "entryType": "measure",
+              "startTime": 2228.7000000029802,
+              "duration": 0.5
+            },
+            {
+              "name": "oxiquill:execution:features__rich-output__python-rich-outputs",
+              "entryType": "measure",
+              "startTime": 2229.3999999910593,
+              "duration": 3193.800000011921
+            },
+            {
+              "name": "oxiquill:display-collect:features__rich-output__python-rich-outputs",
+              "entryType": "measure",
+              "startTime": 5424.0999999940395,
+              "duration": 123.40000000596046
+            }
+          ]
+        }
+      ],
+      "observed": {
+        "requests": [
+          {
+            "requestId": 2,
+            "at": 1788593030172.7
+          }
+        ],
+        "responses": [
+          {
+            "requestId": 2,
+            "at": 1788593035633,
+            "ok": true
+          }
+        ]
+      }
+    },
+    {
+      "example": "features/rich-output/",
+      "condition": "repeat",
+      "run": 2,
+      "triggerMs": 5677.79999999702,
+      "outputMs": 5797.699999988079,
+      "latencyMs": 119.8999999910593,
+      "renderObserverDeltaMs": -2.199951171875,
+      "main": {
+        "timeOrigin": 1788593030009.7,
+        "entries": [
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/index.DANjJwMU.css",
+            "entryType": "resource",
+            "startTime": 14.699999988079071,
+            "duration": 0,
+            "initiatorType": "link",
+            "transferSize": 0,
+            "encodedBodySize": 21609,
+            "decodedBodySize": 105367
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/page.B1wUxXOO.js",
+            "entryType": "resource",
+            "startTime": 14.899999991059303,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 1581,
+            "decodedBodySize": 3458
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/Search.astro_astro_type_script_index_0_lang.DzL-jWp_.js",
+            "entryType": "resource",
+            "startTime": 15,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 945,
+            "decodedBodySize": 1830
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/MobileTableOfContents.astro_astro_type_script_index_0_lang.BcSo_yiZ.js",
+            "entryType": "resource",
+            "startTime": 15,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 364,
+            "decodedBodySize": 622
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/TableOfContents.astro_astro_type_script_index_0_lang.Csloo1VZ.js",
+            "entryType": "resource",
+            "startTime": 15,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 56,
+            "decodedBodySize": 36
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/ec.w36nc.css",
+            "entryType": "resource",
+            "startTime": 15.099999994039536,
+            "duration": 0,
+            "initiatorType": "link",
+            "transferSize": 0,
+            "encodedBodySize": 3946,
+            "decodedBodySize": 18292
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/ec.0vx5m.js",
+            "entryType": "resource",
+            "startTime": 15.199999988079071,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 1168,
+            "decodedBodySize": 2523
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/TwoColumnContent.astro_astro_type_script_index_0_lang.DPGAuL8N.js",
+            "entryType": "resource",
+            "startTime": 15.199999988079071,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 269,
+            "decodedBodySize": 452
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/PageFrame.astro_astro_type_script_index_0_lang.iwTubUja.js",
+            "entryType": "resource",
+            "startTime": 15.299999997019768,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 257,
+            "decodedBodySize": 392
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/print.ehPL0gv-.css",
+            "entryType": "resource",
+            "startTime": 19.099999994039536,
+            "duration": 0,
+            "initiatorType": "link",
+            "transferSize": 0,
+            "encodedBodySize": 996,
+            "decodedBodySize": 3318
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/preload-helper.BnKG7j8P.js",
+            "entryType": "resource",
+            "startTime": 27.19999998807907,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 737,
+            "decodedBodySize": 1351
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/starlight-toc.CTCQXEge.js",
+            "entryType": "resource",
+            "startTime": 27.299999997019768,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 951,
+            "decodedBodySize": 1981
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/persistent-toggle.t6KkBAiq.js",
+            "entryType": "resource",
+            "startTime": 27.599999994039536,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 705,
+            "decodedBodySize": 2082
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/runtime-client.CDKwXtrO.js",
+            "entryType": "resource",
+            "startTime": 50.29999999701977,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 9696,
+            "decodedBodySize": 29967
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/rolldown-runtime.hePW80VL.js",
+            "entryType": "resource",
+            "startTime": 50.5,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 430,
+            "decodedBodySize": 716
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/output-limits.BuPdYbfn.js",
+            "entryType": "resource",
+            "startTime": 50.599999994039536,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 584,
+            "decodedBodySize": 1017
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/InteractiveCell.Ccnnhmwl.js",
+            "entryType": "resource",
+            "startTime": 54.79999999701977,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 8135,
+            "decodedBodySize": 22927
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/client.BJAMOzhD.js",
+            "entryType": "resource",
+            "startTime": 55,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 814,
+            "decodedBodySize": 1412
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/preact.Bl7PEaKa.js",
+            "entryType": "resource",
+            "startTime": 57.29999999701977,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 4413,
+            "decodedBodySize": 10470
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/runtime-localization.vhNiaX9V.js",
+            "entryType": "resource",
+            "startTime": 57.3999999910593,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 3198,
+            "decodedBodySize": 8034
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/hooks.ClbWuNs9.js",
+            "entryType": "resource",
+            "startTime": 57.5,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 1153,
+            "decodedBodySize": 2677
+          },
+          {
+            "name": "oxiquill:worker-start:python",
+            "entryType": "mark",
+            "startTime": 57.69999998807907,
+            "duration": 0
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/favicon.svg",
+            "entryType": "resource",
+            "startTime": 58,
+            "duration": 1.5,
+            "initiatorType": "other",
+            "transferSize": 0,
+            "encodedBodySize": 259,
+            "decodedBodySize": 331
+          },
+          {
+            "name": "oxiquill:hydrated:features__rich-output__python-rich-outputs",
+            "entryType": "mark",
+            "startTime": 65.5,
+            "duration": 0
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/python-worker-DetX1Kyh.js",
+            "entryType": "resource",
+            "startTime": 70.29999999701977,
+            "duration": -9.799999997019768,
+            "initiatorType": "other",
+            "transferSize": 0,
+            "encodedBodySize": 13170,
+            "decodedBodySize": 48070
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/ui-core.BwVUYzUq.js",
+            "entryType": "resource",
+            "startTime": 80.3999999910593,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 26119,
+            "decodedBodySize": 93799
+          },
+          {
+            "name": "oxiquill:output-rendered:features__rich-output__python-rich-outputs",
+            "entryType": "mark",
+            "startTime": 5797.699999988079,
+            "duration": 0
+          }
+        ]
+      },
+      "workers": [
+        {
+          "timeOrigin": 1788593030078.1,
+          "entries": [
+            {
+              "name": "oxiquill:worker-ready:python",
+              "entryType": "mark",
+              "startTime": 3.5,
+              "duration": 0
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pyodide.mjs",
+              "entryType": "resource",
+              "startTime": 6.399999991059303,
+              "duration": 1.1000000089406967,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 7156,
+              "decodedBodySize": 17931
+            },
+            {
+              "name": "oxiquill:initialization:python",
+              "entryType": "measure",
+              "startTime": 10.399999991059303,
+              "duration": 2195.800000011921
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pyodide-lock.json",
+              "entryType": "resource",
+              "startTime": 10.700000002980232,
+              "duration": 1.5999999940395355,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 26534,
+              "decodedBodySize": 114440
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/python_stdlib.zip",
+              "entryType": "resource",
+              "startTime": 11.099999994039536,
+              "duration": 16.400000005960464,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 2503174,
+              "decodedBodySize": 2545564
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pyodide.asm.wasm",
+              "entryType": "resource",
+              "startTime": 11.200000002980232,
+              "duration": 144.09999999403954,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 3546129,
+              "decodedBodySize": 9598218
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pyodide.asm.mjs",
+              "entryType": "resource",
+              "startTime": 11.5,
+              "duration": 9.399999991059303,
+              "initiatorType": "script",
+              "transferSize": 0,
+              "encodedBodySize": 260107,
+              "decodedBodySize": 1250344
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/matplotlib-3.10.8-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 80.3999999910593,
+              "duration": 81,
+              "initiatorType": "fetch",
+              "transferSize": 6867585,
+              "encodedBodySize": 6867285,
+              "decodedBodySize": 6982033
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/contourpy-1.3.3-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 80.70000000298023,
+              "duration": 16.399999991059303,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 117120,
+              "decodedBodySize": 118875
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/numpy-2.4.6-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 80.70000000298023,
+              "duration": 55.099999994039536,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 2882682,
+              "decodedBodySize": 2918760
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/cycler-0.12.1-py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 80.8999999910593,
+              "duration": 11.600000008940697,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 7794,
+              "decodedBodySize": 8321
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/six-1.17.0-py2.py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 81,
+              "duration": 15,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 10640,
+              "decodedBodySize": 11050
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/fonttools-4.62.1-py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 81.09999999403954,
+              "duration": 37.5,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 1124539,
+              "decodedBodySize": 1152647
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/kiwisolver-1.5.0-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 81.20000000298023,
+              "duration": 16.19999998807907,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 35887,
+              "decodedBodySize": 36616
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/packaging-26.1-py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 81.29999999701977,
+              "duration": 17.099999994039536,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 94197,
+              "decodedBodySize": 95852
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pillow-12.2.0-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 81.3999999910593,
+              "duration": 35.1000000089407,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 1029176,
+              "decodedBodySize": 1037807
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pyparsing-3.3.2-py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 81.59999999403954,
+              "duration": 17.900000005960464,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 121160,
+              "decodedBodySize": 122781
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/python_dateutil-2.9.0.post0-py2.py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 81.70000000298023,
+              "duration": 20.5,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 228238,
+              "decodedBodySize": 229892
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pytz-2026.1.post1-py2.py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 81.79999999701977,
+              "duration": 23.599999994039536,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 377648,
+              "decodedBodySize": 510489
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pandas-3.0.2-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 81.8999999910593,
+              "duration": 63.1000000089407,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 4141666,
+              "decodedBodySize": 4177814
+            },
+            {
+              "name": "oxiquill:display-support:python",
+              "entryType": "measure",
+              "startTime": 2206.2999999970198,
+              "duration": 20.900000005960464
+            },
+            {
+              "name": "oxiquill:imports:features__rich-output__python-rich-outputs",
+              "entryType": "measure",
+              "startTime": 5643.5999999940395,
+              "duration": 0.9000000059604645
+            },
+            {
+              "name": "oxiquill:display-prepare:features__rich-output__python-rich-outputs",
+              "entryType": "measure",
+              "startTime": 5644.5,
+              "duration": 0.5
+            },
+            {
+              "name": "oxiquill:execution:features__rich-output__python-rich-outputs",
+              "entryType": "measure",
+              "startTime": 5645,
+              "duration": 12.599999994039536
+            },
+            {
+              "name": "oxiquill:display-collect:features__rich-output__python-rich-outputs",
+              "entryType": "measure",
+              "startTime": 5658.29999999702,
+              "duration": 69.29999999701977
+            }
+          ]
+        }
+      ],
+      "observed": {
+        "requests": [
+          {
+            "requestId": 2,
+            "at": 1788593030172.7
+          },
+          {
+            "requestId": 3,
+            "at": 1788593035721.4
+          }
+        ],
+        "responses": [
+          {
+            "requestId": 2,
+            "at": 1788593035633,
+            "ok": true
+          },
+          {
+            "requestId": 3,
+            "at": 1788593035809.5999,
+            "ok": true
+          }
+        ]
+      }
+    },
+    {
+      "example": "features/rich-output/",
+      "condition": "fresh",
+      "run": 3,
+      "triggerMs": 157.20000000298023,
+      "outputMs": 5780.9000000059605,
+      "latencyMs": 5780.9000000059605,
+      "renderObserverDeltaMs": -3.60009765625,
+      "main": {
+        "timeOrigin": 1788593035878.1,
+        "entries": [
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/index.DANjJwMU.css",
+            "entryType": "resource",
+            "startTime": 5.799999997019768,
+            "duration": 2.7000000029802322,
+            "initiatorType": "link",
+            "transferSize": 21909,
+            "encodedBodySize": 21609,
+            "decodedBodySize": 105367
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/page.B1wUxXOO.js",
+            "entryType": "resource",
+            "startTime": 6,
+            "duration": 8,
+            "initiatorType": "script",
+            "transferSize": 1881,
+            "encodedBodySize": 1581,
+            "decodedBodySize": 3458
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/Search.astro_astro_type_script_index_0_lang.DzL-jWp_.js",
+            "entryType": "resource",
+            "startTime": 6.100000008940697,
+            "duration": 8.099999994039536,
+            "initiatorType": "script",
+            "transferSize": 1245,
+            "encodedBodySize": 945,
+            "decodedBodySize": 1830
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/MobileTableOfContents.astro_astro_type_script_index_0_lang.BcSo_yiZ.js",
+            "entryType": "resource",
+            "startTime": 6.299999997019768,
+            "duration": 8.100000008940697,
+            "initiatorType": "script",
+            "transferSize": 664,
+            "encodedBodySize": 364,
+            "decodedBodySize": 622
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/ec.w36nc.css",
+            "entryType": "resource",
+            "startTime": 6.5,
+            "duration": 7.299999997019768,
+            "initiatorType": "link",
+            "transferSize": 4246,
+            "encodedBodySize": 3946,
+            "decodedBodySize": 18292
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/TableOfContents.astro_astro_type_script_index_0_lang.Csloo1VZ.js",
+            "entryType": "resource",
+            "startTime": 6.5,
+            "duration": 8,
+            "initiatorType": "script",
+            "transferSize": 356,
+            "encodedBodySize": 56,
+            "decodedBodySize": 36
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/ec.0vx5m.js",
+            "entryType": "resource",
+            "startTime": 6.700000002980232,
+            "duration": 7.9000000059604645,
+            "initiatorType": "script",
+            "transferSize": 1468,
+            "encodedBodySize": 1168,
+            "decodedBodySize": 2523
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/TwoColumnContent.astro_astro_type_script_index_0_lang.DPGAuL8N.js",
+            "entryType": "resource",
+            "startTime": 6.9000000059604645,
+            "duration": 11,
+            "initiatorType": "script",
+            "transferSize": 569,
+            "encodedBodySize": 269,
+            "decodedBodySize": 452
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/PageFrame.astro_astro_type_script_index_0_lang.iwTubUja.js",
+            "entryType": "resource",
+            "startTime": 7,
+            "duration": 11,
+            "initiatorType": "script",
+            "transferSize": 557,
+            "encodedBodySize": 257,
+            "decodedBodySize": 392
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/print.ehPL0gv-.css",
+            "entryType": "resource",
+            "startTime": 11.5,
+            "duration": 6.9000000059604645,
+            "initiatorType": "link",
+            "transferSize": 1296,
+            "encodedBodySize": 996,
+            "decodedBodySize": 3318
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/preload-helper.BnKG7j8P.js",
+            "entryType": "resource",
+            "startTime": 41.6000000089407,
+            "duration": 2.8999999910593033,
+            "initiatorType": "script",
+            "transferSize": 1037,
+            "encodedBodySize": 737,
+            "decodedBodySize": 1351
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/starlight-toc.CTCQXEge.js",
+            "entryType": "resource",
+            "startTime": 41.70000000298023,
+            "duration": 3,
+            "initiatorType": "script",
+            "transferSize": 1251,
+            "encodedBodySize": 951,
+            "decodedBodySize": 1981
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/persistent-toggle.t6KkBAiq.js",
+            "entryType": "resource",
+            "startTime": 59.29999999701977,
+            "duration": 2.1000000089406967,
+            "initiatorType": "script",
+            "transferSize": 1005,
+            "encodedBodySize": 705,
+            "decodedBodySize": 2082
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/runtime-client.CDKwXtrO.js",
+            "entryType": "resource",
+            "startTime": 60.5,
+            "duration": 4.600000008940697,
+            "initiatorType": "script",
+            "transferSize": 9996,
+            "encodedBodySize": 9696,
+            "decodedBodySize": 29967
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/rolldown-runtime.hePW80VL.js",
+            "entryType": "resource",
+            "startTime": 60.79999999701977,
+            "duration": 4.100000008940697,
+            "initiatorType": "script",
+            "transferSize": 730,
+            "encodedBodySize": 430,
+            "decodedBodySize": 716
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/output-limits.BuPdYbfn.js",
+            "entryType": "resource",
+            "startTime": 60.900000005960464,
+            "duration": 4.0999999940395355,
+            "initiatorType": "script",
+            "transferSize": 884,
+            "encodedBodySize": 584,
+            "decodedBodySize": 1017
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/favicon.svg",
+            "entryType": "resource",
+            "startTime": 67.40000000596046,
+            "duration": 1.7999999970197678,
+            "initiatorType": "other",
+            "transferSize": 559,
+            "encodedBodySize": 259,
+            "decodedBodySize": 331
+          },
+          {
+            "name": "oxiquill:worker-start:python",
+            "entryType": "mark",
+            "startTime": 67.79999999701977,
+            "duration": 0
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/python-worker-DetX1Kyh.js",
+            "entryType": "resource",
+            "startTime": 84.29999999701977,
+            "duration": -12.799999997019768,
+            "initiatorType": "other",
+            "transferSize": 13470,
+            "encodedBodySize": 13170,
+            "decodedBodySize": 48070
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/ui-core.BwVUYzUq.js",
+            "entryType": "resource",
+            "startTime": 91,
+            "duration": 2.6000000089406967,
+            "initiatorType": "script",
+            "transferSize": 26419,
+            "encodedBodySize": 26119,
+            "decodedBodySize": 93799
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/InteractiveCell.Ccnnhmwl.js",
+            "entryType": "resource",
+            "startTime": 141.1000000089407,
+            "duration": 3.0999999940395355,
+            "initiatorType": "script",
+            "transferSize": 8435,
+            "encodedBodySize": 8135,
+            "decodedBodySize": 22927
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/client.BJAMOzhD.js",
+            "entryType": "resource",
+            "startTime": 141.20000000298023,
+            "duration": 2.9000000059604645,
+            "initiatorType": "script",
+            "transferSize": 1114,
+            "encodedBodySize": 814,
+            "decodedBodySize": 1412
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/preact.Bl7PEaKa.js",
+            "entryType": "resource",
+            "startTime": 145.70000000298023,
+            "duration": 3.7000000029802322,
+            "initiatorType": "script",
+            "transferSize": 4713,
+            "encodedBodySize": 4413,
+            "decodedBodySize": 10470
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/runtime-localization.vhNiaX9V.js",
+            "entryType": "resource",
+            "startTime": 146,
+            "duration": 3.2000000029802322,
+            "initiatorType": "script",
+            "transferSize": 3498,
+            "encodedBodySize": 3198,
+            "decodedBodySize": 8034
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/hooks.ClbWuNs9.js",
+            "entryType": "resource",
+            "startTime": 146.5,
+            "duration": 3.9000000059604645,
+            "initiatorType": "script",
+            "transferSize": 1453,
+            "encodedBodySize": 1153,
+            "decodedBodySize": 2677
+          },
+          {
+            "name": "oxiquill:hydrated:features__rich-output__python-rich-outputs",
+            "entryType": "mark",
+            "startTime": 153.1000000089407,
+            "duration": 0
+          },
+          {
+            "name": "oxiquill:output-rendered:features__rich-output__python-rich-outputs",
+            "entryType": "mark",
+            "startTime": 5780.9000000059605,
+            "duration": 0
+          }
+        ]
+      },
+      "workers": [
+        {
+          "timeOrigin": 1788593035960.7,
+          "entries": [
+            {
+              "name": "oxiquill:worker-ready:python",
+              "entryType": "mark",
+              "startTime": 3.199999988079071,
+              "duration": 0
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pyodide.mjs",
+              "entryType": "resource",
+              "startTime": 7.399999991059303,
+              "duration": 2.2999999970197678,
+              "initiatorType": "fetch",
+              "transferSize": 7456,
+              "encodedBodySize": 7156,
+              "decodedBodySize": 17931
+            },
+            {
+              "name": "oxiquill:initialization:python",
+              "entryType": "measure",
+              "startTime": 13.5,
+              "duration": 2212.3999999910593
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pyodide-lock.json",
+              "entryType": "resource",
+              "startTime": 13.799999997019768,
+              "duration": 7.0999999940395355,
+              "initiatorType": "fetch",
+              "transferSize": 26834,
+              "encodedBodySize": 26534,
+              "decodedBodySize": 114440
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/python_stdlib.zip",
+              "entryType": "resource",
+              "startTime": 14.299999997019768,
+              "duration": 25.099999994039536,
+              "initiatorType": "fetch",
+              "transferSize": 2503474,
+              "encodedBodySize": 2503174,
+              "decodedBodySize": 2545564
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pyodide.asm.wasm",
+              "entryType": "resource",
+              "startTime": 14.399999991059303,
+              "duration": 182.70000000298023,
+              "initiatorType": "fetch",
+              "transferSize": 3546429,
+              "encodedBodySize": 3546129,
+              "decodedBodySize": 9598218
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pyodide.asm.mjs",
+              "entryType": "resource",
+              "startTime": 14.599999994039536,
+              "duration": 14.799999997019768,
+              "initiatorType": "script",
+              "transferSize": 260407,
+              "encodedBodySize": 260107,
+              "decodedBodySize": 1250344
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/matplotlib-3.10.8-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 97.3999999910593,
+              "duration": 106.90000000596046,
+              "initiatorType": "fetch",
+              "transferSize": 6867585,
+              "encodedBodySize": 6867285,
+              "decodedBodySize": 6982033
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/contourpy-1.3.3-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 97.59999999403954,
+              "duration": 10.299999997019768,
+              "initiatorType": "fetch",
+              "transferSize": 117420,
+              "encodedBodySize": 117120,
+              "decodedBodySize": 118875
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/numpy-2.4.6-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 97.79999999701977,
+              "duration": 72.29999999701977,
+              "initiatorType": "fetch",
+              "transferSize": 2882982,
+              "encodedBodySize": 2882682,
+              "decodedBodySize": 2918760
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/cycler-0.12.1-py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 97.8999999910593,
+              "duration": 7.4000000059604645,
+              "initiatorType": "fetch",
+              "transferSize": 8094,
+              "encodedBodySize": 7794,
+              "decodedBodySize": 8321
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/six-1.17.0-py2.py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 98.09999999403954,
+              "duration": 7.4000000059604645,
+              "initiatorType": "fetch",
+              "transferSize": 10940,
+              "encodedBodySize": 10640,
+              "decodedBodySize": 11050
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/fonttools-4.62.1-py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 98.19999998807907,
+              "duration": 46.5,
+              "initiatorType": "fetch",
+              "transferSize": 1124839,
+              "encodedBodySize": 1124539,
+              "decodedBodySize": 1152647
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/kiwisolver-1.5.0-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 98.29999999701977,
+              "duration": 14.599999994039536,
+              "initiatorType": "fetch",
+              "transferSize": 36187,
+              "encodedBodySize": 35887,
+              "decodedBodySize": 36616
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/packaging-26.1-py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 98.29999999701977,
+              "duration": 18.200000002980232,
+              "initiatorType": "fetch",
+              "transferSize": 94497,
+              "encodedBodySize": 94197,
+              "decodedBodySize": 95852
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pillow-12.2.0-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 98.5,
+              "duration": 46,
+              "initiatorType": "fetch",
+              "transferSize": 1029476,
+              "encodedBodySize": 1029176,
+              "decodedBodySize": 1037807
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pyparsing-3.3.2-py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 98.59999999403954,
+              "duration": 23.5,
+              "initiatorType": "fetch",
+              "transferSize": 121460,
+              "encodedBodySize": 121160,
+              "decodedBodySize": 122781
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/python_dateutil-2.9.0.post0-py2.py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 99.5,
+              "duration": 31.19999998807907,
+              "initiatorType": "fetch",
+              "transferSize": 228538,
+              "encodedBodySize": 228238,
+              "decodedBodySize": 229892
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pytz-2026.1.post1-py2.py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 99.69999998807907,
+              "duration": 47.20000000298023,
+              "initiatorType": "fetch",
+              "transferSize": 377948,
+              "encodedBodySize": 377648,
+              "decodedBodySize": 510489
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pandas-3.0.2-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 99.8999999910593,
+              "duration": 97.5,
+              "initiatorType": "fetch",
+              "transferSize": 4141966,
+              "encodedBodySize": 4141666,
+              "decodedBodySize": 4177814
+            },
+            {
+              "name": "oxiquill:display-support:python",
+              "entryType": "measure",
+              "startTime": 2225.8999999910593,
+              "duration": 20.5
+            },
+            {
+              "name": "oxiquill:imports:features__rich-output__python-rich-outputs",
+              "entryType": "measure",
+              "startTime": 2246.5999999940395,
+              "duration": 1.5999999940395355
+            },
+            {
+              "name": "oxiquill:display-prepare:features__rich-output__python-rich-outputs",
+              "entryType": "measure",
+              "startTime": 2248.199999988079,
+              "duration": 0.800000011920929
+            },
+            {
+              "name": "oxiquill:execution:features__rich-output__python-rich-outputs",
+              "entryType": "measure",
+              "startTime": 2249.0999999940395,
+              "duration": 3306.9000000059605
+            },
+            {
+              "name": "oxiquill:display-collect:features__rich-output__python-rich-outputs",
+              "entryType": "measure",
+              "startTime": 5557.0999999940395,
+              "duration": 127.09999999403954
+            }
+          ]
+        }
+      ],
+      "observed": {
+        "requests": [
+          {
+            "requestId": 2,
+            "at": 1788593036073.8
+          }
+        ],
+        "responses": [
+          {
+            "requestId": 2,
+            "at": 1788593041662.6,
+            "ok": true
+          }
+        ]
+      }
+    },
+    {
+      "example": "features/rich-output/",
+      "condition": "reload",
+      "run": 3,
+      "triggerMs": 121.3999999910593,
+      "outputMs": 5806.79999999702,
+      "latencyMs": 5806.79999999702,
+      "renderObserverDeltaMs": -2.599853515625,
+      "main": {
+        "timeOrigin": 1788593041682,
+        "entries": [
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/index.DANjJwMU.css",
+            "entryType": "resource",
+            "startTime": 16.399999991059303,
+            "duration": 0,
+            "initiatorType": "link",
+            "transferSize": 0,
+            "encodedBodySize": 21609,
+            "decodedBodySize": 105367
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/page.B1wUxXOO.js",
+            "entryType": "resource",
+            "startTime": 16.399999991059303,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 1581,
+            "decodedBodySize": 3458
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/Search.astro_astro_type_script_index_0_lang.DzL-jWp_.js",
+            "entryType": "resource",
+            "startTime": 16.5,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 945,
+            "decodedBodySize": 1830
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/MobileTableOfContents.astro_astro_type_script_index_0_lang.BcSo_yiZ.js",
+            "entryType": "resource",
+            "startTime": 16.599999994039536,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 364,
+            "decodedBodySize": 622
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/TableOfContents.astro_astro_type_script_index_0_lang.Csloo1VZ.js",
+            "entryType": "resource",
+            "startTime": 16.700000002980232,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 56,
+            "decodedBodySize": 36
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/ec.w36nc.css",
+            "entryType": "resource",
+            "startTime": 16.799999997019768,
+            "duration": 0,
+            "initiatorType": "link",
+            "transferSize": 0,
+            "encodedBodySize": 3946,
+            "decodedBodySize": 18292
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/ec.0vx5m.js",
+            "entryType": "resource",
+            "startTime": 16.799999997019768,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 1168,
+            "decodedBodySize": 2523
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/TwoColumnContent.astro_astro_type_script_index_0_lang.DPGAuL8N.js",
+            "entryType": "resource",
+            "startTime": 16.799999997019768,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 269,
+            "decodedBodySize": 452
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/PageFrame.astro_astro_type_script_index_0_lang.iwTubUja.js",
+            "entryType": "resource",
+            "startTime": 16.899999991059303,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 257,
+            "decodedBodySize": 392
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/print.ehPL0gv-.css",
+            "entryType": "resource",
+            "startTime": 20.299999997019768,
+            "duration": 0,
+            "initiatorType": "link",
+            "transferSize": 0,
+            "encodedBodySize": 996,
+            "decodedBodySize": 3318
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/preload-helper.BnKG7j8P.js",
+            "entryType": "resource",
+            "startTime": 25.5,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 737,
+            "decodedBodySize": 1351
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/starlight-toc.CTCQXEge.js",
+            "entryType": "resource",
+            "startTime": 25.700000002980232,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 951,
+            "decodedBodySize": 1981
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/persistent-toggle.t6KkBAiq.js",
+            "entryType": "resource",
+            "startTime": 26,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 705,
+            "decodedBodySize": 2082
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/runtime-client.CDKwXtrO.js",
+            "entryType": "resource",
+            "startTime": 27.399999991059303,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 9696,
+            "decodedBodySize": 29967
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/rolldown-runtime.hePW80VL.js",
+            "entryType": "resource",
+            "startTime": 27.700000002980232,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 430,
+            "decodedBodySize": 716
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/output-limits.BuPdYbfn.js",
+            "entryType": "resource",
+            "startTime": 27.799999997019768,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 584,
+            "decodedBodySize": 1017
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/InteractiveCell.Ccnnhmwl.js",
+            "entryType": "resource",
+            "startTime": 57.29999999701977,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 8135,
+            "decodedBodySize": 22927
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/client.BJAMOzhD.js",
+            "entryType": "resource",
+            "startTime": 57.3999999910593,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 814,
+            "decodedBodySize": 1412
+          },
+          {
+            "name": "oxiquill:worker-start:python",
+            "entryType": "mark",
+            "startTime": 58.099999994039536,
+            "duration": 0
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/preact.Bl7PEaKa.js",
+            "entryType": "resource",
+            "startTime": 58.5,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 4413,
+            "decodedBodySize": 10470
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/runtime-localization.vhNiaX9V.js",
+            "entryType": "resource",
+            "startTime": 58.5,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 3198,
+            "decodedBodySize": 8034
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/hooks.ClbWuNs9.js",
+            "entryType": "resource",
+            "startTime": 58.599999994039536,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 1153,
+            "decodedBodySize": 2677
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/favicon.svg",
+            "entryType": "resource",
+            "startTime": 58.79999999701977,
+            "duration": 2.2999999970197678,
+            "initiatorType": "other",
+            "transferSize": 0,
+            "encodedBodySize": 259,
+            "decodedBodySize": 331
+          },
+          {
+            "name": "oxiquill:hydrated:features__rich-output__python-rich-outputs",
+            "entryType": "mark",
+            "startTime": 67.8999999910593,
+            "duration": 0
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/python-worker-DetX1Kyh.js",
+            "entryType": "resource",
+            "startTime": 70,
+            "duration": -8.799999997019768,
+            "initiatorType": "other",
+            "transferSize": 0,
+            "encodedBodySize": 13170,
+            "decodedBodySize": 48070
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/ui-core.BwVUYzUq.js",
+            "entryType": "resource",
+            "startTime": 82.3999999910593,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 26119,
+            "decodedBodySize": 93799
+          },
+          {
+            "name": "oxiquill:output-rendered:features__rich-output__python-rich-outputs",
+            "entryType": "mark",
+            "startTime": 5806.79999999702,
+            "duration": 0
+          }
+        ]
+      },
+      "workers": [
+        {
+          "timeOrigin": 1788593041750.4,
+          "entries": [
+            {
+              "name": "oxiquill:worker-ready:python",
+              "entryType": "mark",
+              "startTime": 3.0999999940395355,
+              "duration": 0
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pyodide.mjs",
+              "entryType": "resource",
+              "startTime": 6,
+              "duration": 1.2000000029802322,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 7156,
+              "decodedBodySize": 17931
+            },
+            {
+              "name": "oxiquill:initialization:python",
+              "entryType": "measure",
+              "startTime": 10.099999994039536,
+              "duration": 2190.6000000089407
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pyodide-lock.json",
+              "entryType": "resource",
+              "startTime": 10.5,
+              "duration": 1.7999999970197678,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 26534,
+              "decodedBodySize": 114440
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/python_stdlib.zip",
+              "entryType": "resource",
+              "startTime": 11,
+              "duration": 16.599999994039536,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 2503174,
+              "decodedBodySize": 2545564
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pyodide.asm.wasm",
+              "entryType": "resource",
+              "startTime": 11.200000002980232,
+              "duration": 143.5,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 3546129,
+              "decodedBodySize": 9598218
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pyodide.asm.mjs",
+              "entryType": "resource",
+              "startTime": 11.299999997019768,
+              "duration": 9.400000005960464,
+              "initiatorType": "script",
+              "transferSize": 0,
+              "encodedBodySize": 260107,
+              "decodedBodySize": 1250344
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/matplotlib-3.10.8-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 79.79999999701977,
+              "duration": 81.6000000089407,
+              "initiatorType": "fetch",
+              "transferSize": 6867585,
+              "encodedBodySize": 6867285,
+              "decodedBodySize": 6982033
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/contourpy-1.3.3-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 80.09999999403954,
+              "duration": 15.600000008940697,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 117120,
+              "decodedBodySize": 118875
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/numpy-2.4.6-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 80.29999999701977,
+              "duration": 54.900000005960464,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 2882682,
+              "decodedBodySize": 2918760
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/cycler-0.12.1-py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 80.40000000596046,
+              "duration": 11.099999994039536,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 7794,
+              "decodedBodySize": 8321
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/six-1.17.0-py2.py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 80.59999999403954,
+              "duration": 14,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 10640,
+              "decodedBodySize": 11050
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/fonttools-4.62.1-py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 80.59999999403954,
+              "duration": 37.20000000298023,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 1124539,
+              "decodedBodySize": 1152647
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/kiwisolver-1.5.0-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 80.79999999701977,
+              "duration": 15.299999997019768,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 35887,
+              "decodedBodySize": 36616
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/packaging-26.1-py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 80.90000000596046,
+              "duration": 16.099999994039536,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 94197,
+              "decodedBodySize": 95852
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pillow-12.2.0-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 81,
+              "duration": 34.79999999701977,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 1029176,
+              "decodedBodySize": 1037807
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pyparsing-3.3.2-py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 81.09999999403954,
+              "duration": 17,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 121160,
+              "decodedBodySize": 122781
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/python_dateutil-2.9.0.post0-py2.py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 81.70000000298023,
+              "duration": 18.799999997019768,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 228238,
+              "decodedBodySize": 229892
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pytz-2026.1.post1-py2.py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 81.79999999701977,
+              "duration": 22.200000002980232,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 377648,
+              "decodedBodySize": 510489
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pandas-3.0.2-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 82,
+              "duration": 62.70000000298023,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 4141666,
+              "decodedBodySize": 4177814
+            },
+            {
+              "name": "oxiquill:display-support:python",
+              "entryType": "measure",
+              "startTime": 2200.7000000029802,
+              "duration": 21.099999994039536
+            },
+            {
+              "name": "oxiquill:imports:features__rich-output__python-rich-outputs",
+              "entryType": "measure",
+              "startTime": 2222.0999999940395,
+              "duration": 1.800000011920929
+            },
+            {
+              "name": "oxiquill:display-prepare:features__rich-output__python-rich-outputs",
+              "entryType": "measure",
+              "startTime": 2223.9000000059605,
+              "duration": 0.699999988079071
+            },
+            {
+              "name": "oxiquill:execution:features__rich-output__python-rich-outputs",
+              "entryType": "measure",
+              "startTime": 2224.7999999970198,
+              "duration": 3375.5
+            },
+            {
+              "name": "oxiquill:display-collect:features__rich-output__python-rich-outputs",
+              "entryType": "measure",
+              "startTime": 5601.0999999940395,
+              "duration": 132.6000000089407
+            }
+          ]
+        }
+      ],
+      "observed": {
+        "requests": [
+          {
+            "requestId": 2,
+            "at": 1788593041837.8
+          }
+        ],
+        "responses": [
+          {
+            "requestId": 2,
+            "at": 1788593047491.4,
+            "ok": true
+          }
+        ]
+      }
+    },
+    {
+      "example": "features/rich-output/",
+      "condition": "repeat",
+      "run": 3,
+      "triggerMs": 5871.79999999702,
+      "outputMs": 5996.0999999940395,
+      "latencyMs": 124.29999999701977,
+      "renderObserverDeltaMs": -2.099853515625,
+      "main": {
+        "timeOrigin": 1788593041682,
+        "entries": [
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/index.DANjJwMU.css",
+            "entryType": "resource",
+            "startTime": 16.399999991059303,
+            "duration": 0,
+            "initiatorType": "link",
+            "transferSize": 0,
+            "encodedBodySize": 21609,
+            "decodedBodySize": 105367
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/page.B1wUxXOO.js",
+            "entryType": "resource",
+            "startTime": 16.399999991059303,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 1581,
+            "decodedBodySize": 3458
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/Search.astro_astro_type_script_index_0_lang.DzL-jWp_.js",
+            "entryType": "resource",
+            "startTime": 16.5,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 945,
+            "decodedBodySize": 1830
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/MobileTableOfContents.astro_astro_type_script_index_0_lang.BcSo_yiZ.js",
+            "entryType": "resource",
+            "startTime": 16.599999994039536,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 364,
+            "decodedBodySize": 622
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/TableOfContents.astro_astro_type_script_index_0_lang.Csloo1VZ.js",
+            "entryType": "resource",
+            "startTime": 16.700000002980232,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 56,
+            "decodedBodySize": 36
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/ec.w36nc.css",
+            "entryType": "resource",
+            "startTime": 16.799999997019768,
+            "duration": 0,
+            "initiatorType": "link",
+            "transferSize": 0,
+            "encodedBodySize": 3946,
+            "decodedBodySize": 18292
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/ec.0vx5m.js",
+            "entryType": "resource",
+            "startTime": 16.799999997019768,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 1168,
+            "decodedBodySize": 2523
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/TwoColumnContent.astro_astro_type_script_index_0_lang.DPGAuL8N.js",
+            "entryType": "resource",
+            "startTime": 16.799999997019768,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 269,
+            "decodedBodySize": 452
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/PageFrame.astro_astro_type_script_index_0_lang.iwTubUja.js",
+            "entryType": "resource",
+            "startTime": 16.899999991059303,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 257,
+            "decodedBodySize": 392
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/print.ehPL0gv-.css",
+            "entryType": "resource",
+            "startTime": 20.299999997019768,
+            "duration": 0,
+            "initiatorType": "link",
+            "transferSize": 0,
+            "encodedBodySize": 996,
+            "decodedBodySize": 3318
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/preload-helper.BnKG7j8P.js",
+            "entryType": "resource",
+            "startTime": 25.5,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 737,
+            "decodedBodySize": 1351
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/starlight-toc.CTCQXEge.js",
+            "entryType": "resource",
+            "startTime": 25.700000002980232,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 951,
+            "decodedBodySize": 1981
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/persistent-toggle.t6KkBAiq.js",
+            "entryType": "resource",
+            "startTime": 26,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 705,
+            "decodedBodySize": 2082
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/runtime-client.CDKwXtrO.js",
+            "entryType": "resource",
+            "startTime": 27.399999991059303,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 9696,
+            "decodedBodySize": 29967
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/rolldown-runtime.hePW80VL.js",
+            "entryType": "resource",
+            "startTime": 27.700000002980232,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 430,
+            "decodedBodySize": 716
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/output-limits.BuPdYbfn.js",
+            "entryType": "resource",
+            "startTime": 27.799999997019768,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 584,
+            "decodedBodySize": 1017
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/InteractiveCell.Ccnnhmwl.js",
+            "entryType": "resource",
+            "startTime": 57.29999999701977,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 8135,
+            "decodedBodySize": 22927
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/client.BJAMOzhD.js",
+            "entryType": "resource",
+            "startTime": 57.3999999910593,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 814,
+            "decodedBodySize": 1412
+          },
+          {
+            "name": "oxiquill:worker-start:python",
+            "entryType": "mark",
+            "startTime": 58.099999994039536,
+            "duration": 0
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/preact.Bl7PEaKa.js",
+            "entryType": "resource",
+            "startTime": 58.5,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 4413,
+            "decodedBodySize": 10470
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/runtime-localization.vhNiaX9V.js",
+            "entryType": "resource",
+            "startTime": 58.5,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 3198,
+            "decodedBodySize": 8034
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/hooks.ClbWuNs9.js",
+            "entryType": "resource",
+            "startTime": 58.599999994039536,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 1153,
+            "decodedBodySize": 2677
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/favicon.svg",
+            "entryType": "resource",
+            "startTime": 58.79999999701977,
+            "duration": 2.2999999970197678,
+            "initiatorType": "other",
+            "transferSize": 0,
+            "encodedBodySize": 259,
+            "decodedBodySize": 331
+          },
+          {
+            "name": "oxiquill:hydrated:features__rich-output__python-rich-outputs",
+            "entryType": "mark",
+            "startTime": 67.8999999910593,
+            "duration": 0
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/python-worker-DetX1Kyh.js",
+            "entryType": "resource",
+            "startTime": 70,
+            "duration": -8.799999997019768,
+            "initiatorType": "other",
+            "transferSize": 0,
+            "encodedBodySize": 13170,
+            "decodedBodySize": 48070
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/ui-core.BwVUYzUq.js",
+            "entryType": "resource",
+            "startTime": 82.3999999910593,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 26119,
+            "decodedBodySize": 93799
+          },
+          {
+            "name": "oxiquill:output-rendered:features__rich-output__python-rich-outputs",
+            "entryType": "mark",
+            "startTime": 5996.0999999940395,
+            "duration": 0
+          }
+        ]
+      },
+      "workers": [
+        {
+          "timeOrigin": 1788593041750.4,
+          "entries": [
+            {
+              "name": "oxiquill:worker-ready:python",
+              "entryType": "mark",
+              "startTime": 3.0999999940395355,
+              "duration": 0
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pyodide.mjs",
+              "entryType": "resource",
+              "startTime": 6,
+              "duration": 1.2000000029802322,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 7156,
+              "decodedBodySize": 17931
+            },
+            {
+              "name": "oxiquill:initialization:python",
+              "entryType": "measure",
+              "startTime": 10.099999994039536,
+              "duration": 2190.6000000089407
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pyodide-lock.json",
+              "entryType": "resource",
+              "startTime": 10.5,
+              "duration": 1.7999999970197678,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 26534,
+              "decodedBodySize": 114440
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/python_stdlib.zip",
+              "entryType": "resource",
+              "startTime": 11,
+              "duration": 16.599999994039536,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 2503174,
+              "decodedBodySize": 2545564
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pyodide.asm.wasm",
+              "entryType": "resource",
+              "startTime": 11.200000002980232,
+              "duration": 143.5,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 3546129,
+              "decodedBodySize": 9598218
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pyodide.asm.mjs",
+              "entryType": "resource",
+              "startTime": 11.299999997019768,
+              "duration": 9.400000005960464,
+              "initiatorType": "script",
+              "transferSize": 0,
+              "encodedBodySize": 260107,
+              "decodedBodySize": 1250344
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/matplotlib-3.10.8-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 79.79999999701977,
+              "duration": 81.6000000089407,
+              "initiatorType": "fetch",
+              "transferSize": 6867585,
+              "encodedBodySize": 6867285,
+              "decodedBodySize": 6982033
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/contourpy-1.3.3-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 80.09999999403954,
+              "duration": 15.600000008940697,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 117120,
+              "decodedBodySize": 118875
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/numpy-2.4.6-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 80.29999999701977,
+              "duration": 54.900000005960464,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 2882682,
+              "decodedBodySize": 2918760
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/cycler-0.12.1-py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 80.40000000596046,
+              "duration": 11.099999994039536,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 7794,
+              "decodedBodySize": 8321
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/six-1.17.0-py2.py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 80.59999999403954,
+              "duration": 14,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 10640,
+              "decodedBodySize": 11050
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/fonttools-4.62.1-py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 80.59999999403954,
+              "duration": 37.20000000298023,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 1124539,
+              "decodedBodySize": 1152647
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/kiwisolver-1.5.0-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 80.79999999701977,
+              "duration": 15.299999997019768,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 35887,
+              "decodedBodySize": 36616
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/packaging-26.1-py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 80.90000000596046,
+              "duration": 16.099999994039536,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 94197,
+              "decodedBodySize": 95852
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pillow-12.2.0-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 81,
+              "duration": 34.79999999701977,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 1029176,
+              "decodedBodySize": 1037807
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pyparsing-3.3.2-py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 81.09999999403954,
+              "duration": 17,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 121160,
+              "decodedBodySize": 122781
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/python_dateutil-2.9.0.post0-py2.py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 81.70000000298023,
+              "duration": 18.799999997019768,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 228238,
+              "decodedBodySize": 229892
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pytz-2026.1.post1-py2.py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 81.79999999701977,
+              "duration": 22.200000002980232,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 377648,
+              "decodedBodySize": 510489
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pandas-3.0.2-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 82,
+              "duration": 62.70000000298023,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 4141666,
+              "decodedBodySize": 4177814
+            },
+            {
+              "name": "oxiquill:display-support:python",
+              "entryType": "measure",
+              "startTime": 2200.7000000029802,
+              "duration": 21.099999994039536
+            },
+            {
+              "name": "oxiquill:imports:features__rich-output__python-rich-outputs",
+              "entryType": "measure",
+              "startTime": 5837.5,
+              "duration": 0.9000000059604645
+            },
+            {
+              "name": "oxiquill:display-prepare:features__rich-output__python-rich-outputs",
+              "entryType": "measure",
+              "startTime": 5838.4000000059605,
+              "duration": 0.3999999910593033
+            },
+            {
+              "name": "oxiquill:execution:features__rich-output__python-rich-outputs",
+              "entryType": "measure",
+              "startTime": 5838.79999999702,
+              "duration": 13.900000005960464
+            },
+            {
+              "name": "oxiquill:display-collect:features__rich-output__python-rich-outputs",
+              "entryType": "measure",
+              "startTime": 5854,
+              "duration": 71.90000000596046
+            }
+          ]
+        }
+      ],
+      "observed": {
+        "requests": [
+          {
+            "requestId": 2,
+            "at": 1788593041837.8
+          },
+          {
+            "requestId": 3,
+            "at": 1788593047587.5
+          }
+        ],
+        "responses": [
+          {
+            "requestId": 2,
+            "at": 1788593047491.4,
+            "ok": true
+          },
+          {
+            "requestId": 3,
+            "at": 1788593047680.2,
+            "ok": true
+          }
+        ]
+      }
+    },
+    {
+      "example": "features/rich-output/",
+      "condition": "fresh",
+      "run": 4,
+      "triggerMs": 175.90000000596046,
+      "outputMs": 5753,
+      "latencyMs": 5753,
+      "renderObserverDeltaMs": -2.800048828125,
+      "main": {
+        "timeOrigin": 1788593047745.9,
+        "entries": [
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/index.DANjJwMU.css",
+            "entryType": "resource",
+            "startTime": 5.700000002980232,
+            "duration": 2.7000000029802322,
+            "initiatorType": "link",
+            "transferSize": 21909,
+            "encodedBodySize": 21609,
+            "decodedBodySize": 105367
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/page.B1wUxXOO.js",
+            "entryType": "resource",
+            "startTime": 6,
+            "duration": 9,
+            "initiatorType": "script",
+            "transferSize": 1881,
+            "encodedBodySize": 1581,
+            "decodedBodySize": 3458
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/Search.astro_astro_type_script_index_0_lang.DzL-jWp_.js",
+            "entryType": "resource",
+            "startTime": 6,
+            "duration": 9.200000002980232,
+            "initiatorType": "script",
+            "transferSize": 1245,
+            "encodedBodySize": 945,
+            "decodedBodySize": 1830
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/MobileTableOfContents.astro_astro_type_script_index_0_lang.BcSo_yiZ.js",
+            "entryType": "resource",
+            "startTime": 6,
+            "duration": 9.300000011920929,
+            "initiatorType": "script",
+            "transferSize": 664,
+            "encodedBodySize": 364,
+            "decodedBodySize": 622
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/TableOfContents.astro_astro_type_script_index_0_lang.Csloo1VZ.js",
+            "entryType": "resource",
+            "startTime": 6,
+            "duration": 9.800000011920929,
+            "initiatorType": "script",
+            "transferSize": 356,
+            "encodedBodySize": 56,
+            "decodedBodySize": 36
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/ec.w36nc.css",
+            "entryType": "resource",
+            "startTime": 6.100000008940697,
+            "duration": 8.700000002980232,
+            "initiatorType": "link",
+            "transferSize": 4246,
+            "encodedBodySize": 3946,
+            "decodedBodySize": 18292
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/ec.0vx5m.js",
+            "entryType": "resource",
+            "startTime": 6.100000008940697,
+            "duration": 9.899999991059303,
+            "initiatorType": "script",
+            "transferSize": 1468,
+            "encodedBodySize": 1168,
+            "decodedBodySize": 2523
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/TwoColumnContent.astro_astro_type_script_index_0_lang.DPGAuL8N.js",
+            "entryType": "resource",
+            "startTime": 6.200000002980232,
+            "duration": 13.299999997019768,
+            "initiatorType": "script",
+            "transferSize": 569,
+            "encodedBodySize": 269,
+            "decodedBodySize": 452
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/PageFrame.astro_astro_type_script_index_0_lang.iwTubUja.js",
+            "entryType": "resource",
+            "startTime": 6.200000002980232,
+            "duration": 13.5,
+            "initiatorType": "script",
+            "transferSize": 557,
+            "encodedBodySize": 257,
+            "decodedBodySize": 392
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/print.ehPL0gv-.css",
+            "entryType": "resource",
+            "startTime": 10,
+            "duration": 9.800000011920929,
+            "initiatorType": "link",
+            "transferSize": 1296,
+            "encodedBodySize": 996,
+            "decodedBodySize": 3318
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/preload-helper.BnKG7j8P.js",
+            "entryType": "resource",
+            "startTime": 57.5,
+            "duration": 3.6000000089406967,
+            "initiatorType": "script",
+            "transferSize": 1037,
+            "encodedBodySize": 737,
+            "decodedBodySize": 1351
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/starlight-toc.CTCQXEge.js",
+            "entryType": "resource",
+            "startTime": 57.6000000089407,
+            "duration": 3.8999999910593033,
+            "initiatorType": "script",
+            "transferSize": 1251,
+            "encodedBodySize": 951,
+            "decodedBodySize": 1981
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/persistent-toggle.t6KkBAiq.js",
+            "entryType": "resource",
+            "startTime": 57.80000001192093,
+            "duration": 3.8999999910593033,
+            "initiatorType": "script",
+            "transferSize": 1005,
+            "encodedBodySize": 705,
+            "decodedBodySize": 2082
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/runtime-client.CDKwXtrO.js",
+            "entryType": "resource",
+            "startTime": 63.20000000298023,
+            "duration": 4.200000002980232,
+            "initiatorType": "script",
+            "transferSize": 9996,
+            "encodedBodySize": 9696,
+            "decodedBodySize": 29967
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/rolldown-runtime.hePW80VL.js",
+            "entryType": "resource",
+            "startTime": 63.30000001192093,
+            "duration": 3.7999999970197678,
+            "initiatorType": "script",
+            "transferSize": 730,
+            "encodedBodySize": 430,
+            "decodedBodySize": 716
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/output-limits.BuPdYbfn.js",
+            "entryType": "resource",
+            "startTime": 63.6000000089407,
+            "duration": 3.7000000029802322,
+            "initiatorType": "script",
+            "transferSize": 884,
+            "encodedBodySize": 584,
+            "decodedBodySize": 1017
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/favicon.svg",
+            "entryType": "resource",
+            "startTime": 69.80000001192093,
+            "duration": 1.699999988079071,
+            "initiatorType": "other",
+            "transferSize": 559,
+            "encodedBodySize": 259,
+            "decodedBodySize": 331
+          },
+          {
+            "name": "oxiquill:worker-start:python",
+            "entryType": "mark",
+            "startTime": 70.30000001192093,
+            "duration": 0
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/python-worker-DetX1Kyh.js",
+            "entryType": "resource",
+            "startTime": 83.30000001192093,
+            "duration": -9.200000002980232,
+            "initiatorType": "other",
+            "transferSize": 13470,
+            "encodedBodySize": 13170,
+            "decodedBodySize": 48070
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/ui-core.BwVUYzUq.js",
+            "entryType": "resource",
+            "startTime": 94.80000001192093,
+            "duration": 7,
+            "initiatorType": "script",
+            "transferSize": 26419,
+            "encodedBodySize": 26119,
+            "decodedBodySize": 93799
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/InteractiveCell.Ccnnhmwl.js",
+            "entryType": "resource",
+            "startTime": 156.40000000596046,
+            "duration": 3.5,
+            "initiatorType": "script",
+            "transferSize": 8435,
+            "encodedBodySize": 8135,
+            "decodedBodySize": 22927
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/client.BJAMOzhD.js",
+            "entryType": "resource",
+            "startTime": 156.6000000089407,
+            "duration": 3.2000000029802322,
+            "initiatorType": "script",
+            "transferSize": 1114,
+            "encodedBodySize": 814,
+            "decodedBodySize": 1412
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/preact.Bl7PEaKa.js",
+            "entryType": "resource",
+            "startTime": 160.90000000596046,
+            "duration": 4.5,
+            "initiatorType": "script",
+            "transferSize": 4713,
+            "encodedBodySize": 4413,
+            "decodedBodySize": 10470
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/hooks.ClbWuNs9.js",
+            "entryType": "resource",
+            "startTime": 161.1000000089407,
+            "duration": 4.200000002980232,
+            "initiatorType": "script",
+            "transferSize": 1453,
+            "encodedBodySize": 1153,
+            "decodedBodySize": 2677
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/runtime-localization.vhNiaX9V.js",
+            "entryType": "resource",
+            "startTime": 161.1000000089407,
+            "duration": 4,
+            "initiatorType": "script",
+            "transferSize": 3498,
+            "encodedBodySize": 3198,
+            "decodedBodySize": 8034
+          },
+          {
+            "name": "oxiquill:hydrated:features__rich-output__python-rich-outputs",
+            "entryType": "mark",
+            "startTime": 168.6000000089407,
+            "duration": 0
+          },
+          {
+            "name": "oxiquill:output-rendered:features__rich-output__python-rich-outputs",
+            "entryType": "mark",
+            "startTime": 5753,
+            "duration": 0
+          }
+        ]
+      },
+      "workers": [
+        {
+          "timeOrigin": 1788593047827.4,
+          "entries": [
+            {
+              "name": "oxiquill:worker-ready:python",
+              "entryType": "mark",
+              "startTime": 3.300000011920929,
+              "duration": 0
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pyodide.mjs",
+              "entryType": "resource",
+              "startTime": 7.9000000059604645,
+              "duration": 1.9000000059604645,
+              "initiatorType": "fetch",
+              "transferSize": 7456,
+              "encodedBodySize": 7156,
+              "decodedBodySize": 17931
+            },
+            {
+              "name": "oxiquill:initialization:python",
+              "entryType": "measure",
+              "startTime": 12.700000002980232,
+              "duration": 2271
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pyodide-lock.json",
+              "entryType": "resource",
+              "startTime": 13,
+              "duration": 7.100000008940697,
+              "initiatorType": "fetch",
+              "transferSize": 26834,
+              "encodedBodySize": 26534,
+              "decodedBodySize": 114440
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/python_stdlib.zip",
+              "entryType": "resource",
+              "startTime": 13.400000005960464,
+              "duration": 25.299999997019768,
+              "initiatorType": "fetch",
+              "transferSize": 2503474,
+              "encodedBodySize": 2503174,
+              "decodedBodySize": 2545564
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pyodide.asm.wasm",
+              "entryType": "resource",
+              "startTime": 13.5,
+              "duration": 176.6000000089407,
+              "initiatorType": "fetch",
+              "transferSize": 3546429,
+              "encodedBodySize": 3546129,
+              "decodedBodySize": 9598218
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pyodide.asm.mjs",
+              "entryType": "resource",
+              "startTime": 13.800000011920929,
+              "duration": 14.599999994039536,
+              "initiatorType": "script",
+              "transferSize": 260407,
+              "encodedBodySize": 260107,
+              "decodedBodySize": 1250344
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/matplotlib-3.10.8-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 90.90000000596046,
+              "duration": 107.09999999403954,
+              "initiatorType": "fetch",
+              "transferSize": 6867585,
+              "encodedBodySize": 6867285,
+              "decodedBodySize": 6982033
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/contourpy-1.3.3-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 91.1000000089407,
+              "duration": 10.099999994039536,
+              "initiatorType": "fetch",
+              "transferSize": 117420,
+              "encodedBodySize": 117120,
+              "decodedBodySize": 118875
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/cycler-0.12.1-py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 91.30000001192093,
+              "duration": 8.399999991059303,
+              "initiatorType": "fetch",
+              "transferSize": 8094,
+              "encodedBodySize": 7794,
+              "decodedBodySize": 8321
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/numpy-2.4.6-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 91.30000001192093,
+              "duration": 71.69999998807907,
+              "initiatorType": "fetch",
+              "transferSize": 2882982,
+              "encodedBodySize": 2882682,
+              "decodedBodySize": 2918760
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/six-1.17.0-py2.py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 91.5,
+              "duration": 8.300000011920929,
+              "initiatorType": "fetch",
+              "transferSize": 10940,
+              "encodedBodySize": 10640,
+              "decodedBodySize": 11050
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/fonttools-4.62.1-py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 91.70000000298023,
+              "duration": 43.70000000298023,
+              "initiatorType": "fetch",
+              "transferSize": 1124839,
+              "encodedBodySize": 1124539,
+              "decodedBodySize": 1152647
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/kiwisolver-1.5.0-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 91.90000000596046,
+              "duration": 14.200000002980232,
+              "initiatorType": "fetch",
+              "transferSize": 36187,
+              "encodedBodySize": 35887,
+              "decodedBodySize": 36616
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/packaging-26.1-py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 92,
+              "duration": 17.400000005960464,
+              "initiatorType": "fetch",
+              "transferSize": 94497,
+              "encodedBodySize": 94197,
+              "decodedBodySize": 95852
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pillow-12.2.0-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 92.1000000089407,
+              "duration": 48.29999999701977,
+              "initiatorType": "fetch",
+              "transferSize": 1029476,
+              "encodedBodySize": 1029176,
+              "decodedBodySize": 1037807
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pyparsing-3.3.2-py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 92.30000001192093,
+              "duration": 22.69999998807907,
+              "initiatorType": "fetch",
+              "transferSize": 121460,
+              "encodedBodySize": 121160,
+              "decodedBodySize": 122781
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/python_dateutil-2.9.0.post0-py2.py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 93.30000001192093,
+              "duration": 30,
+              "initiatorType": "fetch",
+              "transferSize": 228538,
+              "encodedBodySize": 228238,
+              "decodedBodySize": 229892
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pytz-2026.1.post1-py2.py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 93.40000000596046,
+              "duration": 45.5,
+              "initiatorType": "fetch",
+              "transferSize": 377948,
+              "encodedBodySize": 377648,
+              "decodedBodySize": 510489
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pandas-3.0.2-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 93.6000000089407,
+              "duration": 96.09999999403954,
+              "initiatorType": "fetch",
+              "transferSize": 4141966,
+              "encodedBodySize": 4141666,
+              "decodedBodySize": 4177814
+            },
+            {
+              "name": "oxiquill:display-support:python",
+              "entryType": "measure",
+              "startTime": 2283.800000011921,
+              "duration": 21.799999997019768
+            },
+            {
+              "name": "oxiquill:imports:features__rich-output__python-rich-outputs",
+              "entryType": "measure",
+              "startTime": 2305.800000011921,
+              "duration": 1.3999999910593033
+            },
+            {
+              "name": "oxiquill:display-prepare:features__rich-output__python-rich-outputs",
+              "entryType": "measure",
+              "startTime": 2307.2000000029802,
+              "duration": 0.5
+            },
+            {
+              "name": "oxiquill:execution:features__rich-output__python-rich-outputs",
+              "entryType": "measure",
+              "startTime": 2307.9000000059605,
+              "duration": 3237.5
+            },
+            {
+              "name": "oxiquill:display-collect:features__rich-output__python-rich-outputs",
+              "entryType": "measure",
+              "startTime": 5546.4000000059605,
+              "duration": 111.20000000298023
+            }
+          ]
+        }
+      ],
+      "observed": {
+        "requests": [
+          {
+            "requestId": 2,
+            "at": 1788593047956.0999
+          }
+        ],
+        "responses": [
+          {
+            "requestId": 2,
+            "at": 1788593053501.7,
+            "ok": true
+          }
+        ]
+      }
+    },
+    {
+      "example": "features/rich-output/",
+      "condition": "reload",
+      "run": 4,
+      "triggerMs": 117.90000000596046,
+      "outputMs": 5749.5,
+      "latencyMs": 5749.5,
+      "renderObserverDeltaMs": -2.699951171875,
+      "main": {
+        "timeOrigin": 1788593053518.4,
+        "entries": [
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/index.DANjJwMU.css",
+            "entryType": "resource",
+            "startTime": 15.100000008940697,
+            "duration": 0,
+            "initiatorType": "link",
+            "transferSize": 0,
+            "encodedBodySize": 21609,
+            "decodedBodySize": 105367
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/page.B1wUxXOO.js",
+            "entryType": "resource",
+            "startTime": 15.300000011920929,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 1581,
+            "decodedBodySize": 3458
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/Search.astro_astro_type_script_index_0_lang.DzL-jWp_.js",
+            "entryType": "resource",
+            "startTime": 15.300000011920929,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 945,
+            "decodedBodySize": 1830
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/MobileTableOfContents.astro_astro_type_script_index_0_lang.BcSo_yiZ.js",
+            "entryType": "resource",
+            "startTime": 15.400000005960464,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 364,
+            "decodedBodySize": 622
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/TableOfContents.astro_astro_type_script_index_0_lang.Csloo1VZ.js",
+            "entryType": "resource",
+            "startTime": 15.5,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 56,
+            "decodedBodySize": 36
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/ec.w36nc.css",
+            "entryType": "resource",
+            "startTime": 15.5,
+            "duration": 0,
+            "initiatorType": "link",
+            "transferSize": 0,
+            "encodedBodySize": 3946,
+            "decodedBodySize": 18292
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/ec.0vx5m.js",
+            "entryType": "resource",
+            "startTime": 15.600000008940697,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 1168,
+            "decodedBodySize": 2523
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/TwoColumnContent.astro_astro_type_script_index_0_lang.DPGAuL8N.js",
+            "entryType": "resource",
+            "startTime": 15.600000008940697,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 269,
+            "decodedBodySize": 452
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/PageFrame.astro_astro_type_script_index_0_lang.iwTubUja.js",
+            "entryType": "resource",
+            "startTime": 15.700000002980232,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 257,
+            "decodedBodySize": 392
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/print.ehPL0gv-.css",
+            "entryType": "resource",
+            "startTime": 19.5,
+            "duration": 0,
+            "initiatorType": "link",
+            "transferSize": 0,
+            "encodedBodySize": 996,
+            "decodedBodySize": 3318
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/preload-helper.BnKG7j8P.js",
+            "entryType": "resource",
+            "startTime": 26.200000002980232,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 737,
+            "decodedBodySize": 1351
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/starlight-toc.CTCQXEge.js",
+            "entryType": "resource",
+            "startTime": 26.400000005960464,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 951,
+            "decodedBodySize": 1981
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/persistent-toggle.t6KkBAiq.js",
+            "entryType": "resource",
+            "startTime": 26.5,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 705,
+            "decodedBodySize": 2082
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/runtime-client.CDKwXtrO.js",
+            "entryType": "resource",
+            "startTime": 48.70000000298023,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 9696,
+            "decodedBodySize": 29967
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/rolldown-runtime.hePW80VL.js",
+            "entryType": "resource",
+            "startTime": 48.80000001192093,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 430,
+            "decodedBodySize": 716
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/output-limits.BuPdYbfn.js",
+            "entryType": "resource",
+            "startTime": 49,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 584,
+            "decodedBodySize": 1017
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/InteractiveCell.Ccnnhmwl.js",
+            "entryType": "resource",
+            "startTime": 54.70000000298023,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 8135,
+            "decodedBodySize": 22927
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/client.BJAMOzhD.js",
+            "entryType": "resource",
+            "startTime": 54.900000005960464,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 814,
+            "decodedBodySize": 1412
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/preact.Bl7PEaKa.js",
+            "entryType": "resource",
+            "startTime": 55.900000005960464,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 4413,
+            "decodedBodySize": 10470
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/runtime-localization.vhNiaX9V.js",
+            "entryType": "resource",
+            "startTime": 56,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 3198,
+            "decodedBodySize": 8034
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/hooks.ClbWuNs9.js",
+            "entryType": "resource",
+            "startTime": 56.1000000089407,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 1153,
+            "decodedBodySize": 2677
+          },
+          {
+            "name": "oxiquill:worker-start:python",
+            "entryType": "mark",
+            "startTime": 56.30000001192093,
+            "duration": 0
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/favicon.svg",
+            "entryType": "resource",
+            "startTime": 62.6000000089407,
+            "duration": 1.2000000029802322,
+            "initiatorType": "other",
+            "transferSize": 0,
+            "encodedBodySize": 259,
+            "decodedBodySize": 331
+          },
+          {
+            "name": "oxiquill:hydrated:features__rich-output__python-rich-outputs",
+            "entryType": "mark",
+            "startTime": 64.1000000089407,
+            "duration": 0
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/python-worker-DetX1Kyh.js",
+            "entryType": "resource",
+            "startTime": 67.6000000089407,
+            "duration": -9.299999997019768,
+            "initiatorType": "other",
+            "transferSize": 0,
+            "encodedBodySize": 13170,
+            "decodedBodySize": 48070
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/ui-core.BwVUYzUq.js",
+            "entryType": "resource",
+            "startTime": 79.80000001192093,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 26119,
+            "decodedBodySize": 93799
+          },
+          {
+            "name": "oxiquill:output-rendered:features__rich-output__python-rich-outputs",
+            "entryType": "mark",
+            "startTime": 5749.5,
+            "duration": 0
+          }
+        ]
+      },
+      "workers": [
+        {
+          "timeOrigin": 1788593053584.5,
+          "entries": [
+            {
+              "name": "oxiquill:worker-ready:python",
+              "entryType": "mark",
+              "startTime": 3,
+              "duration": 0
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pyodide.mjs",
+              "entryType": "resource",
+              "startTime": 5.299999997019768,
+              "duration": 1.0999999940395355,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 7156,
+              "decodedBodySize": 17931
+            },
+            {
+              "name": "oxiquill:initialization:python",
+              "entryType": "measure",
+              "startTime": 9.399999991059303,
+              "duration": 2245.5
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pyodide-lock.json",
+              "entryType": "resource",
+              "startTime": 9.700000002980232,
+              "duration": 1.5,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 26534,
+              "decodedBodySize": 114440
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/python_stdlib.zip",
+              "entryType": "resource",
+              "startTime": 10.200000002980232,
+              "duration": 17,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 2503174,
+              "decodedBodySize": 2545564
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pyodide.asm.wasm",
+              "entryType": "resource",
+              "startTime": 10.399999991059303,
+              "duration": 144.6000000089407,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 3546129,
+              "decodedBodySize": 9598218
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pyodide.asm.mjs",
+              "entryType": "resource",
+              "startTime": 10.700000002980232,
+              "duration": 8.899999991059303,
+              "initiatorType": "script",
+              "transferSize": 0,
+              "encodedBodySize": 260107,
+              "decodedBodySize": 1250344
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/matplotlib-3.10.8-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 79.8999999910593,
+              "duration": 80.1000000089407,
+              "initiatorType": "fetch",
+              "transferSize": 6867585,
+              "encodedBodySize": 6867285,
+              "decodedBodySize": 6982033
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/contourpy-1.3.3-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 80.20000000298023,
+              "duration": 17.19999998807907,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 117120,
+              "decodedBodySize": 118875
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/numpy-2.4.6-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 80.3999999910593,
+              "duration": 56,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 2882682,
+              "decodedBodySize": 2918760
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/cycler-0.12.1-py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 80.5,
+              "duration": 11.899999991059303,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 7794,
+              "decodedBodySize": 8321
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/six-1.17.0-py2.py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 80.59999999403954,
+              "duration": 15.400000005960464,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 10640,
+              "decodedBodySize": 11050
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/fonttools-4.62.1-py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 80.70000000298023,
+              "duration": 37.599999994039536,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 1124539,
+              "decodedBodySize": 1152647
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/kiwisolver-1.5.0-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 80.79999999701977,
+              "duration": 16.799999997019768,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 35887,
+              "decodedBodySize": 36616
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/packaging-26.1-py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 80.8999999910593,
+              "duration": 17.700000002980232,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 94197,
+              "decodedBodySize": 95852
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pillow-12.2.0-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 81.09999999403954,
+              "duration": 35.1000000089407,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 1029176,
+              "decodedBodySize": 1037807
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pyparsing-3.3.2-py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 81.20000000298023,
+              "duration": 18.399999991059303,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 121160,
+              "decodedBodySize": 122781
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/python_dateutil-2.9.0.post0-py2.py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 81.29999999701977,
+              "duration": 21.200000002980232,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 228238,
+              "decodedBodySize": 229892
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pytz-2026.1.post1-py2.py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 81.5,
+              "duration": 24.099999994039536,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 377648,
+              "decodedBodySize": 510489
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pandas-3.0.2-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 81.59999999403954,
+              "duration": 64.40000000596046,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 4141666,
+              "decodedBodySize": 4177814
+            },
+            {
+              "name": "oxiquill:display-support:python",
+              "entryType": "measure",
+              "startTime": 2254.8999999910593,
+              "duration": 23.400000005960464
+            },
+            {
+              "name": "oxiquill:imports:features__rich-output__python-rich-outputs",
+              "entryType": "measure",
+              "startTime": 2278.5999999940395,
+              "duration": 1.6000000089406967
+            },
+            {
+              "name": "oxiquill:display-prepare:features__rich-output__python-rich-outputs",
+              "entryType": "measure",
+              "startTime": 2280.2000000029802,
+              "duration": 0.5
+            },
+            {
+              "name": "oxiquill:execution:features__rich-output__python-rich-outputs",
+              "entryType": "measure",
+              "startTime": 2280.8999999910593,
+              "duration": 3285.1000000089407
+            },
+            {
+              "name": "oxiquill:display-collect:features__rich-output__python-rich-outputs",
+              "entryType": "measure",
+              "startTime": 5566.899999991059,
+              "duration": 111.6000000089407
+            }
+          ]
+        }
+      ],
+      "observed": {
+        "requests": [
+          {
+            "requestId": 2,
+            "at": 1788593053671.7
+          }
+        ],
+        "responses": [
+          {
+            "requestId": 2,
+            "at": 1788593059270.5999,
+            "ok": true
+          }
+        ]
+      }
+    },
+    {
+      "example": "features/rich-output/",
+      "condition": "repeat",
+      "run": 4,
+      "triggerMs": 5801.300000011921,
+      "outputMs": 5920.800000011921,
+      "latencyMs": 119.5,
+      "renderObserverDeltaMs": -2.199951171875,
+      "main": {
+        "timeOrigin": 1788593053518.4,
+        "entries": [
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/index.DANjJwMU.css",
+            "entryType": "resource",
+            "startTime": 15.100000008940697,
+            "duration": 0,
+            "initiatorType": "link",
+            "transferSize": 0,
+            "encodedBodySize": 21609,
+            "decodedBodySize": 105367
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/page.B1wUxXOO.js",
+            "entryType": "resource",
+            "startTime": 15.300000011920929,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 1581,
+            "decodedBodySize": 3458
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/Search.astro_astro_type_script_index_0_lang.DzL-jWp_.js",
+            "entryType": "resource",
+            "startTime": 15.300000011920929,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 945,
+            "decodedBodySize": 1830
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/MobileTableOfContents.astro_astro_type_script_index_0_lang.BcSo_yiZ.js",
+            "entryType": "resource",
+            "startTime": 15.400000005960464,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 364,
+            "decodedBodySize": 622
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/TableOfContents.astro_astro_type_script_index_0_lang.Csloo1VZ.js",
+            "entryType": "resource",
+            "startTime": 15.5,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 56,
+            "decodedBodySize": 36
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/ec.w36nc.css",
+            "entryType": "resource",
+            "startTime": 15.5,
+            "duration": 0,
+            "initiatorType": "link",
+            "transferSize": 0,
+            "encodedBodySize": 3946,
+            "decodedBodySize": 18292
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/ec.0vx5m.js",
+            "entryType": "resource",
+            "startTime": 15.600000008940697,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 1168,
+            "decodedBodySize": 2523
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/TwoColumnContent.astro_astro_type_script_index_0_lang.DPGAuL8N.js",
+            "entryType": "resource",
+            "startTime": 15.600000008940697,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 269,
+            "decodedBodySize": 452
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/PageFrame.astro_astro_type_script_index_0_lang.iwTubUja.js",
+            "entryType": "resource",
+            "startTime": 15.700000002980232,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 257,
+            "decodedBodySize": 392
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/print.ehPL0gv-.css",
+            "entryType": "resource",
+            "startTime": 19.5,
+            "duration": 0,
+            "initiatorType": "link",
+            "transferSize": 0,
+            "encodedBodySize": 996,
+            "decodedBodySize": 3318
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/preload-helper.BnKG7j8P.js",
+            "entryType": "resource",
+            "startTime": 26.200000002980232,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 737,
+            "decodedBodySize": 1351
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/starlight-toc.CTCQXEge.js",
+            "entryType": "resource",
+            "startTime": 26.400000005960464,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 951,
+            "decodedBodySize": 1981
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/persistent-toggle.t6KkBAiq.js",
+            "entryType": "resource",
+            "startTime": 26.5,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 705,
+            "decodedBodySize": 2082
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/runtime-client.CDKwXtrO.js",
+            "entryType": "resource",
+            "startTime": 48.70000000298023,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 9696,
+            "decodedBodySize": 29967
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/rolldown-runtime.hePW80VL.js",
+            "entryType": "resource",
+            "startTime": 48.80000001192093,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 430,
+            "decodedBodySize": 716
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/output-limits.BuPdYbfn.js",
+            "entryType": "resource",
+            "startTime": 49,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 584,
+            "decodedBodySize": 1017
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/InteractiveCell.Ccnnhmwl.js",
+            "entryType": "resource",
+            "startTime": 54.70000000298023,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 8135,
+            "decodedBodySize": 22927
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/client.BJAMOzhD.js",
+            "entryType": "resource",
+            "startTime": 54.900000005960464,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 814,
+            "decodedBodySize": 1412
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/preact.Bl7PEaKa.js",
+            "entryType": "resource",
+            "startTime": 55.900000005960464,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 4413,
+            "decodedBodySize": 10470
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/runtime-localization.vhNiaX9V.js",
+            "entryType": "resource",
+            "startTime": 56,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 3198,
+            "decodedBodySize": 8034
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/hooks.ClbWuNs9.js",
+            "entryType": "resource",
+            "startTime": 56.1000000089407,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 1153,
+            "decodedBodySize": 2677
+          },
+          {
+            "name": "oxiquill:worker-start:python",
+            "entryType": "mark",
+            "startTime": 56.30000001192093,
+            "duration": 0
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/favicon.svg",
+            "entryType": "resource",
+            "startTime": 62.6000000089407,
+            "duration": 1.2000000029802322,
+            "initiatorType": "other",
+            "transferSize": 0,
+            "encodedBodySize": 259,
+            "decodedBodySize": 331
+          },
+          {
+            "name": "oxiquill:hydrated:features__rich-output__python-rich-outputs",
+            "entryType": "mark",
+            "startTime": 64.1000000089407,
+            "duration": 0
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/python-worker-DetX1Kyh.js",
+            "entryType": "resource",
+            "startTime": 67.6000000089407,
+            "duration": -9.299999997019768,
+            "initiatorType": "other",
+            "transferSize": 0,
+            "encodedBodySize": 13170,
+            "decodedBodySize": 48070
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/ui-core.BwVUYzUq.js",
+            "entryType": "resource",
+            "startTime": 79.80000001192093,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 26119,
+            "decodedBodySize": 93799
+          },
+          {
+            "name": "oxiquill:output-rendered:features__rich-output__python-rich-outputs",
+            "entryType": "mark",
+            "startTime": 5920.800000011921,
+            "duration": 0
+          }
+        ]
+      },
+      "workers": [
+        {
+          "timeOrigin": 1788593053584.5,
+          "entries": [
+            {
+              "name": "oxiquill:worker-ready:python",
+              "entryType": "mark",
+              "startTime": 3,
+              "duration": 0
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pyodide.mjs",
+              "entryType": "resource",
+              "startTime": 5.299999997019768,
+              "duration": 1.0999999940395355,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 7156,
+              "decodedBodySize": 17931
+            },
+            {
+              "name": "oxiquill:initialization:python",
+              "entryType": "measure",
+              "startTime": 9.399999991059303,
+              "duration": 2245.5
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pyodide-lock.json",
+              "entryType": "resource",
+              "startTime": 9.700000002980232,
+              "duration": 1.5,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 26534,
+              "decodedBodySize": 114440
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/python_stdlib.zip",
+              "entryType": "resource",
+              "startTime": 10.200000002980232,
+              "duration": 17,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 2503174,
+              "decodedBodySize": 2545564
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pyodide.asm.wasm",
+              "entryType": "resource",
+              "startTime": 10.399999991059303,
+              "duration": 144.6000000089407,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 3546129,
+              "decodedBodySize": 9598218
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pyodide.asm.mjs",
+              "entryType": "resource",
+              "startTime": 10.700000002980232,
+              "duration": 8.899999991059303,
+              "initiatorType": "script",
+              "transferSize": 0,
+              "encodedBodySize": 260107,
+              "decodedBodySize": 1250344
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/matplotlib-3.10.8-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 79.8999999910593,
+              "duration": 80.1000000089407,
+              "initiatorType": "fetch",
+              "transferSize": 6867585,
+              "encodedBodySize": 6867285,
+              "decodedBodySize": 6982033
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/contourpy-1.3.3-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 80.20000000298023,
+              "duration": 17.19999998807907,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 117120,
+              "decodedBodySize": 118875
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/numpy-2.4.6-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 80.3999999910593,
+              "duration": 56,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 2882682,
+              "decodedBodySize": 2918760
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/cycler-0.12.1-py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 80.5,
+              "duration": 11.899999991059303,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 7794,
+              "decodedBodySize": 8321
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/six-1.17.0-py2.py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 80.59999999403954,
+              "duration": 15.400000005960464,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 10640,
+              "decodedBodySize": 11050
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/fonttools-4.62.1-py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 80.70000000298023,
+              "duration": 37.599999994039536,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 1124539,
+              "decodedBodySize": 1152647
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/kiwisolver-1.5.0-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 80.79999999701977,
+              "duration": 16.799999997019768,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 35887,
+              "decodedBodySize": 36616
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/packaging-26.1-py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 80.8999999910593,
+              "duration": 17.700000002980232,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 94197,
+              "decodedBodySize": 95852
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pillow-12.2.0-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 81.09999999403954,
+              "duration": 35.1000000089407,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 1029176,
+              "decodedBodySize": 1037807
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pyparsing-3.3.2-py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 81.20000000298023,
+              "duration": 18.399999991059303,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 121160,
+              "decodedBodySize": 122781
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/python_dateutil-2.9.0.post0-py2.py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 81.29999999701977,
+              "duration": 21.200000002980232,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 228238,
+              "decodedBodySize": 229892
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pytz-2026.1.post1-py2.py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 81.5,
+              "duration": 24.099999994039536,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 377648,
+              "decodedBodySize": 510489
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pandas-3.0.2-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 81.59999999403954,
+              "duration": 64.40000000596046,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 4141666,
+              "decodedBodySize": 4177814
+            },
+            {
+              "name": "oxiquill:display-support:python",
+              "entryType": "measure",
+              "startTime": 2254.8999999910593,
+              "duration": 23.400000005960464
+            },
+            {
+              "name": "oxiquill:imports:features__rich-output__python-rich-outputs",
+              "entryType": "measure",
+              "startTime": 5769.70000000298,
+              "duration": 0.699999988079071
+            },
+            {
+              "name": "oxiquill:display-prepare:features__rich-output__python-rich-outputs",
+              "entryType": "measure",
+              "startTime": 5770.399999991059,
+              "duration": 0.4000000059604645
+            },
+            {
+              "name": "oxiquill:execution:features__rich-output__python-rich-outputs",
+              "entryType": "measure",
+              "startTime": 5770.899999991059,
+              "duration": 12.5
+            },
+            {
+              "name": "oxiquill:display-collect:features__rich-output__python-rich-outputs",
+              "entryType": "measure",
+              "startTime": 5784.20000000298,
+              "duration": 68.8999999910593
+            }
+          ]
+        }
+      ],
+      "observed": {
+        "requests": [
+          {
+            "requestId": 2,
+            "at": 1788593053671.7
+          },
+          {
+            "requestId": 3,
+            "at": 1788593059353.9
+          }
+        ],
+        "responses": [
+          {
+            "requestId": 2,
+            "at": 1788593059270.5999,
+            "ok": true
+          },
+          {
+            "requestId": 3,
+            "at": 1788593059441.4,
+            "ok": true
+          }
+        ]
+      }
+    },
+    {
+      "example": "features/rich-output/",
+      "condition": "fresh",
+      "run": 5,
+      "triggerMs": 172.90000000596046,
+      "outputMs": 5779.29999999702,
+      "latencyMs": 5779.29999999702,
+      "renderObserverDeltaMs": -3,
+      "main": {
+        "timeOrigin": 1788593059511.7,
+        "entries": [
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/index.DANjJwMU.css",
+            "entryType": "resource",
+            "startTime": 5.600000008940697,
+            "duration": 2.699999988079071,
+            "initiatorType": "link",
+            "transferSize": 21909,
+            "encodedBodySize": 21609,
+            "decodedBodySize": 105367
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/ec.w36nc.css",
+            "entryType": "resource",
+            "startTime": 5.9000000059604645,
+            "duration": 8,
+            "initiatorType": "link",
+            "transferSize": 4246,
+            "encodedBodySize": 3946,
+            "decodedBodySize": 18292
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/page.B1wUxXOO.js",
+            "entryType": "resource",
+            "startTime": 5.9000000059604645,
+            "duration": 8.299999997019768,
+            "initiatorType": "script",
+            "transferSize": 1881,
+            "encodedBodySize": 1581,
+            "decodedBodySize": 3458
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/Search.astro_astro_type_script_index_0_lang.DzL-jWp_.js",
+            "entryType": "resource",
+            "startTime": 5.9000000059604645,
+            "duration": 8.5,
+            "initiatorType": "script",
+            "transferSize": 1245,
+            "encodedBodySize": 945,
+            "decodedBodySize": 1830
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/MobileTableOfContents.astro_astro_type_script_index_0_lang.BcSo_yiZ.js",
+            "entryType": "resource",
+            "startTime": 5.9000000059604645,
+            "duration": 8.599999994039536,
+            "initiatorType": "script",
+            "transferSize": 664,
+            "encodedBodySize": 364,
+            "decodedBodySize": 622
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/TableOfContents.astro_astro_type_script_index_0_lang.Csloo1VZ.js",
+            "entryType": "resource",
+            "startTime": 5.9000000059604645,
+            "duration": 8.700000002980232,
+            "initiatorType": "script",
+            "transferSize": 356,
+            "encodedBodySize": 56,
+            "decodedBodySize": 36
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/ec.0vx5m.js",
+            "entryType": "resource",
+            "startTime": 6,
+            "duration": 8.700000002980232,
+            "initiatorType": "script",
+            "transferSize": 1468,
+            "encodedBodySize": 1168,
+            "decodedBodySize": 2523
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/TwoColumnContent.astro_astro_type_script_index_0_lang.DPGAuL8N.js",
+            "entryType": "resource",
+            "startTime": 6,
+            "duration": 12,
+            "initiatorType": "script",
+            "transferSize": 569,
+            "encodedBodySize": 269,
+            "decodedBodySize": 452
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/PageFrame.astro_astro_type_script_index_0_lang.iwTubUja.js",
+            "entryType": "resource",
+            "startTime": 6,
+            "duration": 12.900000005960464,
+            "initiatorType": "script",
+            "transferSize": 557,
+            "encodedBodySize": 257,
+            "decodedBodySize": 392
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/print.ehPL0gv-.css",
+            "entryType": "resource",
+            "startTime": 9.799999997019768,
+            "duration": 9.200000002980232,
+            "initiatorType": "link",
+            "transferSize": 1296,
+            "encodedBodySize": 996,
+            "decodedBodySize": 3318
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/preload-helper.BnKG7j8P.js",
+            "entryType": "resource",
+            "startTime": 58.400000005960464,
+            "duration": 3.5,
+            "initiatorType": "script",
+            "transferSize": 1037,
+            "encodedBodySize": 737,
+            "decodedBodySize": 1351
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/starlight-toc.CTCQXEge.js",
+            "entryType": "resource",
+            "startTime": 58.5,
+            "duration": 3.6000000089406967,
+            "initiatorType": "script",
+            "transferSize": 1251,
+            "encodedBodySize": 951,
+            "decodedBodySize": 1981
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/persistent-toggle.t6KkBAiq.js",
+            "entryType": "resource",
+            "startTime": 58.6000000089407,
+            "duration": 3.699999988079071,
+            "initiatorType": "script",
+            "transferSize": 1005,
+            "encodedBodySize": 705,
+            "decodedBodySize": 2082
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/runtime-client.CDKwXtrO.js",
+            "entryType": "resource",
+            "startTime": 63.6000000089407,
+            "duration": 4.399999991059303,
+            "initiatorType": "script",
+            "transferSize": 9996,
+            "encodedBodySize": 9696,
+            "decodedBodySize": 29967
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/rolldown-runtime.hePW80VL.js",
+            "entryType": "resource",
+            "startTime": 63.900000005960464,
+            "duration": 3.7999999970197678,
+            "initiatorType": "script",
+            "transferSize": 730,
+            "encodedBodySize": 430,
+            "decodedBodySize": 716
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/output-limits.BuPdYbfn.js",
+            "entryType": "resource",
+            "startTime": 64,
+            "duration": 3.7999999970197678,
+            "initiatorType": "script",
+            "transferSize": 884,
+            "encodedBodySize": 584,
+            "decodedBodySize": 1017
+          },
+          {
+            "name": "oxiquill:worker-start:python",
+            "entryType": "mark",
+            "startTime": 71.1000000089407,
+            "duration": 0
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/favicon.svg",
+            "entryType": "resource",
+            "startTime": 71.6000000089407,
+            "duration": 1.699999988079071,
+            "initiatorType": "other",
+            "transferSize": 559,
+            "encodedBodySize": 259,
+            "decodedBodySize": 331
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/python-worker-DetX1Kyh.js",
+            "entryType": "resource",
+            "startTime": 88.90000000596046,
+            "duration": -13.700000002980232,
+            "initiatorType": "other",
+            "transferSize": 13470,
+            "encodedBodySize": 13170,
+            "decodedBodySize": 48070
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/ui-core.BwVUYzUq.js",
+            "entryType": "resource",
+            "startTime": 95.90000000596046,
+            "duration": 2.8999999910593033,
+            "initiatorType": "script",
+            "transferSize": 26419,
+            "encodedBodySize": 26119,
+            "decodedBodySize": 93799
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/InteractiveCell.Ccnnhmwl.js",
+            "entryType": "resource",
+            "startTime": 156.90000000596046,
+            "duration": 3.2000000029802322,
+            "initiatorType": "script",
+            "transferSize": 8435,
+            "encodedBodySize": 8135,
+            "decodedBodySize": 22927
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/client.BJAMOzhD.js",
+            "entryType": "resource",
+            "startTime": 157,
+            "duration": 3,
+            "initiatorType": "script",
+            "transferSize": 1114,
+            "encodedBodySize": 814,
+            "decodedBodySize": 1412
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/preact.Bl7PEaKa.js",
+            "entryType": "resource",
+            "startTime": 161.20000000298023,
+            "duration": 3.7999999970197678,
+            "initiatorType": "script",
+            "transferSize": 4713,
+            "encodedBodySize": 4413,
+            "decodedBodySize": 10470
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/hooks.ClbWuNs9.js",
+            "entryType": "resource",
+            "startTime": 161.29999999701977,
+            "duration": 3.7000000029802322,
+            "initiatorType": "script",
+            "transferSize": 1453,
+            "encodedBodySize": 1153,
+            "decodedBodySize": 2677
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/runtime-localization.vhNiaX9V.js",
+            "entryType": "resource",
+            "startTime": 161.29999999701977,
+            "duration": 3.6000000089406967,
+            "initiatorType": "script",
+            "transferSize": 3498,
+            "encodedBodySize": 3198,
+            "decodedBodySize": 8034
+          },
+          {
+            "name": "oxiquill:hydrated:features__rich-output__python-rich-outputs",
+            "entryType": "mark",
+            "startTime": 168.6000000089407,
+            "duration": 0
+          },
+          {
+            "name": "oxiquill:output-rendered:features__rich-output__python-rich-outputs",
+            "entryType": "mark",
+            "startTime": 5779.29999999702,
+            "duration": 0
+          }
+        ]
+      },
+      "workers": [
+        {
+          "timeOrigin": 1788593059598.7,
+          "entries": [
+            {
+              "name": "oxiquill:worker-ready:python",
+              "entryType": "mark",
+              "startTime": 3.3999999910593033,
+              "duration": 0
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pyodide.mjs",
+              "entryType": "resource",
+              "startTime": 5.5999999940395355,
+              "duration": 1.7000000029802322,
+              "initiatorType": "fetch",
+              "transferSize": 7456,
+              "encodedBodySize": 7156,
+              "decodedBodySize": 17931
+            },
+            {
+              "name": "oxiquill:initialization:python",
+              "entryType": "measure",
+              "startTime": 10.199999988079071,
+              "duration": 2271.300000011921
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pyodide-lock.json",
+              "entryType": "resource",
+              "startTime": 10.599999994039536,
+              "duration": 6.5,
+              "initiatorType": "fetch",
+              "transferSize": 26834,
+              "encodedBodySize": 26534,
+              "decodedBodySize": 114440
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/python_stdlib.zip",
+              "entryType": "resource",
+              "startTime": 10.899999991059303,
+              "duration": 24.400000005960464,
+              "initiatorType": "fetch",
+              "transferSize": 2503474,
+              "encodedBodySize": 2503174,
+              "decodedBodySize": 2545564
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pyodide.asm.wasm",
+              "entryType": "resource",
+              "startTime": 11.199999988079071,
+              "duration": 179,
+              "initiatorType": "fetch",
+              "transferSize": 3546429,
+              "encodedBodySize": 3546129,
+              "decodedBodySize": 9598218
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pyodide.asm.mjs",
+              "entryType": "resource",
+              "startTime": 11.299999997019768,
+              "duration": 13.700000002980232,
+              "initiatorType": "script",
+              "transferSize": 260407,
+              "encodedBodySize": 260107,
+              "decodedBodySize": 1250344
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/matplotlib-3.10.8-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 89.59999999403954,
+              "duration": 110.09999999403954,
+              "initiatorType": "fetch",
+              "transferSize": 6867585,
+              "encodedBodySize": 6867285,
+              "decodedBodySize": 6982033
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/contourpy-1.3.3-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 89.79999999701977,
+              "duration": 9.899999991059303,
+              "initiatorType": "fetch",
+              "transferSize": 117420,
+              "encodedBodySize": 117120,
+              "decodedBodySize": 118875
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/numpy-2.4.6-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 90,
+              "duration": 71.8999999910593,
+              "initiatorType": "fetch",
+              "transferSize": 2882982,
+              "encodedBodySize": 2882682,
+              "decodedBodySize": 2918760
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/cycler-0.12.1-py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 90.19999998807907,
+              "duration": 7.4000000059604645,
+              "initiatorType": "fetch",
+              "transferSize": 8094,
+              "encodedBodySize": 7794,
+              "decodedBodySize": 8321
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/six-1.17.0-py2.py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 90.29999999701977,
+              "duration": 7.5,
+              "initiatorType": "fetch",
+              "transferSize": 10940,
+              "encodedBodySize": 10640,
+              "decodedBodySize": 11050
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/fonttools-4.62.1-py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 90.3999999910593,
+              "duration": 45.29999999701977,
+              "initiatorType": "fetch",
+              "transferSize": 1124839,
+              "encodedBodySize": 1124539,
+              "decodedBodySize": 1152647
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/kiwisolver-1.5.0-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 90.5,
+              "duration": 14.199999988079071,
+              "initiatorType": "fetch",
+              "transferSize": 36187,
+              "encodedBodySize": 35887,
+              "decodedBodySize": 36616
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/packaging-26.1-py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 90.69999998807907,
+              "duration": 17.200000002980232,
+              "initiatorType": "fetch",
+              "transferSize": 94497,
+              "encodedBodySize": 94197,
+              "decodedBodySize": 95852
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pillow-12.2.0-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 91.29999999701977,
+              "duration": 49.29999999701977,
+              "initiatorType": "fetch",
+              "transferSize": 1029476,
+              "encodedBodySize": 1029176,
+              "decodedBodySize": 1037807
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pyparsing-3.3.2-py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 91.5,
+              "duration": 22.299999997019768,
+              "initiatorType": "fetch",
+              "transferSize": 121460,
+              "encodedBodySize": 121160,
+              "decodedBodySize": 122781
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/python_dateutil-2.9.0.post0-py2.py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 91.59999999403954,
+              "duration": 30.400000005960464,
+              "initiatorType": "fetch",
+              "transferSize": 228538,
+              "encodedBodySize": 228238,
+              "decodedBodySize": 229892
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pytz-2026.1.post1-py2.py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 91.69999998807907,
+              "duration": 46.5,
+              "initiatorType": "fetch",
+              "transferSize": 377948,
+              "encodedBodySize": 377648,
+              "decodedBodySize": 510489
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pandas-3.0.2-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 91.8999999910593,
+              "duration": 102.90000000596046,
+              "initiatorType": "fetch",
+              "transferSize": 4141966,
+              "encodedBodySize": 4141666,
+              "decodedBodySize": 4177814
+            },
+            {
+              "name": "oxiquill:display-support:python",
+              "entryType": "measure",
+              "startTime": 2281.5,
+              "duration": 21.399999991059303
+            },
+            {
+              "name": "oxiquill:imports:features__rich-output__python-rich-outputs",
+              "entryType": "measure",
+              "startTime": 2303,
+              "duration": 1.699999988079071
+            },
+            {
+              "name": "oxiquill:display-prepare:features__rich-output__python-rich-outputs",
+              "entryType": "measure",
+              "startTime": 2304.699999988079,
+              "duration": 0.5
+            },
+            {
+              "name": "oxiquill:execution:features__rich-output__python-rich-outputs",
+              "entryType": "measure",
+              "startTime": 2305.3999999910593,
+              "duration": 3260
+            },
+            {
+              "name": "oxiquill:display-collect:features__rich-output__python-rich-outputs",
+              "entryType": "measure",
+              "startTime": 5566.5999999940395,
+              "duration": 111.59999999403954
+            }
+          ]
+        }
+      ],
+      "observed": {
+        "requests": [
+          {
+            "requestId": 2,
+            "at": 1788593059721.3
+          }
+        ],
+        "responses": [
+          {
+            "requestId": 2,
+            "at": 1788593065294,
+            "ok": true
+          }
+        ]
+      }
+    },
+    {
+      "example": "features/rich-output/",
+      "condition": "reload",
+      "run": 5,
+      "triggerMs": 107.70000000298023,
+      "outputMs": 5675.5999999940395,
+      "latencyMs": 5675.5999999940395,
+      "renderObserverDeltaMs": -2.7998046875,
+      "main": {
+        "timeOrigin": 1788593065311.5,
+        "entries": [
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/index.DANjJwMU.css",
+            "entryType": "resource",
+            "startTime": 14.799999997019768,
+            "duration": 0,
+            "initiatorType": "link",
+            "transferSize": 0,
+            "encodedBodySize": 21609,
+            "decodedBodySize": 105367
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/page.B1wUxXOO.js",
+            "entryType": "resource",
+            "startTime": 15,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 1581,
+            "decodedBodySize": 3458
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/Search.astro_astro_type_script_index_0_lang.DzL-jWp_.js",
+            "entryType": "resource",
+            "startTime": 15,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 945,
+            "decodedBodySize": 1830
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/MobileTableOfContents.astro_astro_type_script_index_0_lang.BcSo_yiZ.js",
+            "entryType": "resource",
+            "startTime": 15.099999994039536,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 364,
+            "decodedBodySize": 622
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/TableOfContents.astro_astro_type_script_index_0_lang.Csloo1VZ.js",
+            "entryType": "resource",
+            "startTime": 15.099999994039536,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 56,
+            "decodedBodySize": 36
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/ec.w36nc.css",
+            "entryType": "resource",
+            "startTime": 15.200000002980232,
+            "duration": 0,
+            "initiatorType": "link",
+            "transferSize": 0,
+            "encodedBodySize": 3946,
+            "decodedBodySize": 18292
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/ec.0vx5m.js",
+            "entryType": "resource",
+            "startTime": 15.299999997019768,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 1168,
+            "decodedBodySize": 2523
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/TwoColumnContent.astro_astro_type_script_index_0_lang.DPGAuL8N.js",
+            "entryType": "resource",
+            "startTime": 15.299999997019768,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 269,
+            "decodedBodySize": 452
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/PageFrame.astro_astro_type_script_index_0_lang.iwTubUja.js",
+            "entryType": "resource",
+            "startTime": 15.399999991059303,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 257,
+            "decodedBodySize": 392
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/print.ehPL0gv-.css",
+            "entryType": "resource",
+            "startTime": 19.299999997019768,
+            "duration": 0,
+            "initiatorType": "link",
+            "transferSize": 0,
+            "encodedBodySize": 996,
+            "decodedBodySize": 3318
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/preload-helper.BnKG7j8P.js",
+            "entryType": "resource",
+            "startTime": 25.700000002980232,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 737,
+            "decodedBodySize": 1351
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/starlight-toc.CTCQXEge.js",
+            "entryType": "resource",
+            "startTime": 26,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 951,
+            "decodedBodySize": 1981
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/persistent-toggle.t6KkBAiq.js",
+            "entryType": "resource",
+            "startTime": 26.099999994039536,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 705,
+            "decodedBodySize": 2082
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/runtime-client.CDKwXtrO.js",
+            "entryType": "resource",
+            "startTime": 26.599999994039536,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 9696,
+            "decodedBodySize": 29967
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/rolldown-runtime.hePW80VL.js",
+            "entryType": "resource",
+            "startTime": 26.899999991059303,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 430,
+            "decodedBodySize": 716
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/output-limits.BuPdYbfn.js",
+            "entryType": "resource",
+            "startTime": 26.899999991059303,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 584,
+            "decodedBodySize": 1017
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/InteractiveCell.Ccnnhmwl.js",
+            "entryType": "resource",
+            "startTime": 54,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 8135,
+            "decodedBodySize": 22927
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/client.BJAMOzhD.js",
+            "entryType": "resource",
+            "startTime": 54.3999999910593,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 814,
+            "decodedBodySize": 1412
+          },
+          {
+            "name": "oxiquill:worker-start:python",
+            "entryType": "mark",
+            "startTime": 56.5,
+            "duration": 0
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/preact.Bl7PEaKa.js",
+            "entryType": "resource",
+            "startTime": 57,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 4413,
+            "decodedBodySize": 10470
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/runtime-localization.vhNiaX9V.js",
+            "entryType": "resource",
+            "startTime": 57.099999994039536,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 3198,
+            "decodedBodySize": 8034
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/hooks.ClbWuNs9.js",
+            "entryType": "resource",
+            "startTime": 57.20000000298023,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 1153,
+            "decodedBodySize": 2677
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/favicon.svg",
+            "entryType": "resource",
+            "startTime": 63.8999999910593,
+            "duration": 1.4000000059604645,
+            "initiatorType": "other",
+            "transferSize": 0,
+            "encodedBodySize": 259,
+            "decodedBodySize": 331
+          },
+          {
+            "name": "oxiquill:hydrated:features__rich-output__python-rich-outputs",
+            "entryType": "mark",
+            "startTime": 65.3999999910593,
+            "duration": 0
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/python-worker-DetX1Kyh.js",
+            "entryType": "resource",
+            "startTime": 66.09999999403954,
+            "duration": -7.799999997019768,
+            "initiatorType": "other",
+            "transferSize": 0,
+            "encodedBodySize": 13170,
+            "decodedBodySize": 48070
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/ui-core.BwVUYzUq.js",
+            "entryType": "resource",
+            "startTime": 87.5,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 26119,
+            "decodedBodySize": 93799
+          },
+          {
+            "name": "oxiquill:output-rendered:features__rich-output__python-rich-outputs",
+            "entryType": "mark",
+            "startTime": 5675.5999999940395,
+            "duration": 0
+          }
+        ]
+      },
+      "workers": [
+        {
+          "timeOrigin": 1788593065376,
+          "entries": [
+            {
+              "name": "oxiquill:worker-ready:python",
+              "entryType": "mark",
+              "startTime": 3.2000000029802322,
+              "duration": 0
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pyodide.mjs",
+              "entryType": "resource",
+              "startTime": 6.0999999940395355,
+              "duration": 1.1000000089406967,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 7156,
+              "decodedBodySize": 17931
+            },
+            {
+              "name": "oxiquill:initialization:python",
+              "entryType": "measure",
+              "startTime": 10.799999997019768,
+              "duration": 2194.2999999970198
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pyodide-lock.json",
+              "entryType": "resource",
+              "startTime": 11.099999994039536,
+              "duration": 1.6000000089406967,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 26534,
+              "decodedBodySize": 114440
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/python_stdlib.zip",
+              "entryType": "resource",
+              "startTime": 11.5,
+              "duration": 17.399999991059303,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 2503174,
+              "decodedBodySize": 2545564
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pyodide.asm.wasm",
+              "entryType": "resource",
+              "startTime": 11.700000002980232,
+              "duration": 143.5,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 3546129,
+              "decodedBodySize": 9598218
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pyodide.asm.mjs",
+              "entryType": "resource",
+              "startTime": 11.899999991059303,
+              "duration": 9.800000011920929,
+              "initiatorType": "script",
+              "transferSize": 0,
+              "encodedBodySize": 260107,
+              "decodedBodySize": 1250344
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/matplotlib-3.10.8-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 80.59999999403954,
+              "duration": 81.5,
+              "initiatorType": "fetch",
+              "transferSize": 6867585,
+              "encodedBodySize": 6867285,
+              "decodedBodySize": 6982033
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/contourpy-1.3.3-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 80.79999999701977,
+              "duration": 15.900000005960464,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 117120,
+              "decodedBodySize": 118875
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/numpy-2.4.6-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 80.8999999910593,
+              "duration": 54.1000000089407,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 2882682,
+              "decodedBodySize": 2918760
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/cycler-0.12.1-py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 81.09999999403954,
+              "duration": 6.100000008940697,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 7794,
+              "decodedBodySize": 8321
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/six-1.17.0-py2.py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 81.20000000298023,
+              "duration": 11.799999997019768,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 10640,
+              "decodedBodySize": 11050
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/fonttools-4.62.1-py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 81.29999999701977,
+              "duration": 35.900000005960464,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 1124539,
+              "decodedBodySize": 1152647
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/kiwisolver-1.5.0-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 81.3999999910593,
+              "duration": 15.5,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 35887,
+              "decodedBodySize": 36616
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/packaging-26.1-py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 81.5,
+              "duration": 16.399999991059303,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 94197,
+              "decodedBodySize": 95852
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pillow-12.2.0-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 81.59999999403954,
+              "duration": 33.6000000089407,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 1029176,
+              "decodedBodySize": 1037807
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pyparsing-3.3.2-py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 81.70000000298023,
+              "duration": 17.5,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 121160,
+              "decodedBodySize": 122781
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/python_dateutil-2.9.0.post0-py2.py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 81.8999999910593,
+              "duration": 19.80000001192093,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 228238,
+              "decodedBodySize": 229892
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pytz-2026.1.post1-py2.py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 81.8999999910593,
+              "duration": 23.200000002980232,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 377648,
+              "decodedBodySize": 510489
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pandas-3.0.2-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 82.09999999403954,
+              "duration": 62.29999999701977,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 4141666,
+              "decodedBodySize": 4177814
+            },
+            {
+              "name": "oxiquill:display-support:python",
+              "entryType": "measure",
+              "startTime": 2205.2000000029802,
+              "duration": 20.399999991059303
+            },
+            {
+              "name": "oxiquill:imports:features__rich-output__python-rich-outputs",
+              "entryType": "measure",
+              "startTime": 2225.7999999970198,
+              "duration": 1.2999999970197678
+            },
+            {
+              "name": "oxiquill:display-prepare:features__rich-output__python-rich-outputs",
+              "entryType": "measure",
+              "startTime": 2227.0999999940395,
+              "duration": 0.5
+            },
+            {
+              "name": "oxiquill:execution:features__rich-output__python-rich-outputs",
+              "entryType": "measure",
+              "startTime": 2227.7000000029802,
+              "duration": 3249.3999999910593
+            },
+            {
+              "name": "oxiquill:display-collect:features__rich-output__python-rich-outputs",
+              "entryType": "measure",
+              "startTime": 5478.0999999940395,
+              "duration": 128.40000000596046
+            }
+          ]
+        }
+      ],
+      "observed": {
+        "requests": [
+          {
+            "requestId": 2,
+            "at": 1788593065453.7
+          }
+        ],
+        "responses": [
+          {
+            "requestId": 2,
+            "at": 1788593070989.9,
+            "ok": true
+          }
+        ]
+      }
+    },
+    {
+      "example": "features/rich-output/",
+      "condition": "repeat",
+      "run": 5,
+      "triggerMs": 5741.29999999702,
+      "outputMs": 5858.5,
+      "latencyMs": 117.20000000298023,
+      "renderObserverDeltaMs": -2.10009765625,
+      "main": {
+        "timeOrigin": 1788593065311.5,
+        "entries": [
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/index.DANjJwMU.css",
+            "entryType": "resource",
+            "startTime": 14.799999997019768,
+            "duration": 0,
+            "initiatorType": "link",
+            "transferSize": 0,
+            "encodedBodySize": 21609,
+            "decodedBodySize": 105367
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/page.B1wUxXOO.js",
+            "entryType": "resource",
+            "startTime": 15,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 1581,
+            "decodedBodySize": 3458
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/Search.astro_astro_type_script_index_0_lang.DzL-jWp_.js",
+            "entryType": "resource",
+            "startTime": 15,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 945,
+            "decodedBodySize": 1830
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/MobileTableOfContents.astro_astro_type_script_index_0_lang.BcSo_yiZ.js",
+            "entryType": "resource",
+            "startTime": 15.099999994039536,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 364,
+            "decodedBodySize": 622
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/TableOfContents.astro_astro_type_script_index_0_lang.Csloo1VZ.js",
+            "entryType": "resource",
+            "startTime": 15.099999994039536,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 56,
+            "decodedBodySize": 36
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/ec.w36nc.css",
+            "entryType": "resource",
+            "startTime": 15.200000002980232,
+            "duration": 0,
+            "initiatorType": "link",
+            "transferSize": 0,
+            "encodedBodySize": 3946,
+            "decodedBodySize": 18292
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/ec.0vx5m.js",
+            "entryType": "resource",
+            "startTime": 15.299999997019768,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 1168,
+            "decodedBodySize": 2523
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/TwoColumnContent.astro_astro_type_script_index_0_lang.DPGAuL8N.js",
+            "entryType": "resource",
+            "startTime": 15.299999997019768,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 269,
+            "decodedBodySize": 452
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/PageFrame.astro_astro_type_script_index_0_lang.iwTubUja.js",
+            "entryType": "resource",
+            "startTime": 15.399999991059303,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 257,
+            "decodedBodySize": 392
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/print.ehPL0gv-.css",
+            "entryType": "resource",
+            "startTime": 19.299999997019768,
+            "duration": 0,
+            "initiatorType": "link",
+            "transferSize": 0,
+            "encodedBodySize": 996,
+            "decodedBodySize": 3318
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/preload-helper.BnKG7j8P.js",
+            "entryType": "resource",
+            "startTime": 25.700000002980232,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 737,
+            "decodedBodySize": 1351
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/starlight-toc.CTCQXEge.js",
+            "entryType": "resource",
+            "startTime": 26,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 951,
+            "decodedBodySize": 1981
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/persistent-toggle.t6KkBAiq.js",
+            "entryType": "resource",
+            "startTime": 26.099999994039536,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 705,
+            "decodedBodySize": 2082
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/runtime-client.CDKwXtrO.js",
+            "entryType": "resource",
+            "startTime": 26.599999994039536,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 9696,
+            "decodedBodySize": 29967
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/rolldown-runtime.hePW80VL.js",
+            "entryType": "resource",
+            "startTime": 26.899999991059303,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 430,
+            "decodedBodySize": 716
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/output-limits.BuPdYbfn.js",
+            "entryType": "resource",
+            "startTime": 26.899999991059303,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 584,
+            "decodedBodySize": 1017
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/InteractiveCell.Ccnnhmwl.js",
+            "entryType": "resource",
+            "startTime": 54,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 8135,
+            "decodedBodySize": 22927
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/client.BJAMOzhD.js",
+            "entryType": "resource",
+            "startTime": 54.3999999910593,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 814,
+            "decodedBodySize": 1412
+          },
+          {
+            "name": "oxiquill:worker-start:python",
+            "entryType": "mark",
+            "startTime": 56.5,
+            "duration": 0
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/preact.Bl7PEaKa.js",
+            "entryType": "resource",
+            "startTime": 57,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 4413,
+            "decodedBodySize": 10470
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/runtime-localization.vhNiaX9V.js",
+            "entryType": "resource",
+            "startTime": 57.099999994039536,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 3198,
+            "decodedBodySize": 8034
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/hooks.ClbWuNs9.js",
+            "entryType": "resource",
+            "startTime": 57.20000000298023,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 1153,
+            "decodedBodySize": 2677
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/favicon.svg",
+            "entryType": "resource",
+            "startTime": 63.8999999910593,
+            "duration": 1.4000000059604645,
+            "initiatorType": "other",
+            "transferSize": 0,
+            "encodedBodySize": 259,
+            "decodedBodySize": 331
+          },
+          {
+            "name": "oxiquill:hydrated:features__rich-output__python-rich-outputs",
+            "entryType": "mark",
+            "startTime": 65.3999999910593,
+            "duration": 0
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/python-worker-DetX1Kyh.js",
+            "entryType": "resource",
+            "startTime": 66.09999999403954,
+            "duration": -7.799999997019768,
+            "initiatorType": "other",
+            "transferSize": 0,
+            "encodedBodySize": 13170,
+            "decodedBodySize": 48070
+          },
+          {
+            "name": "http://127.0.0.1:34389/oxiquill/_astro/ui-core.BwVUYzUq.js",
+            "entryType": "resource",
+            "startTime": 87.5,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 26119,
+            "decodedBodySize": 93799
+          },
+          {
+            "name": "oxiquill:output-rendered:features__rich-output__python-rich-outputs",
+            "entryType": "mark",
+            "startTime": 5858.5,
+            "duration": 0
+          }
+        ]
+      },
+      "workers": [
+        {
+          "timeOrigin": 1788593065376,
+          "entries": [
+            {
+              "name": "oxiquill:worker-ready:python",
+              "entryType": "mark",
+              "startTime": 3.2000000029802322,
+              "duration": 0
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pyodide.mjs",
+              "entryType": "resource",
+              "startTime": 6.0999999940395355,
+              "duration": 1.1000000089406967,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 7156,
+              "decodedBodySize": 17931
+            },
+            {
+              "name": "oxiquill:initialization:python",
+              "entryType": "measure",
+              "startTime": 10.799999997019768,
+              "duration": 2194.2999999970198
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pyodide-lock.json",
+              "entryType": "resource",
+              "startTime": 11.099999994039536,
+              "duration": 1.6000000089406967,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 26534,
+              "decodedBodySize": 114440
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/python_stdlib.zip",
+              "entryType": "resource",
+              "startTime": 11.5,
+              "duration": 17.399999991059303,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 2503174,
+              "decodedBodySize": 2545564
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pyodide.asm.wasm",
+              "entryType": "resource",
+              "startTime": 11.700000002980232,
+              "duration": 143.5,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 3546129,
+              "decodedBodySize": 9598218
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pyodide.asm.mjs",
+              "entryType": "resource",
+              "startTime": 11.899999991059303,
+              "duration": 9.800000011920929,
+              "initiatorType": "script",
+              "transferSize": 0,
+              "encodedBodySize": 260107,
+              "decodedBodySize": 1250344
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/matplotlib-3.10.8-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 80.59999999403954,
+              "duration": 81.5,
+              "initiatorType": "fetch",
+              "transferSize": 6867585,
+              "encodedBodySize": 6867285,
+              "decodedBodySize": 6982033
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/contourpy-1.3.3-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 80.79999999701977,
+              "duration": 15.900000005960464,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 117120,
+              "decodedBodySize": 118875
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/numpy-2.4.6-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 80.8999999910593,
+              "duration": 54.1000000089407,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 2882682,
+              "decodedBodySize": 2918760
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/cycler-0.12.1-py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 81.09999999403954,
+              "duration": 6.100000008940697,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 7794,
+              "decodedBodySize": 8321
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/six-1.17.0-py2.py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 81.20000000298023,
+              "duration": 11.799999997019768,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 10640,
+              "decodedBodySize": 11050
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/fonttools-4.62.1-py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 81.29999999701977,
+              "duration": 35.900000005960464,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 1124539,
+              "decodedBodySize": 1152647
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/kiwisolver-1.5.0-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 81.3999999910593,
+              "duration": 15.5,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 35887,
+              "decodedBodySize": 36616
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/packaging-26.1-py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 81.5,
+              "duration": 16.399999991059303,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 94197,
+              "decodedBodySize": 95852
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pillow-12.2.0-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 81.59999999403954,
+              "duration": 33.6000000089407,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 1029176,
+              "decodedBodySize": 1037807
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pyparsing-3.3.2-py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 81.70000000298023,
+              "duration": 17.5,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 121160,
+              "decodedBodySize": 122781
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/python_dateutil-2.9.0.post0-py2.py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 81.8999999910593,
+              "duration": 19.80000001192093,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 228238,
+              "decodedBodySize": 229892
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pytz-2026.1.post1-py2.py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 81.8999999910593,
+              "duration": 23.200000002980232,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 377648,
+              "decodedBodySize": 510489
+            },
+            {
+              "name": "http://127.0.0.1:34389/oxiquill/oxiquill/pyodide/pandas-3.0.2-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 82.09999999403954,
+              "duration": 62.29999999701977,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 4141666,
+              "decodedBodySize": 4177814
+            },
+            {
+              "name": "oxiquill:display-support:python",
+              "entryType": "measure",
+              "startTime": 2205.2000000029802,
+              "duration": 20.399999991059303
+            },
+            {
+              "name": "oxiquill:imports:features__rich-output__python-rich-outputs",
+              "entryType": "measure",
+              "startTime": 5710.70000000298,
+              "duration": 0.699999988079071
+            },
+            {
+              "name": "oxiquill:display-prepare:features__rich-output__python-rich-outputs",
+              "entryType": "measure",
+              "startTime": 5711.399999991059,
+              "duration": 0.5
+            },
+            {
+              "name": "oxiquill:execution:features__rich-output__python-rich-outputs",
+              "entryType": "measure",
+              "startTime": 5711.899999991059,
+              "duration": 12.300000011920929
+            },
+            {
+              "name": "oxiquill:display-collect:features__rich-output__python-rich-outputs",
+              "entryType": "measure",
+              "startTime": 5725,
+              "duration": 67.20000000298023
+            }
+          ]
+        }
+      ],
+      "observed": {
+        "requests": [
+          {
+            "requestId": 2,
+            "at": 1788593065453.7
+          },
+          {
+            "requestId": 3,
+            "at": 1788593071086.4
+          }
+        ],
+        "responses": [
+          {
+            "requestId": 2,
+            "at": 1788593070989.9,
+            "ok": true
+          },
+          {
+            "requestId": 3,
+            "at": 1788593071172.1,
+            "ok": true
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/tests/performance/python-startup-before.json
+++ b/tests/performance/python-startup-before.json
@@ -1,0 +1,12541 @@
+{
+  "label": "before",
+  "date": "2026-09-05T06:40:45.610Z",
+  "revision": "4047eb4e4a82be83a7523f417d56d1413a7bee1a",
+  "dirty": true,
+  "browser": "149.0.7827.55",
+  "hardware": {
+    "platform": "linux",
+    "cpu": "12th Gen Intel(R) Core(TM) i7-12700F",
+    "parallelism": 16,
+    "memoryBytes": 25199001600
+  },
+  "network": {
+    "origin": "loopback",
+    "gzip": true,
+    "cacheMaxAgeSeconds": 600,
+    "throttling": false
+  },
+  "base": "/oxiquill/",
+  "runs": 5,
+  "medians": {
+    "features/interactive-cells/:fresh": 1526.5999999940395,
+    "features/interactive-cells/:reload": 1386.3999999910593,
+    "features/interactive-cells/:repeat": 162.90000000596046,
+    "features/rich-output/:fresh": 8998.39999999106,
+    "features/rich-output/:reload": 6444.0999999940395,
+    "features/rich-output/:repeat": 117.90000000596046
+  },
+  "samples": [
+    {
+      "example": "features/interactive-cells/",
+      "condition": "fresh",
+      "run": 1,
+      "triggerMs": 203.59999999403954,
+      "outputMs": 1947,
+      "latencyMs": 1947,
+      "renderObserverDeltaMs": -0.10009765625,
+      "main": {
+        "timeOrigin": 1788590347706.9,
+        "entries": [
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/index.DANjJwMU.css",
+            "entryType": "resource",
+            "startTime": 15.099999994039536,
+            "duration": 8.300000011920929,
+            "initiatorType": "link",
+            "transferSize": 21909,
+            "encodedBodySize": 21609,
+            "decodedBodySize": 105367
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/page.Dwipeu-R.js",
+            "entryType": "resource",
+            "startTime": 15.400000005960464,
+            "duration": 13.899999991059303,
+            "initiatorType": "script",
+            "transferSize": 1424,
+            "encodedBodySize": 1124,
+            "decodedBodySize": 2486
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/Search.astro_astro_type_script_index_0_lang.DzL-jWp_.js",
+            "entryType": "resource",
+            "startTime": 15.5,
+            "duration": 14,
+            "initiatorType": "script",
+            "transferSize": 1245,
+            "encodedBodySize": 945,
+            "decodedBodySize": 1830
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/MobileTableOfContents.astro_astro_type_script_index_0_lang.BcSo_yiZ.js",
+            "entryType": "resource",
+            "startTime": 15.599999994039536,
+            "duration": 14,
+            "initiatorType": "script",
+            "transferSize": 664,
+            "encodedBodySize": 364,
+            "decodedBodySize": 622
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/TableOfContents.astro_astro_type_script_index_0_lang.Csloo1VZ.js",
+            "entryType": "resource",
+            "startTime": 15.599999994039536,
+            "duration": 14.100000008940697,
+            "initiatorType": "script",
+            "transferSize": 356,
+            "encodedBodySize": 56,
+            "decodedBodySize": 36
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/TwoColumnContent.astro_astro_type_script_index_0_lang.DPGAuL8N.js",
+            "entryType": "resource",
+            "startTime": 15.700000002980232,
+            "duration": 14.399999991059303,
+            "initiatorType": "script",
+            "transferSize": 569,
+            "encodedBodySize": 269,
+            "decodedBodySize": 452
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/PageFrame.astro_astro_type_script_index_0_lang.iwTubUja.js",
+            "entryType": "resource",
+            "startTime": 15.799999997019768,
+            "duration": 18.799999997019768,
+            "initiatorType": "script",
+            "transferSize": 557,
+            "encodedBodySize": 257,
+            "decodedBodySize": 392
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/print.ehPL0gv-.css",
+            "entryType": "resource",
+            "startTime": 21,
+            "duration": 13.700000002980232,
+            "initiatorType": "link",
+            "transferSize": 1296,
+            "encodedBodySize": 996,
+            "decodedBodySize": 3318
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/starlight-toc.CTCQXEge.js",
+            "entryType": "resource",
+            "startTime": 40.20000000298023,
+            "duration": 4.200000002980232,
+            "initiatorType": "script",
+            "transferSize": 1251,
+            "encodedBodySize": 951,
+            "decodedBodySize": 1981
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/preload-helper.BnKG7j8P.js",
+            "entryType": "resource",
+            "startTime": 40.20000000298023,
+            "duration": 4.399999991059303,
+            "initiatorType": "script",
+            "transferSize": 1037,
+            "encodedBodySize": 737,
+            "decodedBodySize": 1351
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/persistent-toggle.t6KkBAiq.js",
+            "entryType": "resource",
+            "startTime": 40.400000005960464,
+            "duration": 4.399999991059303,
+            "initiatorType": "script",
+            "transferSize": 1005,
+            "encodedBodySize": 705,
+            "decodedBodySize": 2082
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/favicon.svg",
+            "entryType": "resource",
+            "startTime": 99.59999999403954,
+            "duration": 3.6000000089406967,
+            "initiatorType": "other",
+            "transferSize": 559,
+            "encodedBodySize": 259,
+            "decodedBodySize": 331
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/ui-core.BwVUYzUq.js",
+            "entryType": "resource",
+            "startTime": 120,
+            "duration": 4.5999999940395355,
+            "initiatorType": "script",
+            "transferSize": 26419,
+            "encodedBodySize": 26119,
+            "decodedBodySize": 93799
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/InteractiveCell.DoOzatBM.js",
+            "entryType": "resource",
+            "startTime": 186.20000000298023,
+            "duration": 5.5999999940395355,
+            "initiatorType": "script",
+            "transferSize": 16684,
+            "encodedBodySize": 16384,
+            "decodedBodySize": 50227
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/client.BJAMOzhD.js",
+            "entryType": "resource",
+            "startTime": 186.40000000596046,
+            "duration": 5.299999997019768,
+            "initiatorType": "script",
+            "transferSize": 1114,
+            "encodedBodySize": 814,
+            "decodedBodySize": 1412
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/preact.Bl7PEaKa.js",
+            "entryType": "resource",
+            "startTime": 192.40000000596046,
+            "duration": 5.399999991059303,
+            "initiatorType": "script",
+            "transferSize": 4713,
+            "encodedBodySize": 4413,
+            "decodedBodySize": 10470
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/output-limits.vkaihnVu.js",
+            "entryType": "resource",
+            "startTime": 193.09999999403954,
+            "duration": 4.300000011920929,
+            "initiatorType": "script",
+            "transferSize": 3959,
+            "encodedBodySize": 3659,
+            "decodedBodySize": 8969
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/hooks.ClbWuNs9.js",
+            "entryType": "resource",
+            "startTime": 193.20000000298023,
+            "duration": 4.5999999940395355,
+            "initiatorType": "script",
+            "transferSize": 1453,
+            "encodedBodySize": 1153,
+            "decodedBodySize": 2677
+          },
+          {
+            "name": "oxiquill:hydrated:features__interactive-cells__python-controls",
+            "entryType": "mark",
+            "startTime": 201.5,
+            "duration": 0
+          },
+          {
+            "name": "oxiquill:worker-start:python",
+            "entryType": "mark",
+            "startTime": 203,
+            "duration": 0
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/python-worker-CZmazRja.js",
+            "entryType": "resource",
+            "startTime": 210.20000000298023,
+            "duration": -2.9000000059604645,
+            "initiatorType": "other",
+            "transferSize": 13324,
+            "encodedBodySize": 13024,
+            "decodedBodySize": 47679
+          },
+          {
+            "name": "oxiquill:output-rendered:features__interactive-cells__python-controls",
+            "entryType": "mark",
+            "startTime": 1947,
+            "duration": 0
+          }
+        ]
+      },
+      "workers": [
+        {
+          "timeOrigin": 1788590347915,
+          "entries": [
+            {
+              "name": "oxiquill:worker-ready:python",
+              "entryType": "mark",
+              "startTime": 3.7000000029802322,
+              "duration": 0
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pyodide.mjs",
+              "entryType": "resource",
+              "startTime": 4.600000008940697,
+              "duration": 2.3999999910593033,
+              "initiatorType": "fetch",
+              "transferSize": 7456,
+              "encodedBodySize": 7156,
+              "decodedBodySize": 17931
+            },
+            {
+              "name": "oxiquill:initialization:python",
+              "entryType": "measure",
+              "startTime": 10.600000008940697,
+              "duration": 1687
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pyodide-lock.json",
+              "entryType": "resource",
+              "startTime": 10.900000005960464,
+              "duration": 4.5999999940395355,
+              "initiatorType": "fetch",
+              "transferSize": 26834,
+              "encodedBodySize": 26534,
+              "decodedBodySize": 114440
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/python_stdlib.zip",
+              "entryType": "resource",
+              "startTime": 11.300000011920929,
+              "duration": 63.19999998807907,
+              "initiatorType": "fetch",
+              "transferSize": 2503474,
+              "encodedBodySize": 2503174,
+              "decodedBodySize": 2545564
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pyodide.asm.wasm",
+              "entryType": "resource",
+              "startTime": 11.600000008940697,
+              "duration": 468.29999999701977,
+              "initiatorType": "fetch",
+              "transferSize": 3546429,
+              "encodedBodySize": 3546129,
+              "decodedBodySize": 9598218
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pyodide.asm.mjs",
+              "entryType": "resource",
+              "startTime": 11.700000002980232,
+              "duration": 82.40000000596046,
+              "initiatorType": "script",
+              "transferSize": 260407,
+              "encodedBodySize": 260107,
+              "decodedBodySize": 1250344
+            },
+            {
+              "name": "oxiquill:display-support:python",
+              "entryType": "measure",
+              "startTime": 1697.7000000029802,
+              "duration": 32.6000000089407
+            },
+            {
+              "name": "oxiquill:imports:features__interactive-cells__python-controls",
+              "entryType": "measure",
+              "startTime": 1730.4000000059605,
+              "duration": 0.9000000059604645
+            },
+            {
+              "name": "oxiquill:display-prepare:features__interactive-cells__python-controls",
+              "entryType": "measure",
+              "startTime": 1731.300000011921,
+              "duration": 0.7999999970197678
+            },
+            {
+              "name": "oxiquill:execution:features__interactive-cells__python-controls",
+              "entryType": "measure",
+              "startTime": 1732.2000000029802,
+              "duration": 3.7999999970197678
+            },
+            {
+              "name": "oxiquill:display-collect:features__interactive-cells__python-controls",
+              "entryType": "measure",
+              "startTime": 1736.6000000089407,
+              "duration": 0.5
+            }
+          ]
+        }
+      ],
+      "observed": {
+        "requests": [
+          {
+            "requestId": 1,
+            "at": 1788590347910.2
+          }
+        ],
+        "responses": [
+          {
+            "requestId": 1,
+            "at": 1788590349654,
+            "ok": true
+          }
+        ]
+      }
+    },
+    {
+      "example": "features/interactive-cells/",
+      "condition": "reload",
+      "run": 1,
+      "triggerMs": 102.29999999701977,
+      "outputMs": 1434.2999999970198,
+      "latencyMs": 1434.2999999970198,
+      "renderObserverDeltaMs": 0,
+      "main": {
+        "timeOrigin": 1788590349675.8,
+        "entries": [
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/index.DANjJwMU.css",
+            "entryType": "resource",
+            "startTime": 16.099999994039536,
+            "duration": 0,
+            "initiatorType": "link",
+            "transferSize": 0,
+            "encodedBodySize": 21609,
+            "decodedBodySize": 105367
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/page.Dwipeu-R.js",
+            "entryType": "resource",
+            "startTime": 16.200000002980232,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 1124,
+            "decodedBodySize": 2486
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/Search.astro_astro_type_script_index_0_lang.DzL-jWp_.js",
+            "entryType": "resource",
+            "startTime": 16.200000002980232,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 945,
+            "decodedBodySize": 1830
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/MobileTableOfContents.astro_astro_type_script_index_0_lang.BcSo_yiZ.js",
+            "entryType": "resource",
+            "startTime": 16.200000002980232,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 364,
+            "decodedBodySize": 622
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/TableOfContents.astro_astro_type_script_index_0_lang.Csloo1VZ.js",
+            "entryType": "resource",
+            "startTime": 16.299999997019768,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 56,
+            "decodedBodySize": 36
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/TwoColumnContent.astro_astro_type_script_index_0_lang.DPGAuL8N.js",
+            "entryType": "resource",
+            "startTime": 16.5,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 269,
+            "decodedBodySize": 452
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/PageFrame.astro_astro_type_script_index_0_lang.iwTubUja.js",
+            "entryType": "resource",
+            "startTime": 16.599999994039536,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 257,
+            "decodedBodySize": 392
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/print.ehPL0gv-.css",
+            "entryType": "resource",
+            "startTime": 19.700000002980232,
+            "duration": 0,
+            "initiatorType": "link",
+            "transferSize": 0,
+            "encodedBodySize": 996,
+            "decodedBodySize": 3318
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/preload-helper.BnKG7j8P.js",
+            "entryType": "resource",
+            "startTime": 25.700000002980232,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 737,
+            "decodedBodySize": 1351
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/starlight-toc.CTCQXEge.js",
+            "entryType": "resource",
+            "startTime": 25.799999997019768,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 951,
+            "decodedBodySize": 1981
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/persistent-toggle.t6KkBAiq.js",
+            "entryType": "resource",
+            "startTime": 25.900000005960464,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 705,
+            "decodedBodySize": 2082
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/InteractiveCell.DoOzatBM.js",
+            "entryType": "resource",
+            "startTime": 42.29999999701977,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 16384,
+            "decodedBodySize": 50227
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/client.BJAMOzhD.js",
+            "entryType": "resource",
+            "startTime": 42.5,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 814,
+            "decodedBodySize": 1412
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/preact.Bl7PEaKa.js",
+            "entryType": "resource",
+            "startTime": 44.20000000298023,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 4413,
+            "decodedBodySize": 10470
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/output-limits.vkaihnVu.js",
+            "entryType": "resource",
+            "startTime": 44.400000005960464,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 3659,
+            "decodedBodySize": 8969
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/hooks.ClbWuNs9.js",
+            "entryType": "resource",
+            "startTime": 44.400000005960464,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 1153,
+            "decodedBodySize": 2677
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/favicon.svg",
+            "entryType": "resource",
+            "startTime": 44.70000000298023,
+            "duration": 1.5999999940395355,
+            "initiatorType": "other",
+            "transferSize": 0,
+            "encodedBodySize": 259,
+            "decodedBodySize": 331
+          },
+          {
+            "name": "oxiquill:hydrated:features__interactive-cells__python-controls",
+            "entryType": "mark",
+            "startTime": 46.599999994039536,
+            "duration": 0
+          },
+          {
+            "name": "oxiquill:worker-start:python",
+            "entryType": "mark",
+            "startTime": 56.70000000298023,
+            "duration": 0
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/python-worker-CZmazRja.js",
+            "entryType": "resource",
+            "startTime": 61.099999994039536,
+            "duration": -2.2999999970197678,
+            "initiatorType": "other",
+            "transferSize": 0,
+            "encodedBodySize": 13024,
+            "decodedBodySize": 47679
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/ui-core.BwVUYzUq.js",
+            "entryType": "resource",
+            "startTime": 68.40000000596046,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 26119,
+            "decodedBodySize": 93799
+          },
+          {
+            "name": "oxiquill:output-rendered:features__interactive-cells__python-controls",
+            "entryType": "mark",
+            "startTime": 1434.2999999970198,
+            "duration": 0
+          }
+        ]
+      },
+      "workers": [
+        {
+          "timeOrigin": 1788590349735.3,
+          "entries": [
+            {
+              "name": "oxiquill:worker-ready:python",
+              "entryType": "mark",
+              "startTime": 2.9000000059604645,
+              "duration": 0
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pyodide.mjs",
+              "entryType": "resource",
+              "startTime": 4.200000002980232,
+              "duration": 1.2000000029802322,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 7156,
+              "decodedBodySize": 17931
+            },
+            {
+              "name": "oxiquill:initialization:python",
+              "entryType": "measure",
+              "startTime": 8.299999997019768,
+              "duration": 1321.4000000059605
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pyodide-lock.json",
+              "entryType": "resource",
+              "startTime": 8.599999994039536,
+              "duration": 1.6000000089406967,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 26534,
+              "decodedBodySize": 114440
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/python_stdlib.zip",
+              "entryType": "resource",
+              "startTime": 9,
+              "duration": 15.200000002980232,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 2503174,
+              "decodedBodySize": 2545564
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pyodide.asm.wasm",
+              "entryType": "resource",
+              "startTime": 9.200000002980232,
+              "duration": 84.59999999403954,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 3546129,
+              "decodedBodySize": 9598218
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pyodide.asm.mjs",
+              "entryType": "resource",
+              "startTime": 9.5,
+              "duration": 8.400000005960464,
+              "initiatorType": "script",
+              "transferSize": 0,
+              "encodedBodySize": 260107,
+              "decodedBodySize": 1250344
+            },
+            {
+              "name": "oxiquill:display-support:python",
+              "entryType": "measure",
+              "startTime": 1329.7999999970198,
+              "duration": 35.900000005960464
+            },
+            {
+              "name": "oxiquill:imports:features__interactive-cells__python-controls",
+              "entryType": "measure",
+              "startTime": 1365.7999999970198,
+              "duration": 0.9000000059604645
+            },
+            {
+              "name": "oxiquill:display-prepare:features__interactive-cells__python-controls",
+              "entryType": "measure",
+              "startTime": 1366.7999999970198,
+              "duration": 0.7000000029802322
+            },
+            {
+              "name": "oxiquill:execution:features__interactive-cells__python-controls",
+              "entryType": "measure",
+              "startTime": 1367.7000000029802,
+              "duration": 3.8999999910593033
+            },
+            {
+              "name": "oxiquill:display-collect:features__interactive-cells__python-controls",
+              "entryType": "measure",
+              "startTime": 1372.5,
+              "duration": 0.9000000059604645
+            }
+          ]
+        }
+      ],
+      "observed": {
+        "requests": [
+          {
+            "requestId": 1,
+            "at": 1788590349732.7
+          }
+        ],
+        "responses": [
+          {
+            "requestId": 1,
+            "at": 1788590351110.1,
+            "ok": true
+          }
+        ]
+      }
+    },
+    {
+      "example": "features/interactive-cells/",
+      "condition": "repeat",
+      "run": 1,
+      "triggerMs": 1486.2999999970198,
+      "outputMs": 1650,
+      "latencyMs": 163.70000000298023,
+      "renderObserverDeltaMs": -0.10009765625,
+      "main": {
+        "timeOrigin": 1788590349675.8,
+        "entries": [
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/index.DANjJwMU.css",
+            "entryType": "resource",
+            "startTime": 16.099999994039536,
+            "duration": 0,
+            "initiatorType": "link",
+            "transferSize": 0,
+            "encodedBodySize": 21609,
+            "decodedBodySize": 105367
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/page.Dwipeu-R.js",
+            "entryType": "resource",
+            "startTime": 16.200000002980232,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 1124,
+            "decodedBodySize": 2486
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/Search.astro_astro_type_script_index_0_lang.DzL-jWp_.js",
+            "entryType": "resource",
+            "startTime": 16.200000002980232,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 945,
+            "decodedBodySize": 1830
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/MobileTableOfContents.astro_astro_type_script_index_0_lang.BcSo_yiZ.js",
+            "entryType": "resource",
+            "startTime": 16.200000002980232,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 364,
+            "decodedBodySize": 622
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/TableOfContents.astro_astro_type_script_index_0_lang.Csloo1VZ.js",
+            "entryType": "resource",
+            "startTime": 16.299999997019768,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 56,
+            "decodedBodySize": 36
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/TwoColumnContent.astro_astro_type_script_index_0_lang.DPGAuL8N.js",
+            "entryType": "resource",
+            "startTime": 16.5,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 269,
+            "decodedBodySize": 452
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/PageFrame.astro_astro_type_script_index_0_lang.iwTubUja.js",
+            "entryType": "resource",
+            "startTime": 16.599999994039536,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 257,
+            "decodedBodySize": 392
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/print.ehPL0gv-.css",
+            "entryType": "resource",
+            "startTime": 19.700000002980232,
+            "duration": 0,
+            "initiatorType": "link",
+            "transferSize": 0,
+            "encodedBodySize": 996,
+            "decodedBodySize": 3318
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/preload-helper.BnKG7j8P.js",
+            "entryType": "resource",
+            "startTime": 25.700000002980232,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 737,
+            "decodedBodySize": 1351
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/starlight-toc.CTCQXEge.js",
+            "entryType": "resource",
+            "startTime": 25.799999997019768,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 951,
+            "decodedBodySize": 1981
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/persistent-toggle.t6KkBAiq.js",
+            "entryType": "resource",
+            "startTime": 25.900000005960464,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 705,
+            "decodedBodySize": 2082
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/InteractiveCell.DoOzatBM.js",
+            "entryType": "resource",
+            "startTime": 42.29999999701977,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 16384,
+            "decodedBodySize": 50227
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/client.BJAMOzhD.js",
+            "entryType": "resource",
+            "startTime": 42.5,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 814,
+            "decodedBodySize": 1412
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/preact.Bl7PEaKa.js",
+            "entryType": "resource",
+            "startTime": 44.20000000298023,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 4413,
+            "decodedBodySize": 10470
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/output-limits.vkaihnVu.js",
+            "entryType": "resource",
+            "startTime": 44.400000005960464,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 3659,
+            "decodedBodySize": 8969
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/hooks.ClbWuNs9.js",
+            "entryType": "resource",
+            "startTime": 44.400000005960464,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 1153,
+            "decodedBodySize": 2677
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/favicon.svg",
+            "entryType": "resource",
+            "startTime": 44.70000000298023,
+            "duration": 1.5999999940395355,
+            "initiatorType": "other",
+            "transferSize": 0,
+            "encodedBodySize": 259,
+            "decodedBodySize": 331
+          },
+          {
+            "name": "oxiquill:hydrated:features__interactive-cells__python-controls",
+            "entryType": "mark",
+            "startTime": 46.599999994039536,
+            "duration": 0
+          },
+          {
+            "name": "oxiquill:worker-start:python",
+            "entryType": "mark",
+            "startTime": 56.70000000298023,
+            "duration": 0
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/python-worker-CZmazRja.js",
+            "entryType": "resource",
+            "startTime": 61.099999994039536,
+            "duration": -2.2999999970197678,
+            "initiatorType": "other",
+            "transferSize": 0,
+            "encodedBodySize": 13024,
+            "decodedBodySize": 47679
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/ui-core.BwVUYzUq.js",
+            "entryType": "resource",
+            "startTime": 68.40000000596046,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 26119,
+            "decodedBodySize": 93799
+          },
+          {
+            "name": "oxiquill:output-rendered:features__interactive-cells__python-controls",
+            "entryType": "mark",
+            "startTime": 1650,
+            "duration": 0
+          }
+        ]
+      },
+      "workers": [
+        {
+          "timeOrigin": 1788590349735.3,
+          "entries": [
+            {
+              "name": "oxiquill:worker-ready:python",
+              "entryType": "mark",
+              "startTime": 2.9000000059604645,
+              "duration": 0
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pyodide.mjs",
+              "entryType": "resource",
+              "startTime": 4.200000002980232,
+              "duration": 1.2000000029802322,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 7156,
+              "decodedBodySize": 17931
+            },
+            {
+              "name": "oxiquill:initialization:python",
+              "entryType": "measure",
+              "startTime": 8.299999997019768,
+              "duration": 1321.4000000059605
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pyodide-lock.json",
+              "entryType": "resource",
+              "startTime": 8.599999994039536,
+              "duration": 1.6000000089406967,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 26534,
+              "decodedBodySize": 114440
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/python_stdlib.zip",
+              "entryType": "resource",
+              "startTime": 9,
+              "duration": 15.200000002980232,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 2503174,
+              "decodedBodySize": 2545564
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pyodide.asm.wasm",
+              "entryType": "resource",
+              "startTime": 9.200000002980232,
+              "duration": 84.59999999403954,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 3546129,
+              "decodedBodySize": 9598218
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pyodide.asm.mjs",
+              "entryType": "resource",
+              "startTime": 9.5,
+              "duration": 8.400000005960464,
+              "initiatorType": "script",
+              "transferSize": 0,
+              "encodedBodySize": 260107,
+              "decodedBodySize": 1250344
+            },
+            {
+              "name": "oxiquill:display-support:python",
+              "entryType": "measure",
+              "startTime": 1329.7999999970198,
+              "duration": 35.900000005960464
+            },
+            {
+              "name": "oxiquill:imports:features__interactive-cells__python-controls",
+              "entryType": "measure",
+              "startTime": 1586.2000000029802,
+              "duration": 0.5999999940395355
+            },
+            {
+              "name": "oxiquill:display-prepare:features__interactive-cells__python-controls",
+              "entryType": "measure",
+              "startTime": 1586.7999999970198,
+              "duration": 0.6000000089406967
+            },
+            {
+              "name": "oxiquill:execution:features__interactive-cells__python-controls",
+              "entryType": "measure",
+              "startTime": 1587.5,
+              "duration": 1.5
+            },
+            {
+              "name": "oxiquill:display-collect:features__interactive-cells__python-controls",
+              "entryType": "measure",
+              "startTime": 1589.2999999970198,
+              "duration": 0.6000000089406967
+            }
+          ]
+        }
+      ],
+      "observed": {
+        "requests": [
+          {
+            "requestId": 1,
+            "at": 1788590349732.7
+          },
+          {
+            "requestId": 2,
+            "at": 1788590351321.2
+          }
+        ],
+        "responses": [
+          {
+            "requestId": 1,
+            "at": 1788590351110.1,
+            "ok": true
+          },
+          {
+            "requestId": 2,
+            "at": 1788590351325.9001,
+            "ok": true
+          }
+        ]
+      }
+    },
+    {
+      "example": "features/interactive-cells/",
+      "condition": "fresh",
+      "run": 2,
+      "triggerMs": 157.80000001192093,
+      "outputMs": 1554.300000011921,
+      "latencyMs": 1554.300000011921,
+      "renderObserverDeltaMs": -0.199951171875,
+      "main": {
+        "timeOrigin": 1788590351402.9,
+        "entries": [
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/index.DANjJwMU.css",
+            "entryType": "resource",
+            "startTime": 5.800000011920929,
+            "duration": 2.3999999910593033,
+            "initiatorType": "link",
+            "transferSize": 21909,
+            "encodedBodySize": 21609,
+            "decodedBodySize": 105367
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/page.Dwipeu-R.js",
+            "entryType": "resource",
+            "startTime": 6,
+            "duration": 7,
+            "initiatorType": "script",
+            "transferSize": 1424,
+            "encodedBodySize": 1124,
+            "decodedBodySize": 2486
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/Search.astro_astro_type_script_index_0_lang.DzL-jWp_.js",
+            "entryType": "resource",
+            "startTime": 6.100000008940697,
+            "duration": 7.299999997019768,
+            "initiatorType": "script",
+            "transferSize": 1245,
+            "encodedBodySize": 945,
+            "decodedBodySize": 1830
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/MobileTableOfContents.astro_astro_type_script_index_0_lang.BcSo_yiZ.js",
+            "entryType": "resource",
+            "startTime": 6.100000008940697,
+            "duration": 7.5,
+            "initiatorType": "script",
+            "transferSize": 664,
+            "encodedBodySize": 364,
+            "decodedBodySize": 622
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/TableOfContents.astro_astro_type_script_index_0_lang.Csloo1VZ.js",
+            "entryType": "resource",
+            "startTime": 6.200000002980232,
+            "duration": 7.4000000059604645,
+            "initiatorType": "script",
+            "transferSize": 356,
+            "encodedBodySize": 56,
+            "decodedBodySize": 36
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/TwoColumnContent.astro_astro_type_script_index_0_lang.DPGAuL8N.js",
+            "entryType": "resource",
+            "startTime": 6.200000002980232,
+            "duration": 7.600000008940697,
+            "initiatorType": "script",
+            "transferSize": 569,
+            "encodedBodySize": 269,
+            "decodedBodySize": 452
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/PageFrame.astro_astro_type_script_index_0_lang.iwTubUja.js",
+            "entryType": "resource",
+            "startTime": 6.200000002980232,
+            "duration": 7.799999997019768,
+            "initiatorType": "script",
+            "transferSize": 557,
+            "encodedBodySize": 257,
+            "decodedBodySize": 392
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/print.ehPL0gv-.css",
+            "entryType": "resource",
+            "startTime": 10.400000005960464,
+            "duration": 5,
+            "initiatorType": "link",
+            "transferSize": 1296,
+            "encodedBodySize": 996,
+            "decodedBodySize": 3318
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/preload-helper.BnKG7j8P.js",
+            "entryType": "resource",
+            "startTime": 50.400000005960464,
+            "duration": 3.2999999970197678,
+            "initiatorType": "script",
+            "transferSize": 1037,
+            "encodedBodySize": 737,
+            "decodedBodySize": 1351
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/starlight-toc.CTCQXEge.js",
+            "entryType": "resource",
+            "startTime": 50.5,
+            "duration": 3.300000011920929,
+            "initiatorType": "script",
+            "transferSize": 1251,
+            "encodedBodySize": 951,
+            "decodedBodySize": 1981
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/persistent-toggle.t6KkBAiq.js",
+            "entryType": "resource",
+            "startTime": 50.6000000089407,
+            "duration": 3.2999999970197678,
+            "initiatorType": "script",
+            "transferSize": 1005,
+            "encodedBodySize": 705,
+            "decodedBodySize": 2082
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/favicon.svg",
+            "entryType": "resource",
+            "startTime": 59.6000000089407,
+            "duration": 1.5,
+            "initiatorType": "other",
+            "transferSize": 559,
+            "encodedBodySize": 259,
+            "decodedBodySize": 331
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/ui-core.BwVUYzUq.js",
+            "entryType": "resource",
+            "startTime": 80.30000001192093,
+            "duration": 2.199999988079071,
+            "initiatorType": "script",
+            "transferSize": 26419,
+            "encodedBodySize": 26119,
+            "decodedBodySize": 93799
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/client.BJAMOzhD.js",
+            "entryType": "resource",
+            "startTime": 140.1000000089407,
+            "duration": 3,
+            "initiatorType": "script",
+            "transferSize": 1114,
+            "encodedBodySize": 814,
+            "decodedBodySize": 1412
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/InteractiveCell.DoOzatBM.js",
+            "entryType": "resource",
+            "startTime": 140.1000000089407,
+            "duration": 3.2000000029802322,
+            "initiatorType": "script",
+            "transferSize": 16684,
+            "encodedBodySize": 16384,
+            "decodedBodySize": 50227
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/preact.Bl7PEaKa.js",
+            "entryType": "resource",
+            "startTime": 143.70000000298023,
+            "duration": 2.5,
+            "initiatorType": "script",
+            "transferSize": 4713,
+            "encodedBodySize": 4413,
+            "decodedBodySize": 10470
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/output-limits.vkaihnVu.js",
+            "entryType": "resource",
+            "startTime": 145,
+            "duration": 3.300000011920929,
+            "initiatorType": "script",
+            "transferSize": 3959,
+            "encodedBodySize": 3659,
+            "decodedBodySize": 8969
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/hooks.ClbWuNs9.js",
+            "entryType": "resource",
+            "startTime": 145.1000000089407,
+            "duration": 3.3999999910593033,
+            "initiatorType": "script",
+            "transferSize": 1453,
+            "encodedBodySize": 1153,
+            "decodedBodySize": 2677
+          },
+          {
+            "name": "oxiquill:hydrated:features__interactive-cells__python-controls",
+            "entryType": "mark",
+            "startTime": 152.1000000089407,
+            "duration": 0
+          },
+          {
+            "name": "oxiquill:worker-start:python",
+            "entryType": "mark",
+            "startTime": 157.20000000298023,
+            "duration": 0
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/python-worker-CZmazRja.js",
+            "entryType": "resource",
+            "startTime": 161.70000000298023,
+            "duration": -1.5,
+            "initiatorType": "other",
+            "transferSize": 13324,
+            "encodedBodySize": 13024,
+            "decodedBodySize": 47679
+          },
+          {
+            "name": "oxiquill:output-rendered:features__interactive-cells__python-controls",
+            "entryType": "mark",
+            "startTime": 1554.300000011921,
+            "duration": 0
+          }
+        ]
+      },
+      "workers": [
+        {
+          "timeOrigin": 1788590351562.8,
+          "entries": [
+            {
+              "name": "oxiquill:worker-ready:python",
+              "entryType": "mark",
+              "startTime": 3.300000011920929,
+              "duration": 0
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pyodide.mjs",
+              "entryType": "resource",
+              "startTime": 4.100000008940697,
+              "duration": 2.7000000029802322,
+              "initiatorType": "fetch",
+              "transferSize": 7456,
+              "encodedBodySize": 7156,
+              "decodedBodySize": 17931
+            },
+            {
+              "name": "oxiquill:initialization:python",
+              "entryType": "measure",
+              "startTime": 10.600000008940697,
+              "duration": 1342.3999999910593
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pyodide-lock.json",
+              "entryType": "resource",
+              "startTime": 10.900000005960464,
+              "duration": 6.0999999940395355,
+              "initiatorType": "fetch",
+              "transferSize": 26834,
+              "encodedBodySize": 26534,
+              "decodedBodySize": 114440
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/python_stdlib.zip",
+              "entryType": "resource",
+              "startTime": 11.300000011920929,
+              "duration": 25.5,
+              "initiatorType": "fetch",
+              "transferSize": 2503474,
+              "encodedBodySize": 2503174,
+              "decodedBodySize": 2545564
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pyodide.asm.wasm",
+              "entryType": "resource",
+              "startTime": 11.5,
+              "duration": 102.5,
+              "initiatorType": "fetch",
+              "transferSize": 3546429,
+              "encodedBodySize": 3546129,
+              "decodedBodySize": 9598218
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pyodide.asm.mjs",
+              "entryType": "resource",
+              "startTime": 11.600000008940697,
+              "duration": 13.299999997019768,
+              "initiatorType": "script",
+              "transferSize": 260407,
+              "encodedBodySize": 260107,
+              "decodedBodySize": 1250344
+            },
+            {
+              "name": "oxiquill:display-support:python",
+              "entryType": "measure",
+              "startTime": 1353.1000000089407,
+              "duration": 32.3999999910593
+            },
+            {
+              "name": "oxiquill:imports:features__interactive-cells__python-controls",
+              "entryType": "measure",
+              "startTime": 1385.7000000029802,
+              "duration": 0.9000000059604645
+            },
+            {
+              "name": "oxiquill:display-prepare:features__interactive-cells__python-controls",
+              "entryType": "measure",
+              "startTime": 1386.6000000089407,
+              "duration": 0.8999999910593033
+            },
+            {
+              "name": "oxiquill:execution:features__interactive-cells__python-controls",
+              "entryType": "measure",
+              "startTime": 1387.7000000029802,
+              "duration": 3.5
+            },
+            {
+              "name": "oxiquill:display-collect:features__interactive-cells__python-controls",
+              "entryType": "measure",
+              "startTime": 1391.9000000059605,
+              "duration": 0.7000000029802322
+            }
+          ]
+        }
+      ],
+      "observed": {
+        "requests": [
+          {
+            "requestId": 1,
+            "at": 1788590351560.5
+          }
+        ],
+        "responses": [
+          {
+            "requestId": 1,
+            "at": 1788590352957.4,
+            "ok": true
+          }
+        ]
+      }
+    },
+    {
+      "example": "features/interactive-cells/",
+      "condition": "reload",
+      "run": 2,
+      "triggerMs": 102.40000000596046,
+      "outputMs": 1386.7999999970198,
+      "latencyMs": 1386.7999999970198,
+      "renderObserverDeltaMs": -0.099853515625,
+      "main": {
+        "timeOrigin": 1788590352975.3,
+        "entries": [
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/index.DANjJwMU.css",
+            "entryType": "resource",
+            "startTime": 14.5,
+            "duration": 0,
+            "initiatorType": "link",
+            "transferSize": 0,
+            "encodedBodySize": 21609,
+            "decodedBodySize": 105367
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/page.Dwipeu-R.js",
+            "entryType": "resource",
+            "startTime": 14.599999994039536,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 1124,
+            "decodedBodySize": 2486
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/Search.astro_astro_type_script_index_0_lang.DzL-jWp_.js",
+            "entryType": "resource",
+            "startTime": 14.599999994039536,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 945,
+            "decodedBodySize": 1830
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/MobileTableOfContents.astro_astro_type_script_index_0_lang.BcSo_yiZ.js",
+            "entryType": "resource",
+            "startTime": 14.700000002980232,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 364,
+            "decodedBodySize": 622
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/TableOfContents.astro_astro_type_script_index_0_lang.Csloo1VZ.js",
+            "entryType": "resource",
+            "startTime": 14.799999997019768,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 56,
+            "decodedBodySize": 36
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/TwoColumnContent.astro_astro_type_script_index_0_lang.DPGAuL8N.js",
+            "entryType": "resource",
+            "startTime": 14.799999997019768,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 269,
+            "decodedBodySize": 452
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/PageFrame.astro_astro_type_script_index_0_lang.iwTubUja.js",
+            "entryType": "resource",
+            "startTime": 14.900000005960464,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 257,
+            "decodedBodySize": 392
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/print.ehPL0gv-.css",
+            "entryType": "resource",
+            "startTime": 18.200000002980232,
+            "duration": 0,
+            "initiatorType": "link",
+            "transferSize": 0,
+            "encodedBodySize": 996,
+            "decodedBodySize": 3318
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/preload-helper.BnKG7j8P.js",
+            "entryType": "resource",
+            "startTime": 24.700000002980232,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 737,
+            "decodedBodySize": 1351
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/starlight-toc.CTCQXEge.js",
+            "entryType": "resource",
+            "startTime": 24.900000005960464,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 951,
+            "decodedBodySize": 1981
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/persistent-toggle.t6KkBAiq.js",
+            "entryType": "resource",
+            "startTime": 25,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 705,
+            "decodedBodySize": 2082
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/InteractiveCell.DoOzatBM.js",
+            "entryType": "resource",
+            "startTime": 41.599999994039536,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 16384,
+            "decodedBodySize": 50227
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/client.BJAMOzhD.js",
+            "entryType": "resource",
+            "startTime": 41.599999994039536,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 814,
+            "decodedBodySize": 1412
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/preact.Bl7PEaKa.js",
+            "entryType": "resource",
+            "startTime": 43.5,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 4413,
+            "decodedBodySize": 10470
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/output-limits.vkaihnVu.js",
+            "entryType": "resource",
+            "startTime": 43.599999994039536,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 3659,
+            "decodedBodySize": 8969
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/hooks.ClbWuNs9.js",
+            "entryType": "resource",
+            "startTime": 43.70000000298023,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 1153,
+            "decodedBodySize": 2677
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/favicon.svg",
+            "entryType": "resource",
+            "startTime": 43.900000005960464,
+            "duration": 1.3999999910593033,
+            "initiatorType": "other",
+            "transferSize": 0,
+            "encodedBodySize": 259,
+            "decodedBodySize": 331
+          },
+          {
+            "name": "oxiquill:hydrated:features__interactive-cells__python-controls",
+            "entryType": "mark",
+            "startTime": 46,
+            "duration": 0
+          },
+          {
+            "name": "oxiquill:worker-start:python",
+            "entryType": "mark",
+            "startTime": 56.599999994039536,
+            "duration": 0
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/python-worker-CZmazRja.js",
+            "entryType": "resource",
+            "startTime": 64.29999999701977,
+            "duration": -5.700000002980232,
+            "initiatorType": "other",
+            "transferSize": 0,
+            "encodedBodySize": 13024,
+            "decodedBodySize": 47679
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/ui-core.BwVUYzUq.js",
+            "entryType": "resource",
+            "startTime": 68.09999999403954,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 26119,
+            "decodedBodySize": 93799
+          },
+          {
+            "name": "oxiquill:output-rendered:features__interactive-cells__python-controls",
+            "entryType": "mark",
+            "startTime": 1386.7999999970198,
+            "duration": 0
+          }
+        ]
+      },
+      "workers": [
+        {
+          "timeOrigin": 1788590353038.1,
+          "entries": [
+            {
+              "name": "oxiquill:worker-ready:python",
+              "entryType": "mark",
+              "startTime": 3.1000000089406967,
+              "duration": 0
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pyodide.mjs",
+              "entryType": "resource",
+              "startTime": 5.200000002980232,
+              "duration": 1.2999999970197678,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 7156,
+              "decodedBodySize": 17931
+            },
+            {
+              "name": "oxiquill:initialization:python",
+              "entryType": "measure",
+              "startTime": 9.600000008940697,
+              "duration": 1274.0999999940395
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pyodide-lock.json",
+              "entryType": "resource",
+              "startTime": 10,
+              "duration": 1.6000000089406967,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 26534,
+              "decodedBodySize": 114440
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/python_stdlib.zip",
+              "entryType": "resource",
+              "startTime": 10.600000008940697,
+              "duration": 16.19999998807907,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 2503174,
+              "decodedBodySize": 2545564
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pyodide.asm.wasm",
+              "entryType": "resource",
+              "startTime": 10.799999997019768,
+              "duration": 87.6000000089407,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 3546129,
+              "decodedBodySize": 9598218
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pyodide.asm.mjs",
+              "entryType": "resource",
+              "startTime": 10.900000005960464,
+              "duration": 9.399999991059303,
+              "initiatorType": "script",
+              "transferSize": 0,
+              "encodedBodySize": 260107,
+              "decodedBodySize": 1250344
+            },
+            {
+              "name": "oxiquill:display-support:python",
+              "entryType": "measure",
+              "startTime": 1283.7000000029802,
+              "duration": 29.5
+            },
+            {
+              "name": "oxiquill:imports:features__interactive-cells__python-controls",
+              "entryType": "measure",
+              "startTime": 1316,
+              "duration": 1.2000000029802322
+            },
+            {
+              "name": "oxiquill:display-prepare:features__interactive-cells__python-controls",
+              "entryType": "measure",
+              "startTime": 1317.4000000059605,
+              "duration": 1.0999999940395355
+            },
+            {
+              "name": "oxiquill:execution:features__interactive-cells__python-controls",
+              "entryType": "measure",
+              "startTime": 1318.7000000029802,
+              "duration": 3.2000000029802322
+            },
+            {
+              "name": "oxiquill:display-collect:features__interactive-cells__python-controls",
+              "entryType": "measure",
+              "startTime": 1322.5,
+              "duration": 0.5
+            }
+          ]
+        }
+      ],
+      "observed": {
+        "requests": [
+          {
+            "requestId": 1,
+            "at": 1788590353032.1
+          }
+        ],
+        "responses": [
+          {
+            "requestId": 1,
+            "at": 1788590354362.2,
+            "ok": true
+          }
+        ]
+      }
+    },
+    {
+      "example": "features/interactive-cells/",
+      "condition": "repeat",
+      "run": 2,
+      "triggerMs": 1436.2000000029802,
+      "outputMs": 1598.5,
+      "latencyMs": 162.29999999701977,
+      "renderObserverDeltaMs": -0.10009765625,
+      "main": {
+        "timeOrigin": 1788590352975.3,
+        "entries": [
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/index.DANjJwMU.css",
+            "entryType": "resource",
+            "startTime": 14.5,
+            "duration": 0,
+            "initiatorType": "link",
+            "transferSize": 0,
+            "encodedBodySize": 21609,
+            "decodedBodySize": 105367
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/page.Dwipeu-R.js",
+            "entryType": "resource",
+            "startTime": 14.599999994039536,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 1124,
+            "decodedBodySize": 2486
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/Search.astro_astro_type_script_index_0_lang.DzL-jWp_.js",
+            "entryType": "resource",
+            "startTime": 14.599999994039536,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 945,
+            "decodedBodySize": 1830
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/MobileTableOfContents.astro_astro_type_script_index_0_lang.BcSo_yiZ.js",
+            "entryType": "resource",
+            "startTime": 14.700000002980232,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 364,
+            "decodedBodySize": 622
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/TableOfContents.astro_astro_type_script_index_0_lang.Csloo1VZ.js",
+            "entryType": "resource",
+            "startTime": 14.799999997019768,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 56,
+            "decodedBodySize": 36
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/TwoColumnContent.astro_astro_type_script_index_0_lang.DPGAuL8N.js",
+            "entryType": "resource",
+            "startTime": 14.799999997019768,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 269,
+            "decodedBodySize": 452
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/PageFrame.astro_astro_type_script_index_0_lang.iwTubUja.js",
+            "entryType": "resource",
+            "startTime": 14.900000005960464,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 257,
+            "decodedBodySize": 392
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/print.ehPL0gv-.css",
+            "entryType": "resource",
+            "startTime": 18.200000002980232,
+            "duration": 0,
+            "initiatorType": "link",
+            "transferSize": 0,
+            "encodedBodySize": 996,
+            "decodedBodySize": 3318
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/preload-helper.BnKG7j8P.js",
+            "entryType": "resource",
+            "startTime": 24.700000002980232,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 737,
+            "decodedBodySize": 1351
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/starlight-toc.CTCQXEge.js",
+            "entryType": "resource",
+            "startTime": 24.900000005960464,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 951,
+            "decodedBodySize": 1981
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/persistent-toggle.t6KkBAiq.js",
+            "entryType": "resource",
+            "startTime": 25,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 705,
+            "decodedBodySize": 2082
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/InteractiveCell.DoOzatBM.js",
+            "entryType": "resource",
+            "startTime": 41.599999994039536,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 16384,
+            "decodedBodySize": 50227
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/client.BJAMOzhD.js",
+            "entryType": "resource",
+            "startTime": 41.599999994039536,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 814,
+            "decodedBodySize": 1412
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/preact.Bl7PEaKa.js",
+            "entryType": "resource",
+            "startTime": 43.5,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 4413,
+            "decodedBodySize": 10470
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/output-limits.vkaihnVu.js",
+            "entryType": "resource",
+            "startTime": 43.599999994039536,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 3659,
+            "decodedBodySize": 8969
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/hooks.ClbWuNs9.js",
+            "entryType": "resource",
+            "startTime": 43.70000000298023,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 1153,
+            "decodedBodySize": 2677
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/favicon.svg",
+            "entryType": "resource",
+            "startTime": 43.900000005960464,
+            "duration": 1.3999999910593033,
+            "initiatorType": "other",
+            "transferSize": 0,
+            "encodedBodySize": 259,
+            "decodedBodySize": 331
+          },
+          {
+            "name": "oxiquill:hydrated:features__interactive-cells__python-controls",
+            "entryType": "mark",
+            "startTime": 46,
+            "duration": 0
+          },
+          {
+            "name": "oxiquill:worker-start:python",
+            "entryType": "mark",
+            "startTime": 56.599999994039536,
+            "duration": 0
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/python-worker-CZmazRja.js",
+            "entryType": "resource",
+            "startTime": 64.29999999701977,
+            "duration": -5.700000002980232,
+            "initiatorType": "other",
+            "transferSize": 0,
+            "encodedBodySize": 13024,
+            "decodedBodySize": 47679
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/ui-core.BwVUYzUq.js",
+            "entryType": "resource",
+            "startTime": 68.09999999403954,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 26119,
+            "decodedBodySize": 93799
+          },
+          {
+            "name": "oxiquill:output-rendered:features__interactive-cells__python-controls",
+            "entryType": "mark",
+            "startTime": 1598.5,
+            "duration": 0
+          }
+        ]
+      },
+      "workers": [
+        {
+          "timeOrigin": 1788590353038.1,
+          "entries": [
+            {
+              "name": "oxiquill:worker-ready:python",
+              "entryType": "mark",
+              "startTime": 3.1000000089406967,
+              "duration": 0
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pyodide.mjs",
+              "entryType": "resource",
+              "startTime": 5.200000002980232,
+              "duration": 1.2999999970197678,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 7156,
+              "decodedBodySize": 17931
+            },
+            {
+              "name": "oxiquill:initialization:python",
+              "entryType": "measure",
+              "startTime": 9.600000008940697,
+              "duration": 1274.0999999940395
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pyodide-lock.json",
+              "entryType": "resource",
+              "startTime": 10,
+              "duration": 1.6000000089406967,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 26534,
+              "decodedBodySize": 114440
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/python_stdlib.zip",
+              "entryType": "resource",
+              "startTime": 10.600000008940697,
+              "duration": 16.19999998807907,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 2503174,
+              "decodedBodySize": 2545564
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pyodide.asm.wasm",
+              "entryType": "resource",
+              "startTime": 10.799999997019768,
+              "duration": 87.6000000089407,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 3546129,
+              "decodedBodySize": 9598218
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pyodide.asm.mjs",
+              "entryType": "resource",
+              "startTime": 10.900000005960464,
+              "duration": 9.399999991059303,
+              "initiatorType": "script",
+              "transferSize": 0,
+              "encodedBodySize": 260107,
+              "decodedBodySize": 1250344
+            },
+            {
+              "name": "oxiquill:display-support:python",
+              "entryType": "measure",
+              "startTime": 1283.7000000029802,
+              "duration": 29.5
+            },
+            {
+              "name": "oxiquill:imports:features__interactive-cells__python-controls",
+              "entryType": "measure",
+              "startTime": 1530.7999999970198,
+              "duration": 0.9000000059604645
+            },
+            {
+              "name": "oxiquill:display-prepare:features__interactive-cells__python-controls",
+              "entryType": "measure",
+              "startTime": 1531.7000000029802,
+              "duration": 0.9000000059604645
+            },
+            {
+              "name": "oxiquill:execution:features__interactive-cells__python-controls",
+              "entryType": "measure",
+              "startTime": 1532.6000000089407,
+              "duration": 1.5999999940395355
+            },
+            {
+              "name": "oxiquill:display-collect:features__interactive-cells__python-controls",
+              "entryType": "measure",
+              "startTime": 1534.6000000089407,
+              "duration": 0.5999999940395355
+            }
+          ]
+        }
+      ],
+      "observed": {
+        "requests": [
+          {
+            "requestId": 1,
+            "at": 1788590353032.1
+          },
+          {
+            "requestId": 2,
+            "at": 1788590354568.5
+          }
+        ],
+        "responses": [
+          {
+            "requestId": 1,
+            "at": 1788590354362.2,
+            "ok": true
+          },
+          {
+            "requestId": 2,
+            "at": 1788590354573.9001,
+            "ok": true
+          }
+        ]
+      }
+    },
+    {
+      "example": "features/interactive-cells/",
+      "condition": "fresh",
+      "run": 3,
+      "triggerMs": 160,
+      "outputMs": 1493.2000000029802,
+      "latencyMs": 1493.2000000029802,
+      "renderObserverDeltaMs": -0.10009765625,
+      "main": {
+        "timeOrigin": 1788590354636.3,
+        "entries": [
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/index.DANjJwMU.css",
+            "entryType": "resource",
+            "startTime": 5.9000000059604645,
+            "duration": 2.3999999910593033,
+            "initiatorType": "link",
+            "transferSize": 21909,
+            "encodedBodySize": 21609,
+            "decodedBodySize": 105367
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/page.Dwipeu-R.js",
+            "entryType": "resource",
+            "startTime": 6.200000002980232,
+            "duration": 7.899999991059303,
+            "initiatorType": "script",
+            "transferSize": 1424,
+            "encodedBodySize": 1124,
+            "decodedBodySize": 2486
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/Search.astro_astro_type_script_index_0_lang.DzL-jWp_.js",
+            "entryType": "resource",
+            "startTime": 6.200000002980232,
+            "duration": 8.599999994039536,
+            "initiatorType": "script",
+            "transferSize": 1245,
+            "encodedBodySize": 945,
+            "decodedBodySize": 1830
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/MobileTableOfContents.astro_astro_type_script_index_0_lang.BcSo_yiZ.js",
+            "entryType": "resource",
+            "startTime": 6.200000002980232,
+            "duration": 8.700000002980232,
+            "initiatorType": "script",
+            "transferSize": 664,
+            "encodedBodySize": 364,
+            "decodedBodySize": 622
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/TableOfContents.astro_astro_type_script_index_0_lang.Csloo1VZ.js",
+            "entryType": "resource",
+            "startTime": 6.200000002980232,
+            "duration": 8.799999997019768,
+            "initiatorType": "script",
+            "transferSize": 356,
+            "encodedBodySize": 56,
+            "decodedBodySize": 36
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/TwoColumnContent.astro_astro_type_script_index_0_lang.DPGAuL8N.js",
+            "entryType": "resource",
+            "startTime": 6.200000002980232,
+            "duration": 9,
+            "initiatorType": "script",
+            "transferSize": 569,
+            "encodedBodySize": 269,
+            "decodedBodySize": 452
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/PageFrame.astro_astro_type_script_index_0_lang.iwTubUja.js",
+            "entryType": "resource",
+            "startTime": 6.299999997019768,
+            "duration": 9.100000008940697,
+            "initiatorType": "script",
+            "transferSize": 557,
+            "encodedBodySize": 257,
+            "decodedBodySize": 392
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/print.ehPL0gv-.css",
+            "entryType": "resource",
+            "startTime": 10.5,
+            "duration": 6.299999997019768,
+            "initiatorType": "link",
+            "transferSize": 1296,
+            "encodedBodySize": 996,
+            "decodedBodySize": 3318
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/preload-helper.BnKG7j8P.js",
+            "entryType": "resource",
+            "startTime": 52.5,
+            "duration": 3.7000000029802322,
+            "initiatorType": "script",
+            "transferSize": 1037,
+            "encodedBodySize": 737,
+            "decodedBodySize": 1351
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/starlight-toc.CTCQXEge.js",
+            "entryType": "resource",
+            "startTime": 52.70000000298023,
+            "duration": 3.7000000029802322,
+            "initiatorType": "script",
+            "transferSize": 1251,
+            "encodedBodySize": 951,
+            "decodedBodySize": 1981
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/persistent-toggle.t6KkBAiq.js",
+            "entryType": "resource",
+            "startTime": 52.900000005960464,
+            "duration": 3.5,
+            "initiatorType": "script",
+            "transferSize": 1005,
+            "encodedBodySize": 705,
+            "decodedBodySize": 2082
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/favicon.svg",
+            "entryType": "resource",
+            "startTime": 62.5,
+            "duration": 2.7000000029802322,
+            "initiatorType": "other",
+            "transferSize": 559,
+            "encodedBodySize": 259,
+            "decodedBodySize": 331
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/ui-core.BwVUYzUq.js",
+            "entryType": "resource",
+            "startTime": 83.90000000596046,
+            "duration": 2.0999999940395355,
+            "initiatorType": "script",
+            "transferSize": 26419,
+            "encodedBodySize": 26119,
+            "decodedBodySize": 93799
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/InteractiveCell.DoOzatBM.js",
+            "entryType": "resource",
+            "startTime": 139.70000000298023,
+            "duration": 3,
+            "initiatorType": "script",
+            "transferSize": 16684,
+            "encodedBodySize": 16384,
+            "decodedBodySize": 50227
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/client.BJAMOzhD.js",
+            "entryType": "resource",
+            "startTime": 139.90000000596046,
+            "duration": 2.5999999940395355,
+            "initiatorType": "script",
+            "transferSize": 1114,
+            "encodedBodySize": 814,
+            "decodedBodySize": 1412
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/preact.Bl7PEaKa.js",
+            "entryType": "resource",
+            "startTime": 143.70000000298023,
+            "duration": 3.7000000029802322,
+            "initiatorType": "script",
+            "transferSize": 4713,
+            "encodedBodySize": 4413,
+            "decodedBodySize": 10470
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/output-limits.vkaihnVu.js",
+            "entryType": "resource",
+            "startTime": 144.5,
+            "duration": 5.5,
+            "initiatorType": "script",
+            "transferSize": 3959,
+            "encodedBodySize": 3659,
+            "decodedBodySize": 8969
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/hooks.ClbWuNs9.js",
+            "entryType": "resource",
+            "startTime": 144.70000000298023,
+            "duration": 5.399999991059303,
+            "initiatorType": "script",
+            "transferSize": 1453,
+            "encodedBodySize": 1153,
+            "decodedBodySize": 2677
+          },
+          {
+            "name": "oxiquill:hydrated:features__interactive-cells__python-controls",
+            "entryType": "mark",
+            "startTime": 154,
+            "duration": 0
+          },
+          {
+            "name": "oxiquill:worker-start:python",
+            "entryType": "mark",
+            "startTime": 159.40000000596046,
+            "duration": 0
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/python-worker-CZmazRja.js",
+            "entryType": "resource",
+            "startTime": 163.79999999701977,
+            "duration": -1.5,
+            "initiatorType": "other",
+            "transferSize": 13324,
+            "encodedBodySize": 13024,
+            "decodedBodySize": 47679
+          },
+          {
+            "name": "oxiquill:output-rendered:features__interactive-cells__python-controls",
+            "entryType": "mark",
+            "startTime": 1493.2000000029802,
+            "duration": 0
+          }
+        ]
+      },
+      "workers": [
+        {
+          "timeOrigin": 1788590354798.4,
+          "entries": [
+            {
+              "name": "oxiquill:worker-ready:python",
+              "entryType": "mark",
+              "startTime": 3.4000000059604645,
+              "duration": 0
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pyodide.mjs",
+              "entryType": "resource",
+              "startTime": 4.200000002980232,
+              "duration": 1.5,
+              "initiatorType": "fetch",
+              "transferSize": 7456,
+              "encodedBodySize": 7156,
+              "decodedBodySize": 17931
+            },
+            {
+              "name": "oxiquill:initialization:python",
+              "entryType": "measure",
+              "startTime": 8.700000002980232,
+              "duration": 1282.7999999970198
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pyodide-lock.json",
+              "entryType": "resource",
+              "startTime": 9,
+              "duration": 5.5999999940395355,
+              "initiatorType": "fetch",
+              "transferSize": 26834,
+              "encodedBodySize": 26534,
+              "decodedBodySize": 114440
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/python_stdlib.zip",
+              "entryType": "resource",
+              "startTime": 9.400000005960464,
+              "duration": 23.69999998807907,
+              "initiatorType": "fetch",
+              "transferSize": 2503474,
+              "encodedBodySize": 2503174,
+              "decodedBodySize": 2545564
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pyodide.asm.wasm",
+              "entryType": "resource",
+              "startTime": 9.599999994039536,
+              "duration": 96.70000000298023,
+              "initiatorType": "fetch",
+              "transferSize": 3546429,
+              "encodedBodySize": 3546129,
+              "decodedBodySize": 9598218
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pyodide.asm.mjs",
+              "entryType": "resource",
+              "startTime": 9.700000002980232,
+              "duration": 12.399999991059303,
+              "initiatorType": "script",
+              "transferSize": 260407,
+              "encodedBodySize": 260107,
+              "decodedBodySize": 1250344
+            },
+            {
+              "name": "oxiquill:display-support:python",
+              "entryType": "measure",
+              "startTime": 1291.5999999940395,
+              "duration": 32
+            },
+            {
+              "name": "oxiquill:imports:features__interactive-cells__python-controls",
+              "entryType": "measure",
+              "startTime": 1323.7000000029802,
+              "duration": 1
+            },
+            {
+              "name": "oxiquill:display-prepare:features__interactive-cells__python-controls",
+              "entryType": "measure",
+              "startTime": 1324.7000000029802,
+              "duration": 0.7999999970197678
+            },
+            {
+              "name": "oxiquill:execution:features__interactive-cells__python-controls",
+              "entryType": "measure",
+              "startTime": 1325.5999999940395,
+              "duration": 2.7000000029802322
+            },
+            {
+              "name": "oxiquill:display-collect:features__interactive-cells__python-controls",
+              "entryType": "measure",
+              "startTime": 1329,
+              "duration": 0.4000000059604645
+            }
+          ]
+        }
+      ],
+      "observed": {
+        "requests": [
+          {
+            "requestId": 1,
+            "at": 1788590354796
+          }
+        ],
+        "responses": [
+          {
+            "requestId": 1,
+            "at": 1788590356129.6,
+            "ok": true
+          }
+        ]
+      }
+    },
+    {
+      "example": "features/interactive-cells/",
+      "condition": "reload",
+      "run": 3,
+      "triggerMs": 104.5,
+      "outputMs": 1385.5,
+      "latencyMs": 1385.5,
+      "renderObserverDeltaMs": -0.10009765625,
+      "main": {
+        "timeOrigin": 1788590356156.6,
+        "entries": [
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/index.DANjJwMU.css",
+            "entryType": "resource",
+            "startTime": 13.5,
+            "duration": 0,
+            "initiatorType": "link",
+            "transferSize": 0,
+            "encodedBodySize": 21609,
+            "decodedBodySize": 105367
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/page.Dwipeu-R.js",
+            "entryType": "resource",
+            "startTime": 13.5,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 1124,
+            "decodedBodySize": 2486
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/Search.astro_astro_type_script_index_0_lang.DzL-jWp_.js",
+            "entryType": "resource",
+            "startTime": 13.599999994039536,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 945,
+            "decodedBodySize": 1830
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/MobileTableOfContents.astro_astro_type_script_index_0_lang.BcSo_yiZ.js",
+            "entryType": "resource",
+            "startTime": 13.599999994039536,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 364,
+            "decodedBodySize": 622
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/TableOfContents.astro_astro_type_script_index_0_lang.Csloo1VZ.js",
+            "entryType": "resource",
+            "startTime": 13.700000002980232,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 56,
+            "decodedBodySize": 36
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/TwoColumnContent.astro_astro_type_script_index_0_lang.DPGAuL8N.js",
+            "entryType": "resource",
+            "startTime": 13.700000002980232,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 269,
+            "decodedBodySize": 452
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/PageFrame.astro_astro_type_script_index_0_lang.iwTubUja.js",
+            "entryType": "resource",
+            "startTime": 13.700000002980232,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 257,
+            "decodedBodySize": 392
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/print.ehPL0gv-.css",
+            "entryType": "resource",
+            "startTime": 17.200000002980232,
+            "duration": 0,
+            "initiatorType": "link",
+            "transferSize": 0,
+            "encodedBodySize": 996,
+            "decodedBodySize": 3318
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/preload-helper.BnKG7j8P.js",
+            "entryType": "resource",
+            "startTime": 23.299999997019768,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 737,
+            "decodedBodySize": 1351
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/starlight-toc.CTCQXEge.js",
+            "entryType": "resource",
+            "startTime": 23.5,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 951,
+            "decodedBodySize": 1981
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/persistent-toggle.t6KkBAiq.js",
+            "entryType": "resource",
+            "startTime": 23.5,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 705,
+            "decodedBodySize": 2082
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/InteractiveCell.DoOzatBM.js",
+            "entryType": "resource",
+            "startTime": 40.3999999910593,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 16384,
+            "decodedBodySize": 50227
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/client.BJAMOzhD.js",
+            "entryType": "resource",
+            "startTime": 40.79999999701977,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 814,
+            "decodedBodySize": 1412
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/preact.Bl7PEaKa.js",
+            "entryType": "resource",
+            "startTime": 42.70000000298023,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 4413,
+            "decodedBodySize": 10470
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/output-limits.vkaihnVu.js",
+            "entryType": "resource",
+            "startTime": 42.79999999701977,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 3659,
+            "decodedBodySize": 8969
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/hooks.ClbWuNs9.js",
+            "entryType": "resource",
+            "startTime": 42.79999999701977,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 1153,
+            "decodedBodySize": 2677
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/favicon.svg",
+            "entryType": "resource",
+            "startTime": 43.099999994039536,
+            "duration": 1.2000000029802322,
+            "initiatorType": "other",
+            "transferSize": 0,
+            "encodedBodySize": 259,
+            "decodedBodySize": 331
+          },
+          {
+            "name": "oxiquill:hydrated:features__interactive-cells__python-controls",
+            "entryType": "mark",
+            "startTime": 50,
+            "duration": 0
+          },
+          {
+            "name": "oxiquill:worker-start:python",
+            "entryType": "mark",
+            "startTime": 54.599999994039536,
+            "duration": 0
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/python-worker-CZmazRja.js",
+            "entryType": "resource",
+            "startTime": 59.5,
+            "duration": -3.1000000089406967,
+            "initiatorType": "other",
+            "transferSize": 0,
+            "encodedBodySize": 13024,
+            "decodedBodySize": 47679
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/ui-core.BwVUYzUq.js",
+            "entryType": "resource",
+            "startTime": 66.20000000298023,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 26119,
+            "decodedBodySize": 93799
+          },
+          {
+            "name": "oxiquill:output-rendered:features__interactive-cells__python-controls",
+            "entryType": "mark",
+            "startTime": 1385.5,
+            "duration": 0
+          }
+        ]
+      },
+      "workers": [
+        {
+          "timeOrigin": 1788590356214.3,
+          "entries": [
+            {
+              "name": "oxiquill:worker-ready:python",
+              "entryType": "mark",
+              "startTime": 3.1000000089406967,
+              "duration": 0
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pyodide.mjs",
+              "entryType": "resource",
+              "startTime": 4.700000002980232,
+              "duration": 1.2000000029802322,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 7156,
+              "decodedBodySize": 17931
+            },
+            {
+              "name": "oxiquill:initialization:python",
+              "entryType": "measure",
+              "startTime": 9.300000011920929,
+              "duration": 1276.8999999910593
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pyodide-lock.json",
+              "entryType": "resource",
+              "startTime": 9.600000008940697,
+              "duration": 2,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 26534,
+              "decodedBodySize": 114440
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/python_stdlib.zip",
+              "entryType": "resource",
+              "startTime": 10,
+              "duration": 16.200000002980232,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 2503174,
+              "decodedBodySize": 2545564
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pyodide.asm.wasm",
+              "entryType": "resource",
+              "startTime": 10.200000002980232,
+              "duration": 87.40000000596046,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 3546129,
+              "decodedBodySize": 9598218
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pyodide.asm.mjs",
+              "entryType": "resource",
+              "startTime": 10.400000005960464,
+              "duration": 9.400000005960464,
+              "initiatorType": "script",
+              "transferSize": 0,
+              "encodedBodySize": 260107,
+              "decodedBodySize": 1250344
+            },
+            {
+              "name": "oxiquill:display-support:python",
+              "entryType": "measure",
+              "startTime": 1286.300000011921,
+              "duration": 33.5
+            },
+            {
+              "name": "oxiquill:imports:features__interactive-cells__python-controls",
+              "entryType": "measure",
+              "startTime": 1319.9000000059605,
+              "duration": 1.0999999940395355
+            },
+            {
+              "name": "oxiquill:display-prepare:features__interactive-cells__python-controls",
+              "entryType": "measure",
+              "startTime": 1321.1000000089407,
+              "duration": 0.7000000029802322
+            },
+            {
+              "name": "oxiquill:execution:features__interactive-cells__python-controls",
+              "entryType": "measure",
+              "startTime": 1321.9000000059605,
+              "duration": 3.2000000029802322
+            },
+            {
+              "name": "oxiquill:display-collect:features__interactive-cells__python-controls",
+              "entryType": "measure",
+              "startTime": 1325.7000000029802,
+              "duration": 0.6000000089406967
+            }
+          ]
+        }
+      ],
+      "observed": {
+        "requests": [
+          {
+            "requestId": 1,
+            "at": 1788590356211.3
+          }
+        ],
+        "responses": [
+          {
+            "requestId": 1,
+            "at": 1788590357542.2002,
+            "ok": true
+          }
+        ]
+      }
+    },
+    {
+      "example": "features/interactive-cells/",
+      "condition": "repeat",
+      "run": 3,
+      "triggerMs": 1437.5,
+      "outputMs": 1598.3999999910593,
+      "latencyMs": 160.8999999910593,
+      "renderObserverDeltaMs": 0,
+      "main": {
+        "timeOrigin": 1788590356156.6,
+        "entries": [
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/index.DANjJwMU.css",
+            "entryType": "resource",
+            "startTime": 13.5,
+            "duration": 0,
+            "initiatorType": "link",
+            "transferSize": 0,
+            "encodedBodySize": 21609,
+            "decodedBodySize": 105367
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/page.Dwipeu-R.js",
+            "entryType": "resource",
+            "startTime": 13.5,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 1124,
+            "decodedBodySize": 2486
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/Search.astro_astro_type_script_index_0_lang.DzL-jWp_.js",
+            "entryType": "resource",
+            "startTime": 13.599999994039536,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 945,
+            "decodedBodySize": 1830
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/MobileTableOfContents.astro_astro_type_script_index_0_lang.BcSo_yiZ.js",
+            "entryType": "resource",
+            "startTime": 13.599999994039536,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 364,
+            "decodedBodySize": 622
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/TableOfContents.astro_astro_type_script_index_0_lang.Csloo1VZ.js",
+            "entryType": "resource",
+            "startTime": 13.700000002980232,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 56,
+            "decodedBodySize": 36
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/TwoColumnContent.astro_astro_type_script_index_0_lang.DPGAuL8N.js",
+            "entryType": "resource",
+            "startTime": 13.700000002980232,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 269,
+            "decodedBodySize": 452
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/PageFrame.astro_astro_type_script_index_0_lang.iwTubUja.js",
+            "entryType": "resource",
+            "startTime": 13.700000002980232,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 257,
+            "decodedBodySize": 392
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/print.ehPL0gv-.css",
+            "entryType": "resource",
+            "startTime": 17.200000002980232,
+            "duration": 0,
+            "initiatorType": "link",
+            "transferSize": 0,
+            "encodedBodySize": 996,
+            "decodedBodySize": 3318
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/preload-helper.BnKG7j8P.js",
+            "entryType": "resource",
+            "startTime": 23.299999997019768,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 737,
+            "decodedBodySize": 1351
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/starlight-toc.CTCQXEge.js",
+            "entryType": "resource",
+            "startTime": 23.5,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 951,
+            "decodedBodySize": 1981
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/persistent-toggle.t6KkBAiq.js",
+            "entryType": "resource",
+            "startTime": 23.5,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 705,
+            "decodedBodySize": 2082
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/InteractiveCell.DoOzatBM.js",
+            "entryType": "resource",
+            "startTime": 40.3999999910593,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 16384,
+            "decodedBodySize": 50227
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/client.BJAMOzhD.js",
+            "entryType": "resource",
+            "startTime": 40.79999999701977,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 814,
+            "decodedBodySize": 1412
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/preact.Bl7PEaKa.js",
+            "entryType": "resource",
+            "startTime": 42.70000000298023,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 4413,
+            "decodedBodySize": 10470
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/output-limits.vkaihnVu.js",
+            "entryType": "resource",
+            "startTime": 42.79999999701977,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 3659,
+            "decodedBodySize": 8969
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/hooks.ClbWuNs9.js",
+            "entryType": "resource",
+            "startTime": 42.79999999701977,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 1153,
+            "decodedBodySize": 2677
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/favicon.svg",
+            "entryType": "resource",
+            "startTime": 43.099999994039536,
+            "duration": 1.2000000029802322,
+            "initiatorType": "other",
+            "transferSize": 0,
+            "encodedBodySize": 259,
+            "decodedBodySize": 331
+          },
+          {
+            "name": "oxiquill:hydrated:features__interactive-cells__python-controls",
+            "entryType": "mark",
+            "startTime": 50,
+            "duration": 0
+          },
+          {
+            "name": "oxiquill:worker-start:python",
+            "entryType": "mark",
+            "startTime": 54.599999994039536,
+            "duration": 0
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/python-worker-CZmazRja.js",
+            "entryType": "resource",
+            "startTime": 59.5,
+            "duration": -3.1000000089406967,
+            "initiatorType": "other",
+            "transferSize": 0,
+            "encodedBodySize": 13024,
+            "decodedBodySize": 47679
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/ui-core.BwVUYzUq.js",
+            "entryType": "resource",
+            "startTime": 66.20000000298023,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 26119,
+            "decodedBodySize": 93799
+          },
+          {
+            "name": "oxiquill:output-rendered:features__interactive-cells__python-controls",
+            "entryType": "mark",
+            "startTime": 1598.3999999910593,
+            "duration": 0
+          }
+        ]
+      },
+      "workers": [
+        {
+          "timeOrigin": 1788590356214.3,
+          "entries": [
+            {
+              "name": "oxiquill:worker-ready:python",
+              "entryType": "mark",
+              "startTime": 3.1000000089406967,
+              "duration": 0
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pyodide.mjs",
+              "entryType": "resource",
+              "startTime": 4.700000002980232,
+              "duration": 1.2000000029802322,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 7156,
+              "decodedBodySize": 17931
+            },
+            {
+              "name": "oxiquill:initialization:python",
+              "entryType": "measure",
+              "startTime": 9.300000011920929,
+              "duration": 1276.8999999910593
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pyodide-lock.json",
+              "entryType": "resource",
+              "startTime": 9.600000008940697,
+              "duration": 2,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 26534,
+              "decodedBodySize": 114440
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/python_stdlib.zip",
+              "entryType": "resource",
+              "startTime": 10,
+              "duration": 16.200000002980232,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 2503174,
+              "decodedBodySize": 2545564
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pyodide.asm.wasm",
+              "entryType": "resource",
+              "startTime": 10.200000002980232,
+              "duration": 87.40000000596046,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 3546129,
+              "decodedBodySize": 9598218
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pyodide.asm.mjs",
+              "entryType": "resource",
+              "startTime": 10.400000005960464,
+              "duration": 9.400000005960464,
+              "initiatorType": "script",
+              "transferSize": 0,
+              "encodedBodySize": 260107,
+              "decodedBodySize": 1250344
+            },
+            {
+              "name": "oxiquill:display-support:python",
+              "entryType": "measure",
+              "startTime": 1286.300000011921,
+              "duration": 33.5
+            },
+            {
+              "name": "oxiquill:imports:features__interactive-cells__python-controls",
+              "entryType": "measure",
+              "startTime": 1536.300000011921,
+              "duration": 0.699999988079071
+            },
+            {
+              "name": "oxiquill:display-prepare:features__interactive-cells__python-controls",
+              "entryType": "measure",
+              "startTime": 1537.1000000089407,
+              "duration": 0.7000000029802322
+            },
+            {
+              "name": "oxiquill:execution:features__interactive-cells__python-controls",
+              "entryType": "measure",
+              "startTime": 1537.9000000059605,
+              "duration": 1.2999999970197678
+            },
+            {
+              "name": "oxiquill:display-collect:features__interactive-cells__python-controls",
+              "entryType": "measure",
+              "startTime": 1539.5,
+              "duration": 0.4000000059604645
+            }
+          ]
+        }
+      ],
+      "observed": {
+        "requests": [
+          {
+            "requestId": 1,
+            "at": 1788590356211.3
+          },
+          {
+            "requestId": 2,
+            "at": 1788590357750.6
+          }
+        ],
+        "responses": [
+          {
+            "requestId": 1,
+            "at": 1788590357542.2002,
+            "ok": true
+          },
+          {
+            "requestId": 2,
+            "at": 1788590357755,
+            "ok": true
+          }
+        ]
+      }
+    },
+    {
+      "example": "features/interactive-cells/",
+      "condition": "fresh",
+      "run": 4,
+      "triggerMs": 155.29999999701977,
+      "outputMs": 1505.3999999910593,
+      "latencyMs": 1505.3999999910593,
+      "renderObserverDeltaMs": -0.2001953125,
+      "main": {
+        "timeOrigin": 1788590357820.8,
+        "entries": [
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/index.DANjJwMU.css",
+            "entryType": "resource",
+            "startTime": 6.199999988079071,
+            "duration": 2.6000000089406967,
+            "initiatorType": "link",
+            "transferSize": 21909,
+            "encodedBodySize": 21609,
+            "decodedBodySize": 105367
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/page.Dwipeu-R.js",
+            "entryType": "resource",
+            "startTime": 6.399999991059303,
+            "duration": 8,
+            "initiatorType": "script",
+            "transferSize": 1424,
+            "encodedBodySize": 1124,
+            "decodedBodySize": 2486
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/Search.astro_astro_type_script_index_0_lang.DzL-jWp_.js",
+            "entryType": "resource",
+            "startTime": 6.5,
+            "duration": 8.199999988079071,
+            "initiatorType": "script",
+            "transferSize": 1245,
+            "encodedBodySize": 945,
+            "decodedBodySize": 1830
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/MobileTableOfContents.astro_astro_type_script_index_0_lang.BcSo_yiZ.js",
+            "entryType": "resource",
+            "startTime": 6.5,
+            "duration": 8.299999997019768,
+            "initiatorType": "script",
+            "transferSize": 664,
+            "encodedBodySize": 364,
+            "decodedBodySize": 622
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/TableOfContents.astro_astro_type_script_index_0_lang.Csloo1VZ.js",
+            "entryType": "resource",
+            "startTime": 6.5999999940395355,
+            "duration": 8.299999997019768,
+            "initiatorType": "script",
+            "transferSize": 356,
+            "encodedBodySize": 56,
+            "decodedBodySize": 36
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/TwoColumnContent.astro_astro_type_script_index_0_lang.DPGAuL8N.js",
+            "entryType": "resource",
+            "startTime": 6.5999999940395355,
+            "duration": 8.5,
+            "initiatorType": "script",
+            "transferSize": 569,
+            "encodedBodySize": 269,
+            "decodedBodySize": 452
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/PageFrame.astro_astro_type_script_index_0_lang.iwTubUja.js",
+            "entryType": "resource",
+            "startTime": 6.699999988079071,
+            "duration": 8.5,
+            "initiatorType": "script",
+            "transferSize": 557,
+            "encodedBodySize": 257,
+            "decodedBodySize": 392
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/print.ehPL0gv-.css",
+            "entryType": "resource",
+            "startTime": 11.399999991059303,
+            "duration": 5,
+            "initiatorType": "link",
+            "transferSize": 1296,
+            "encodedBodySize": 996,
+            "decodedBodySize": 3318
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/preload-helper.BnKG7j8P.js",
+            "entryType": "resource",
+            "startTime": 22.19999998807907,
+            "duration": 3.1000000089406967,
+            "initiatorType": "script",
+            "transferSize": 1037,
+            "encodedBodySize": 737,
+            "decodedBodySize": 1351
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/starlight-toc.CTCQXEge.js",
+            "entryType": "resource",
+            "startTime": 22.299999997019768,
+            "duration": 3.0999999940395355,
+            "initiatorType": "script",
+            "transferSize": 1251,
+            "encodedBodySize": 951,
+            "decodedBodySize": 1981
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/persistent-toggle.t6KkBAiq.js",
+            "entryType": "resource",
+            "startTime": 22.299999997019768,
+            "duration": 3.2000000029802322,
+            "initiatorType": "script",
+            "transferSize": 1005,
+            "encodedBodySize": 705,
+            "decodedBodySize": 2082
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/favicon.svg",
+            "entryType": "resource",
+            "startTime": 68.69999998807907,
+            "duration": 1.800000011920929,
+            "initiatorType": "other",
+            "transferSize": 559,
+            "encodedBodySize": 259,
+            "decodedBodySize": 331
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/ui-core.BwVUYzUq.js",
+            "entryType": "resource",
+            "startTime": 79.79999999701977,
+            "duration": 1.7999999970197678,
+            "initiatorType": "script",
+            "transferSize": 26419,
+            "encodedBodySize": 26119,
+            "decodedBodySize": 93799
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/InteractiveCell.DoOzatBM.js",
+            "entryType": "resource",
+            "startTime": 138.5,
+            "duration": 2.5999999940395355,
+            "initiatorType": "script",
+            "transferSize": 16684,
+            "encodedBodySize": 16384,
+            "decodedBodySize": 50227
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/client.BJAMOzhD.js",
+            "entryType": "resource",
+            "startTime": 138.59999999403954,
+            "duration": 2.4000000059604645,
+            "initiatorType": "script",
+            "transferSize": 1114,
+            "encodedBodySize": 814,
+            "decodedBodySize": 1412
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/preact.Bl7PEaKa.js",
+            "entryType": "resource",
+            "startTime": 141.79999999701977,
+            "duration": 2.7000000029802322,
+            "initiatorType": "script",
+            "transferSize": 4713,
+            "encodedBodySize": 4413,
+            "decodedBodySize": 10470
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/output-limits.vkaihnVu.js",
+            "entryType": "resource",
+            "startTime": 142.69999998807907,
+            "duration": 3.800000011920929,
+            "initiatorType": "script",
+            "transferSize": 3959,
+            "encodedBodySize": 3659,
+            "decodedBodySize": 8969
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/hooks.ClbWuNs9.js",
+            "entryType": "resource",
+            "startTime": 142.69999998807907,
+            "duration": 3.9000000059604645,
+            "initiatorType": "script",
+            "transferSize": 1453,
+            "encodedBodySize": 1153,
+            "decodedBodySize": 2677
+          },
+          {
+            "name": "oxiquill:hydrated:features__interactive-cells__python-controls",
+            "entryType": "mark",
+            "startTime": 150.09999999403954,
+            "duration": 0
+          },
+          {
+            "name": "oxiquill:worker-start:python",
+            "entryType": "mark",
+            "startTime": 154.79999999701977,
+            "duration": 0
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/python-worker-CZmazRja.js",
+            "entryType": "resource",
+            "startTime": 159.29999999701977,
+            "duration": -1.6000000089406967,
+            "initiatorType": "other",
+            "transferSize": 13324,
+            "encodedBodySize": 13024,
+            "decodedBodySize": 47679
+          },
+          {
+            "name": "oxiquill:output-rendered:features__interactive-cells__python-controls",
+            "entryType": "mark",
+            "startTime": 1505.3999999910593,
+            "duration": 0
+          }
+        ]
+      },
+      "workers": [
+        {
+          "timeOrigin": 1788590357978.2,
+          "entries": [
+            {
+              "name": "oxiquill:worker-ready:python",
+              "entryType": "mark",
+              "startTime": 3.2999999970197678,
+              "duration": 0
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pyodide.mjs",
+              "entryType": "resource",
+              "startTime": 4.0999999940395355,
+              "duration": 1.5,
+              "initiatorType": "fetch",
+              "transferSize": 7456,
+              "encodedBodySize": 7156,
+              "decodedBodySize": 17931
+            },
+            {
+              "name": "oxiquill:initialization:python",
+              "entryType": "measure",
+              "startTime": 8.799999997019768,
+              "duration": 1299
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pyodide-lock.json",
+              "entryType": "resource",
+              "startTime": 9.099999994039536,
+              "duration": 6,
+              "initiatorType": "fetch",
+              "transferSize": 26834,
+              "encodedBodySize": 26534,
+              "decodedBodySize": 114440
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/python_stdlib.zip",
+              "entryType": "resource",
+              "startTime": 9.5,
+              "duration": 23.69999998807907,
+              "initiatorType": "fetch",
+              "transferSize": 2503474,
+              "encodedBodySize": 2503174,
+              "decodedBodySize": 2545564
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pyodide.asm.wasm",
+              "entryType": "resource",
+              "startTime": 9.799999997019768,
+              "duration": 99.09999999403954,
+              "initiatorType": "fetch",
+              "transferSize": 3546429,
+              "encodedBodySize": 3546129,
+              "decodedBodySize": 9598218
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pyodide.asm.mjs",
+              "entryType": "resource",
+              "startTime": 10,
+              "duration": 12.599999994039536,
+              "initiatorType": "script",
+              "transferSize": 260407,
+              "encodedBodySize": 260107,
+              "decodedBodySize": 1250344
+            },
+            {
+              "name": "oxiquill:display-support:python",
+              "entryType": "measure",
+              "startTime": 1307.7999999970198,
+              "duration": 32
+            },
+            {
+              "name": "oxiquill:imports:features__interactive-cells__python-controls",
+              "entryType": "measure",
+              "startTime": 1340.0999999940395,
+              "duration": 0.9000000059604645
+            },
+            {
+              "name": "oxiquill:display-prepare:features__interactive-cells__python-controls",
+              "entryType": "measure",
+              "startTime": 1341,
+              "duration": 0.699999988079071
+            },
+            {
+              "name": "oxiquill:execution:features__interactive-cells__python-controls",
+              "entryType": "measure",
+              "startTime": 1341.7999999970198,
+              "duration": 3.3999999910593033
+            },
+            {
+              "name": "oxiquill:display-collect:features__interactive-cells__python-controls",
+              "entryType": "measure",
+              "startTime": 1345.699999988079,
+              "duration": 0.5
+            }
+          ]
+        }
+      ],
+      "observed": {
+        "requests": [
+          {
+            "requestId": 1,
+            "at": 1788590357975.8
+          }
+        ],
+        "responses": [
+          {
+            "requestId": 1,
+            "at": 1788590359326.4001,
+            "ok": true
+          }
+        ]
+      }
+    },
+    {
+      "example": "features/interactive-cells/",
+      "condition": "reload",
+      "run": 4,
+      "triggerMs": 106.1000000089407,
+      "outputMs": 1376.1000000089407,
+      "latencyMs": 1376.1000000089407,
+      "renderObserverDeltaMs": -0.099853515625,
+      "main": {
+        "timeOrigin": 1788590359354,
+        "entries": [
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/index.DANjJwMU.css",
+            "entryType": "resource",
+            "startTime": 12,
+            "duration": 0,
+            "initiatorType": "link",
+            "transferSize": 0,
+            "encodedBodySize": 21609,
+            "decodedBodySize": 105367
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/page.Dwipeu-R.js",
+            "entryType": "resource",
+            "startTime": 12,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 1124,
+            "decodedBodySize": 2486
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/Search.astro_astro_type_script_index_0_lang.DzL-jWp_.js",
+            "entryType": "resource",
+            "startTime": 12.100000008940697,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 945,
+            "decodedBodySize": 1830
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/MobileTableOfContents.astro_astro_type_script_index_0_lang.BcSo_yiZ.js",
+            "entryType": "resource",
+            "startTime": 12.100000008940697,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 364,
+            "decodedBodySize": 622
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/TableOfContents.astro_astro_type_script_index_0_lang.Csloo1VZ.js",
+            "entryType": "resource",
+            "startTime": 12.200000002980232,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 56,
+            "decodedBodySize": 36
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/TwoColumnContent.astro_astro_type_script_index_0_lang.DPGAuL8N.js",
+            "entryType": "resource",
+            "startTime": 12.200000002980232,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 269,
+            "decodedBodySize": 452
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/PageFrame.astro_astro_type_script_index_0_lang.iwTubUja.js",
+            "entryType": "resource",
+            "startTime": 12.299999997019768,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 257,
+            "decodedBodySize": 392
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/print.ehPL0gv-.css",
+            "entryType": "resource",
+            "startTime": 15.5,
+            "duration": 0,
+            "initiatorType": "link",
+            "transferSize": 0,
+            "encodedBodySize": 996,
+            "decodedBodySize": 3318
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/preload-helper.BnKG7j8P.js",
+            "entryType": "resource",
+            "startTime": 21.299999997019768,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 737,
+            "decodedBodySize": 1351
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/starlight-toc.CTCQXEge.js",
+            "entryType": "resource",
+            "startTime": 22.200000002980232,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 951,
+            "decodedBodySize": 1981
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/persistent-toggle.t6KkBAiq.js",
+            "entryType": "resource",
+            "startTime": 22.5,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 705,
+            "decodedBodySize": 2082
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/InteractiveCell.DoOzatBM.js",
+            "entryType": "resource",
+            "startTime": 38.900000005960464,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 16384,
+            "decodedBodySize": 50227
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/client.BJAMOzhD.js",
+            "entryType": "resource",
+            "startTime": 39.1000000089407,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 814,
+            "decodedBodySize": 1412
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/preact.Bl7PEaKa.js",
+            "entryType": "resource",
+            "startTime": 41,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 4413,
+            "decodedBodySize": 10470
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/output-limits.vkaihnVu.js",
+            "entryType": "resource",
+            "startTime": 41.1000000089407,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 3659,
+            "decodedBodySize": 8969
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/hooks.ClbWuNs9.js",
+            "entryType": "resource",
+            "startTime": 41.20000000298023,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 1153,
+            "decodedBodySize": 2677
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/favicon.svg",
+            "entryType": "resource",
+            "startTime": 41.5,
+            "duration": 1.4000000059604645,
+            "initiatorType": "other",
+            "transferSize": 0,
+            "encodedBodySize": 259,
+            "decodedBodySize": 331
+          },
+          {
+            "name": "oxiquill:hydrated:features__interactive-cells__python-controls",
+            "entryType": "mark",
+            "startTime": 43,
+            "duration": 0
+          },
+          {
+            "name": "oxiquill:worker-start:python",
+            "entryType": "mark",
+            "startTime": 57.900000005960464,
+            "duration": 0
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/ui-core.BwVUYzUq.js",
+            "entryType": "resource",
+            "startTime": 63.400000005960464,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 26119,
+            "decodedBodySize": 93799
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/python-worker-CZmazRja.js",
+            "entryType": "resource",
+            "startTime": 64.1000000089407,
+            "duration": -4.100000008940697,
+            "initiatorType": "other",
+            "transferSize": 0,
+            "encodedBodySize": 13024,
+            "decodedBodySize": 47679
+          },
+          {
+            "name": "oxiquill:output-rendered:features__interactive-cells__python-controls",
+            "entryType": "mark",
+            "startTime": 1376.1000000089407,
+            "duration": 0
+          }
+        ]
+      },
+      "workers": [
+        {
+          "timeOrigin": 1788590359416.7,
+          "entries": [
+            {
+              "name": "oxiquill:worker-ready:python",
+              "entryType": "mark",
+              "startTime": 3,
+              "duration": 0
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pyodide.mjs",
+              "entryType": "resource",
+              "startTime": 3.8999999910593033,
+              "duration": 1.2999999970197678,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 7156,
+              "decodedBodySize": 17931
+            },
+            {
+              "name": "oxiquill:initialization:python",
+              "entryType": "measure",
+              "startTime": 8,
+              "duration": 1265.199999988079
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pyodide-lock.json",
+              "entryType": "resource",
+              "startTime": 8.399999991059303,
+              "duration": 1.4000000059604645,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 26534,
+              "decodedBodySize": 114440
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/python_stdlib.zip",
+              "entryType": "resource",
+              "startTime": 8.799999997019768,
+              "duration": 15.399999991059303,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 2503174,
+              "decodedBodySize": 2545564
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pyodide.asm.wasm",
+              "entryType": "resource",
+              "startTime": 9,
+              "duration": 85,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 3546129,
+              "decodedBodySize": 9598218
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pyodide.asm.mjs",
+              "entryType": "resource",
+              "startTime": 9.199999988079071,
+              "duration": 8.700000002980232,
+              "initiatorType": "script",
+              "transferSize": 0,
+              "encodedBodySize": 260107,
+              "decodedBodySize": 1250344
+            },
+            {
+              "name": "oxiquill:display-support:python",
+              "entryType": "measure",
+              "startTime": 1273.199999988079,
+              "duration": 32.6000000089407
+            },
+            {
+              "name": "oxiquill:imports:features__interactive-cells__python-controls",
+              "entryType": "measure",
+              "startTime": 1306,
+              "duration": 1.199999988079071
+            },
+            {
+              "name": "oxiquill:display-prepare:features__interactive-cells__python-controls",
+              "entryType": "measure",
+              "startTime": 1307.199999988079,
+              "duration": 0.800000011920929
+            },
+            {
+              "name": "oxiquill:execution:features__interactive-cells__python-controls",
+              "entryType": "measure",
+              "startTime": 1308.199999988079,
+              "duration": 3.1000000089406967
+            },
+            {
+              "name": "oxiquill:display-collect:features__interactive-cells__python-controls",
+              "entryType": "measure",
+              "startTime": 1311.8999999910593,
+              "duration": 0.5
+            }
+          ]
+        }
+      ],
+      "observed": {
+        "requests": [
+          {
+            "requestId": 1,
+            "at": 1788590359412.1
+          }
+        ],
+        "responses": [
+          {
+            "requestId": 1,
+            "at": 1788590360730.2,
+            "ok": true
+          }
+        ]
+      }
+    },
+    {
+      "example": "features/interactive-cells/",
+      "condition": "repeat",
+      "run": 4,
+      "triggerMs": 1423.2999999970198,
+      "outputMs": 1586.9000000059605,
+      "latencyMs": 163.6000000089407,
+      "renderObserverDeltaMs": -0.10009765625,
+      "main": {
+        "timeOrigin": 1788590359354,
+        "entries": [
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/index.DANjJwMU.css",
+            "entryType": "resource",
+            "startTime": 12,
+            "duration": 0,
+            "initiatorType": "link",
+            "transferSize": 0,
+            "encodedBodySize": 21609,
+            "decodedBodySize": 105367
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/page.Dwipeu-R.js",
+            "entryType": "resource",
+            "startTime": 12,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 1124,
+            "decodedBodySize": 2486
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/Search.astro_astro_type_script_index_0_lang.DzL-jWp_.js",
+            "entryType": "resource",
+            "startTime": 12.100000008940697,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 945,
+            "decodedBodySize": 1830
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/MobileTableOfContents.astro_astro_type_script_index_0_lang.BcSo_yiZ.js",
+            "entryType": "resource",
+            "startTime": 12.100000008940697,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 364,
+            "decodedBodySize": 622
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/TableOfContents.astro_astro_type_script_index_0_lang.Csloo1VZ.js",
+            "entryType": "resource",
+            "startTime": 12.200000002980232,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 56,
+            "decodedBodySize": 36
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/TwoColumnContent.astro_astro_type_script_index_0_lang.DPGAuL8N.js",
+            "entryType": "resource",
+            "startTime": 12.200000002980232,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 269,
+            "decodedBodySize": 452
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/PageFrame.astro_astro_type_script_index_0_lang.iwTubUja.js",
+            "entryType": "resource",
+            "startTime": 12.299999997019768,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 257,
+            "decodedBodySize": 392
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/print.ehPL0gv-.css",
+            "entryType": "resource",
+            "startTime": 15.5,
+            "duration": 0,
+            "initiatorType": "link",
+            "transferSize": 0,
+            "encodedBodySize": 996,
+            "decodedBodySize": 3318
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/preload-helper.BnKG7j8P.js",
+            "entryType": "resource",
+            "startTime": 21.299999997019768,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 737,
+            "decodedBodySize": 1351
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/starlight-toc.CTCQXEge.js",
+            "entryType": "resource",
+            "startTime": 22.200000002980232,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 951,
+            "decodedBodySize": 1981
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/persistent-toggle.t6KkBAiq.js",
+            "entryType": "resource",
+            "startTime": 22.5,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 705,
+            "decodedBodySize": 2082
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/InteractiveCell.DoOzatBM.js",
+            "entryType": "resource",
+            "startTime": 38.900000005960464,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 16384,
+            "decodedBodySize": 50227
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/client.BJAMOzhD.js",
+            "entryType": "resource",
+            "startTime": 39.1000000089407,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 814,
+            "decodedBodySize": 1412
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/preact.Bl7PEaKa.js",
+            "entryType": "resource",
+            "startTime": 41,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 4413,
+            "decodedBodySize": 10470
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/output-limits.vkaihnVu.js",
+            "entryType": "resource",
+            "startTime": 41.1000000089407,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 3659,
+            "decodedBodySize": 8969
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/hooks.ClbWuNs9.js",
+            "entryType": "resource",
+            "startTime": 41.20000000298023,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 1153,
+            "decodedBodySize": 2677
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/favicon.svg",
+            "entryType": "resource",
+            "startTime": 41.5,
+            "duration": 1.4000000059604645,
+            "initiatorType": "other",
+            "transferSize": 0,
+            "encodedBodySize": 259,
+            "decodedBodySize": 331
+          },
+          {
+            "name": "oxiquill:hydrated:features__interactive-cells__python-controls",
+            "entryType": "mark",
+            "startTime": 43,
+            "duration": 0
+          },
+          {
+            "name": "oxiquill:worker-start:python",
+            "entryType": "mark",
+            "startTime": 57.900000005960464,
+            "duration": 0
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/ui-core.BwVUYzUq.js",
+            "entryType": "resource",
+            "startTime": 63.400000005960464,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 26119,
+            "decodedBodySize": 93799
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/python-worker-CZmazRja.js",
+            "entryType": "resource",
+            "startTime": 64.1000000089407,
+            "duration": -4.100000008940697,
+            "initiatorType": "other",
+            "transferSize": 0,
+            "encodedBodySize": 13024,
+            "decodedBodySize": 47679
+          },
+          {
+            "name": "oxiquill:output-rendered:features__interactive-cells__python-controls",
+            "entryType": "mark",
+            "startTime": 1586.9000000059605,
+            "duration": 0
+          }
+        ]
+      },
+      "workers": [
+        {
+          "timeOrigin": 1788590359416.7,
+          "entries": [
+            {
+              "name": "oxiquill:worker-ready:python",
+              "entryType": "mark",
+              "startTime": 3,
+              "duration": 0
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pyodide.mjs",
+              "entryType": "resource",
+              "startTime": 3.8999999910593033,
+              "duration": 1.2999999970197678,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 7156,
+              "decodedBodySize": 17931
+            },
+            {
+              "name": "oxiquill:initialization:python",
+              "entryType": "measure",
+              "startTime": 8,
+              "duration": 1265.199999988079
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pyodide-lock.json",
+              "entryType": "resource",
+              "startTime": 8.399999991059303,
+              "duration": 1.4000000059604645,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 26534,
+              "decodedBodySize": 114440
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/python_stdlib.zip",
+              "entryType": "resource",
+              "startTime": 8.799999997019768,
+              "duration": 15.399999991059303,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 2503174,
+              "decodedBodySize": 2545564
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pyodide.asm.wasm",
+              "entryType": "resource",
+              "startTime": 9,
+              "duration": 85,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 3546129,
+              "decodedBodySize": 9598218
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pyodide.asm.mjs",
+              "entryType": "resource",
+              "startTime": 9.199999988079071,
+              "duration": 8.700000002980232,
+              "initiatorType": "script",
+              "transferSize": 0,
+              "encodedBodySize": 260107,
+              "decodedBodySize": 1250344
+            },
+            {
+              "name": "oxiquill:display-support:python",
+              "entryType": "measure",
+              "startTime": 1273.199999988079,
+              "duration": 32.6000000089407
+            },
+            {
+              "name": "oxiquill:imports:features__interactive-cells__python-controls",
+              "entryType": "measure",
+              "startTime": 1517.699999988079,
+              "duration": 1.1000000089406967
+            },
+            {
+              "name": "oxiquill:display-prepare:features__interactive-cells__python-controls",
+              "entryType": "measure",
+              "startTime": 1518.8999999910593,
+              "duration": 1.2999999970197678
+            },
+            {
+              "name": "oxiquill:execution:features__interactive-cells__python-controls",
+              "entryType": "measure",
+              "startTime": 1520.2999999970198,
+              "duration": 2.2000000029802322
+            },
+            {
+              "name": "oxiquill:display-collect:features__interactive-cells__python-controls",
+              "entryType": "measure",
+              "startTime": 1523,
+              "duration": 0.699999988079071
+            }
+          ]
+        }
+      ],
+      "observed": {
+        "requests": [
+          {
+            "requestId": 1,
+            "at": 1788590359412.1
+          },
+          {
+            "requestId": 2,
+            "at": 1788590360933.9
+          }
+        ],
+        "responses": [
+          {
+            "requestId": 1,
+            "at": 1788590360730.2,
+            "ok": true
+          },
+          {
+            "requestId": 2,
+            "at": 1788590360941,
+            "ok": true
+          }
+        ]
+      }
+    },
+    {
+      "example": "features/interactive-cells/",
+      "condition": "fresh",
+      "run": 5,
+      "triggerMs": 158.59999999403954,
+      "outputMs": 1526.5999999940395,
+      "latencyMs": 1526.5999999940395,
+      "renderObserverDeltaMs": -0.099853515625,
+      "main": {
+        "timeOrigin": 1788590361002.4,
+        "entries": [
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/index.DANjJwMU.css",
+            "entryType": "resource",
+            "startTime": 6.299999997019768,
+            "duration": 2.4000000059604645,
+            "initiatorType": "link",
+            "transferSize": 21909,
+            "encodedBodySize": 21609,
+            "decodedBodySize": 105367
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/page.Dwipeu-R.js",
+            "entryType": "resource",
+            "startTime": 6.5,
+            "duration": 7.700000002980232,
+            "initiatorType": "script",
+            "transferSize": 1424,
+            "encodedBodySize": 1124,
+            "decodedBodySize": 2486
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/Search.astro_astro_type_script_index_0_lang.DzL-jWp_.js",
+            "entryType": "resource",
+            "startTime": 6.5,
+            "duration": 8.099999994039536,
+            "initiatorType": "script",
+            "transferSize": 1245,
+            "encodedBodySize": 945,
+            "decodedBodySize": 1830
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/MobileTableOfContents.astro_astro_type_script_index_0_lang.BcSo_yiZ.js",
+            "entryType": "resource",
+            "startTime": 6.5999999940395355,
+            "duration": 8.100000008940697,
+            "initiatorType": "script",
+            "transferSize": 664,
+            "encodedBodySize": 364,
+            "decodedBodySize": 622
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/TableOfContents.astro_astro_type_script_index_0_lang.Csloo1VZ.js",
+            "entryType": "resource",
+            "startTime": 6.5999999940395355,
+            "duration": 8.200000002980232,
+            "initiatorType": "script",
+            "transferSize": 356,
+            "encodedBodySize": 56,
+            "decodedBodySize": 36
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/TwoColumnContent.astro_astro_type_script_index_0_lang.DPGAuL8N.js",
+            "entryType": "resource",
+            "startTime": 6.5999999940395355,
+            "duration": 8.400000005960464,
+            "initiatorType": "script",
+            "transferSize": 569,
+            "encodedBodySize": 269,
+            "decodedBodySize": 452
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/PageFrame.astro_astro_type_script_index_0_lang.iwTubUja.js",
+            "entryType": "resource",
+            "startTime": 6.5999999940395355,
+            "duration": 8.5,
+            "initiatorType": "script",
+            "transferSize": 557,
+            "encodedBodySize": 257,
+            "decodedBodySize": 392
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/print.ehPL0gv-.css",
+            "entryType": "resource",
+            "startTime": 10.299999997019768,
+            "duration": 6.100000008940697,
+            "initiatorType": "link",
+            "transferSize": 1296,
+            "encodedBodySize": 996,
+            "decodedBodySize": 3318
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/preload-helper.BnKG7j8P.js",
+            "entryType": "resource",
+            "startTime": 51.29999999701977,
+            "duration": 3.7000000029802322,
+            "initiatorType": "script",
+            "transferSize": 1037,
+            "encodedBodySize": 737,
+            "decodedBodySize": 1351
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/starlight-toc.CTCQXEge.js",
+            "entryType": "resource",
+            "startTime": 51.29999999701977,
+            "duration": 3.7999999970197678,
+            "initiatorType": "script",
+            "transferSize": 1251,
+            "encodedBodySize": 951,
+            "decodedBodySize": 1981
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/persistent-toggle.t6KkBAiq.js",
+            "entryType": "resource",
+            "startTime": 51.400000005960464,
+            "duration": 3.7999999970197678,
+            "initiatorType": "script",
+            "transferSize": 1005,
+            "encodedBodySize": 705,
+            "decodedBodySize": 2082
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/favicon.svg",
+            "entryType": "resource",
+            "startTime": 61.599999994039536,
+            "duration": 2,
+            "initiatorType": "other",
+            "transferSize": 559,
+            "encodedBodySize": 259,
+            "decodedBodySize": 331
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/ui-core.BwVUYzUq.js",
+            "entryType": "resource",
+            "startTime": 83.70000000298023,
+            "duration": 2.2999999970197678,
+            "initiatorType": "script",
+            "transferSize": 26419,
+            "encodedBodySize": 26119,
+            "decodedBodySize": 93799
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/InteractiveCell.DoOzatBM.js",
+            "entryType": "resource",
+            "startTime": 140.09999999403954,
+            "duration": 2.9000000059604645,
+            "initiatorType": "script",
+            "transferSize": 16684,
+            "encodedBodySize": 16384,
+            "decodedBodySize": 50227
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/client.BJAMOzhD.js",
+            "entryType": "resource",
+            "startTime": 140.20000000298023,
+            "duration": 2.7000000029802322,
+            "initiatorType": "script",
+            "transferSize": 1114,
+            "encodedBodySize": 814,
+            "decodedBodySize": 1412
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/preact.Bl7PEaKa.js",
+            "entryType": "resource",
+            "startTime": 143.70000000298023,
+            "duration": 2.5999999940395355,
+            "initiatorType": "script",
+            "transferSize": 4713,
+            "encodedBodySize": 4413,
+            "decodedBodySize": 10470
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/output-limits.vkaihnVu.js",
+            "entryType": "resource",
+            "startTime": 144.70000000298023,
+            "duration": 4.200000002980232,
+            "initiatorType": "script",
+            "transferSize": 3959,
+            "encodedBodySize": 3659,
+            "decodedBodySize": 8969
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/hooks.ClbWuNs9.js",
+            "entryType": "resource",
+            "startTime": 144.79999999701977,
+            "duration": 4.299999997019768,
+            "initiatorType": "script",
+            "transferSize": 1453,
+            "encodedBodySize": 1153,
+            "decodedBodySize": 2677
+          },
+          {
+            "name": "oxiquill:hydrated:features__interactive-cells__python-controls",
+            "entryType": "mark",
+            "startTime": 152.79999999701977,
+            "duration": 0
+          },
+          {
+            "name": "oxiquill:worker-start:python",
+            "entryType": "mark",
+            "startTime": 158,
+            "duration": 0
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/python-worker-CZmazRja.js",
+            "entryType": "resource",
+            "startTime": 162,
+            "duration": -1.5,
+            "initiatorType": "other",
+            "transferSize": 13324,
+            "encodedBodySize": 13024,
+            "decodedBodySize": 47679
+          },
+          {
+            "name": "oxiquill:output-rendered:features__interactive-cells__python-controls",
+            "entryType": "mark",
+            "startTime": 1526.5999999940395,
+            "duration": 0
+          }
+        ]
+      },
+      "workers": [
+        {
+          "timeOrigin": 1788590361162.7,
+          "entries": [
+            {
+              "name": "oxiquill:worker-ready:python",
+              "entryType": "mark",
+              "startTime": 3.1000000089406967,
+              "duration": 0
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pyodide.mjs",
+              "entryType": "resource",
+              "startTime": 4,
+              "duration": 1.6000000089406967,
+              "initiatorType": "fetch",
+              "transferSize": 7456,
+              "encodedBodySize": 7156,
+              "decodedBodySize": 17931
+            },
+            {
+              "name": "oxiquill:initialization:python",
+              "entryType": "measure",
+              "startTime": 9,
+              "duration": 1314.6000000089407
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pyodide-lock.json",
+              "entryType": "resource",
+              "startTime": 9.299999997019768,
+              "duration": 5.9000000059604645,
+              "initiatorType": "fetch",
+              "transferSize": 26834,
+              "encodedBodySize": 26534,
+              "decodedBodySize": 114440
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/python_stdlib.zip",
+              "entryType": "resource",
+              "startTime": 9.799999997019768,
+              "duration": 22.5,
+              "initiatorType": "fetch",
+              "transferSize": 2503474,
+              "encodedBodySize": 2503174,
+              "decodedBodySize": 2545564
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pyodide.asm.wasm",
+              "entryType": "resource",
+              "startTime": 10.100000008940697,
+              "duration": 97,
+              "initiatorType": "fetch",
+              "transferSize": 3546429,
+              "encodedBodySize": 3546129,
+              "decodedBodySize": 9598218
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pyodide.asm.mjs",
+              "entryType": "resource",
+              "startTime": 10.200000002980232,
+              "duration": 12.400000005960464,
+              "initiatorType": "script",
+              "transferSize": 260407,
+              "encodedBodySize": 260107,
+              "decodedBodySize": 1250344
+            },
+            {
+              "name": "oxiquill:display-support:python",
+              "entryType": "measure",
+              "startTime": 1323.7000000029802,
+              "duration": 33.900000005960464
+            },
+            {
+              "name": "oxiquill:imports:features__interactive-cells__python-controls",
+              "entryType": "measure",
+              "startTime": 1357.7999999970198,
+              "duration": 1.2000000029802322
+            },
+            {
+              "name": "oxiquill:display-prepare:features__interactive-cells__python-controls",
+              "entryType": "measure",
+              "startTime": 1359,
+              "duration": 0.9000000059604645
+            },
+            {
+              "name": "oxiquill:execution:features__interactive-cells__python-controls",
+              "entryType": "measure",
+              "startTime": 1359.9000000059605,
+              "duration": 3.2999999970197678
+            },
+            {
+              "name": "oxiquill:display-collect:features__interactive-cells__python-controls",
+              "entryType": "measure",
+              "startTime": 1363.9000000059605,
+              "duration": 0.5999999940395355
+            }
+          ]
+        }
+      ],
+      "observed": {
+        "requests": [
+          {
+            "requestId": 1,
+            "at": 1788590361160.7
+          }
+        ],
+        "responses": [
+          {
+            "requestId": 1,
+            "at": 1788590362529.0999,
+            "ok": true
+          }
+        ]
+      }
+    },
+    {
+      "example": "features/interactive-cells/",
+      "condition": "reload",
+      "run": 5,
+      "triggerMs": 106.09999999403954,
+      "outputMs": 1386.3999999910593,
+      "latencyMs": 1386.3999999910593,
+      "renderObserverDeltaMs": -0.10009765625,
+      "main": {
+        "timeOrigin": 1788590362554.2,
+        "entries": [
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/index.DANjJwMU.css",
+            "entryType": "resource",
+            "startTime": 12.699999988079071,
+            "duration": 0,
+            "initiatorType": "link",
+            "transferSize": 0,
+            "encodedBodySize": 21609,
+            "decodedBodySize": 105367
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/page.Dwipeu-R.js",
+            "entryType": "resource",
+            "startTime": 12.699999988079071,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 1124,
+            "decodedBodySize": 2486
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/Search.astro_astro_type_script_index_0_lang.DzL-jWp_.js",
+            "entryType": "resource",
+            "startTime": 12.799999997019768,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 945,
+            "decodedBodySize": 1830
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/MobileTableOfContents.astro_astro_type_script_index_0_lang.BcSo_yiZ.js",
+            "entryType": "resource",
+            "startTime": 12.899999991059303,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 364,
+            "decodedBodySize": 622
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/TableOfContents.astro_astro_type_script_index_0_lang.Csloo1VZ.js",
+            "entryType": "resource",
+            "startTime": 12.899999991059303,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 56,
+            "decodedBodySize": 36
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/TwoColumnContent.astro_astro_type_script_index_0_lang.DPGAuL8N.js",
+            "entryType": "resource",
+            "startTime": 12.899999991059303,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 269,
+            "decodedBodySize": 452
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/PageFrame.astro_astro_type_script_index_0_lang.iwTubUja.js",
+            "entryType": "resource",
+            "startTime": 13,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 257,
+            "decodedBodySize": 392
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/print.ehPL0gv-.css",
+            "entryType": "resource",
+            "startTime": 17.099999994039536,
+            "duration": 0,
+            "initiatorType": "link",
+            "transferSize": 0,
+            "encodedBodySize": 996,
+            "decodedBodySize": 3318
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/preload-helper.BnKG7j8P.js",
+            "entryType": "resource",
+            "startTime": 23.19999998807907,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 737,
+            "decodedBodySize": 1351
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/starlight-toc.CTCQXEge.js",
+            "entryType": "resource",
+            "startTime": 23.399999991059303,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 951,
+            "decodedBodySize": 1981
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/persistent-toggle.t6KkBAiq.js",
+            "entryType": "resource",
+            "startTime": 23.5,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 705,
+            "decodedBodySize": 2082
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/InteractiveCell.DoOzatBM.js",
+            "entryType": "resource",
+            "startTime": 40.79999999701977,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 16384,
+            "decodedBodySize": 50227
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/client.BJAMOzhD.js",
+            "entryType": "resource",
+            "startTime": 40.8999999910593,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 814,
+            "decodedBodySize": 1412
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/preact.Bl7PEaKa.js",
+            "entryType": "resource",
+            "startTime": 43.099999994039536,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 4413,
+            "decodedBodySize": 10470
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/output-limits.vkaihnVu.js",
+            "entryType": "resource",
+            "startTime": 43.19999998807907,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 3659,
+            "decodedBodySize": 8969
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/hooks.ClbWuNs9.js",
+            "entryType": "resource",
+            "startTime": 43.29999999701977,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 1153,
+            "decodedBodySize": 2677
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/favicon.svg",
+            "entryType": "resource",
+            "startTime": 43.79999999701977,
+            "duration": 1.5,
+            "initiatorType": "other",
+            "transferSize": 0,
+            "encodedBodySize": 259,
+            "decodedBodySize": 331
+          },
+          {
+            "name": "oxiquill:hydrated:features__interactive-cells__python-controls",
+            "entryType": "mark",
+            "startTime": 51.29999999701977,
+            "duration": 0
+          },
+          {
+            "name": "oxiquill:worker-start:python",
+            "entryType": "mark",
+            "startTime": 55.8999999910593,
+            "duration": 0
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/python-worker-CZmazRja.js",
+            "entryType": "resource",
+            "startTime": 60.599999994039536,
+            "duration": -2.7999999970197678,
+            "initiatorType": "other",
+            "transferSize": 0,
+            "encodedBodySize": 13024,
+            "decodedBodySize": 47679
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/ui-core.BwVUYzUq.js",
+            "entryType": "resource",
+            "startTime": 67.29999999701977,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 26119,
+            "decodedBodySize": 93799
+          },
+          {
+            "name": "oxiquill:output-rendered:features__interactive-cells__python-controls",
+            "entryType": "mark",
+            "startTime": 1386.3999999910593,
+            "duration": 0
+          }
+        ]
+      },
+      "workers": [
+        {
+          "timeOrigin": 1788590362613.3,
+          "entries": [
+            {
+              "name": "oxiquill:worker-ready:python",
+              "entryType": "mark",
+              "startTime": 2.9000000059604645,
+              "duration": 0
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pyodide.mjs",
+              "entryType": "resource",
+              "startTime": 4.5,
+              "duration": 1.2000000029802322,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 7156,
+              "decodedBodySize": 17931
+            },
+            {
+              "name": "oxiquill:initialization:python",
+              "entryType": "measure",
+              "startTime": 8.900000005960464,
+              "duration": 1277.8999999910593
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pyodide-lock.json",
+              "entryType": "resource",
+              "startTime": 9.200000002980232,
+              "duration": 2.0999999940395355,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 26534,
+              "decodedBodySize": 114440
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/python_stdlib.zip",
+              "entryType": "resource",
+              "startTime": 9.5,
+              "duration": 18.400000005960464,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 2503174,
+              "decodedBodySize": 2545564
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pyodide.asm.wasm",
+              "entryType": "resource",
+              "startTime": 9.799999997019768,
+              "duration": 90.79999999701977,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 3546129,
+              "decodedBodySize": 9598218
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pyodide.asm.mjs",
+              "entryType": "resource",
+              "startTime": 9.900000005960464,
+              "duration": 10.899999991059303,
+              "initiatorType": "script",
+              "transferSize": 0,
+              "encodedBodySize": 260107,
+              "decodedBodySize": 1250344
+            },
+            {
+              "name": "oxiquill:display-support:python",
+              "entryType": "measure",
+              "startTime": 1286.7999999970198,
+              "duration": 32.1000000089407
+            },
+            {
+              "name": "oxiquill:imports:features__interactive-cells__python-controls",
+              "entryType": "measure",
+              "startTime": 1319.2000000029802,
+              "duration": 0.8999999910593033
+            },
+            {
+              "name": "oxiquill:display-prepare:features__interactive-cells__python-controls",
+              "entryType": "measure",
+              "startTime": 1320.0999999940395,
+              "duration": 0.9000000059604645
+            },
+            {
+              "name": "oxiquill:execution:features__interactive-cells__python-controls",
+              "entryType": "measure",
+              "startTime": 1321.0999999940395,
+              "duration": 3.5
+            },
+            {
+              "name": "oxiquill:display-collect:features__interactive-cells__python-controls",
+              "entryType": "measure",
+              "startTime": 1325.4000000059605,
+              "duration": 0.5999999940395355
+            }
+          ]
+        }
+      ],
+      "observed": {
+        "requests": [
+          {
+            "requestId": 1,
+            "at": 1788590362610.3
+          }
+        ],
+        "responses": [
+          {
+            "requestId": 1,
+            "at": 1788590363940.7,
+            "ok": true
+          }
+        ]
+      }
+    },
+    {
+      "example": "features/interactive-cells/",
+      "condition": "repeat",
+      "run": 5,
+      "triggerMs": 1422.5999999940395,
+      "outputMs": 1585.5,
+      "latencyMs": 162.90000000596046,
+      "renderObserverDeltaMs": -0.10009765625,
+      "main": {
+        "timeOrigin": 1788590362554.2,
+        "entries": [
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/index.DANjJwMU.css",
+            "entryType": "resource",
+            "startTime": 12.699999988079071,
+            "duration": 0,
+            "initiatorType": "link",
+            "transferSize": 0,
+            "encodedBodySize": 21609,
+            "decodedBodySize": 105367
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/page.Dwipeu-R.js",
+            "entryType": "resource",
+            "startTime": 12.699999988079071,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 1124,
+            "decodedBodySize": 2486
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/Search.astro_astro_type_script_index_0_lang.DzL-jWp_.js",
+            "entryType": "resource",
+            "startTime": 12.799999997019768,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 945,
+            "decodedBodySize": 1830
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/MobileTableOfContents.astro_astro_type_script_index_0_lang.BcSo_yiZ.js",
+            "entryType": "resource",
+            "startTime": 12.899999991059303,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 364,
+            "decodedBodySize": 622
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/TableOfContents.astro_astro_type_script_index_0_lang.Csloo1VZ.js",
+            "entryType": "resource",
+            "startTime": 12.899999991059303,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 56,
+            "decodedBodySize": 36
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/TwoColumnContent.astro_astro_type_script_index_0_lang.DPGAuL8N.js",
+            "entryType": "resource",
+            "startTime": 12.899999991059303,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 269,
+            "decodedBodySize": 452
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/PageFrame.astro_astro_type_script_index_0_lang.iwTubUja.js",
+            "entryType": "resource",
+            "startTime": 13,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 257,
+            "decodedBodySize": 392
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/print.ehPL0gv-.css",
+            "entryType": "resource",
+            "startTime": 17.099999994039536,
+            "duration": 0,
+            "initiatorType": "link",
+            "transferSize": 0,
+            "encodedBodySize": 996,
+            "decodedBodySize": 3318
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/preload-helper.BnKG7j8P.js",
+            "entryType": "resource",
+            "startTime": 23.19999998807907,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 737,
+            "decodedBodySize": 1351
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/starlight-toc.CTCQXEge.js",
+            "entryType": "resource",
+            "startTime": 23.399999991059303,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 951,
+            "decodedBodySize": 1981
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/persistent-toggle.t6KkBAiq.js",
+            "entryType": "resource",
+            "startTime": 23.5,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 705,
+            "decodedBodySize": 2082
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/InteractiveCell.DoOzatBM.js",
+            "entryType": "resource",
+            "startTime": 40.79999999701977,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 16384,
+            "decodedBodySize": 50227
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/client.BJAMOzhD.js",
+            "entryType": "resource",
+            "startTime": 40.8999999910593,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 814,
+            "decodedBodySize": 1412
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/preact.Bl7PEaKa.js",
+            "entryType": "resource",
+            "startTime": 43.099999994039536,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 4413,
+            "decodedBodySize": 10470
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/output-limits.vkaihnVu.js",
+            "entryType": "resource",
+            "startTime": 43.19999998807907,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 3659,
+            "decodedBodySize": 8969
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/hooks.ClbWuNs9.js",
+            "entryType": "resource",
+            "startTime": 43.29999999701977,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 1153,
+            "decodedBodySize": 2677
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/favicon.svg",
+            "entryType": "resource",
+            "startTime": 43.79999999701977,
+            "duration": 1.5,
+            "initiatorType": "other",
+            "transferSize": 0,
+            "encodedBodySize": 259,
+            "decodedBodySize": 331
+          },
+          {
+            "name": "oxiquill:hydrated:features__interactive-cells__python-controls",
+            "entryType": "mark",
+            "startTime": 51.29999999701977,
+            "duration": 0
+          },
+          {
+            "name": "oxiquill:worker-start:python",
+            "entryType": "mark",
+            "startTime": 55.8999999910593,
+            "duration": 0
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/python-worker-CZmazRja.js",
+            "entryType": "resource",
+            "startTime": 60.599999994039536,
+            "duration": -2.7999999970197678,
+            "initiatorType": "other",
+            "transferSize": 0,
+            "encodedBodySize": 13024,
+            "decodedBodySize": 47679
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/ui-core.BwVUYzUq.js",
+            "entryType": "resource",
+            "startTime": 67.29999999701977,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 26119,
+            "decodedBodySize": 93799
+          },
+          {
+            "name": "oxiquill:output-rendered:features__interactive-cells__python-controls",
+            "entryType": "mark",
+            "startTime": 1585.5,
+            "duration": 0
+          }
+        ]
+      },
+      "workers": [
+        {
+          "timeOrigin": 1788590362613.3,
+          "entries": [
+            {
+              "name": "oxiquill:worker-ready:python",
+              "entryType": "mark",
+              "startTime": 2.9000000059604645,
+              "duration": 0
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pyodide.mjs",
+              "entryType": "resource",
+              "startTime": 4.5,
+              "duration": 1.2000000029802322,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 7156,
+              "decodedBodySize": 17931
+            },
+            {
+              "name": "oxiquill:initialization:python",
+              "entryType": "measure",
+              "startTime": 8.900000005960464,
+              "duration": 1277.8999999910593
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pyodide-lock.json",
+              "entryType": "resource",
+              "startTime": 9.200000002980232,
+              "duration": 2.0999999940395355,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 26534,
+              "decodedBodySize": 114440
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/python_stdlib.zip",
+              "entryType": "resource",
+              "startTime": 9.5,
+              "duration": 18.400000005960464,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 2503174,
+              "decodedBodySize": 2545564
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pyodide.asm.wasm",
+              "entryType": "resource",
+              "startTime": 9.799999997019768,
+              "duration": 90.79999999701977,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 3546129,
+              "decodedBodySize": 9598218
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pyodide.asm.mjs",
+              "entryType": "resource",
+              "startTime": 9.900000005960464,
+              "duration": 10.899999991059303,
+              "initiatorType": "script",
+              "transferSize": 0,
+              "encodedBodySize": 260107,
+              "decodedBodySize": 1250344
+            },
+            {
+              "name": "oxiquill:display-support:python",
+              "entryType": "measure",
+              "startTime": 1286.7999999970198,
+              "duration": 32.1000000089407
+            },
+            {
+              "name": "oxiquill:imports:features__interactive-cells__python-controls",
+              "entryType": "measure",
+              "startTime": 1520.2000000029802,
+              "duration": 1.2999999970197678
+            },
+            {
+              "name": "oxiquill:display-prepare:features__interactive-cells__python-controls",
+              "entryType": "measure",
+              "startTime": 1521.5,
+              "duration": 1.2000000029802322
+            },
+            {
+              "name": "oxiquill:execution:features__interactive-cells__python-controls",
+              "entryType": "measure",
+              "startTime": 1522.7999999970198,
+              "duration": 2.2000000029802322
+            },
+            {
+              "name": "oxiquill:display-collect:features__interactive-cells__python-controls",
+              "entryType": "measure",
+              "startTime": 1525.4000000059605,
+              "duration": 0.3999999910593033
+            }
+          ]
+        }
+      ],
+      "observed": {
+        "requests": [
+          {
+            "requestId": 1,
+            "at": 1788590362610.3
+          },
+          {
+            "requestId": 2,
+            "at": 1788590364133.0999
+          }
+        ],
+        "responses": [
+          {
+            "requestId": 1,
+            "at": 1788590363940.7,
+            "ok": true
+          },
+          {
+            "requestId": 2,
+            "at": 1788590364139.8,
+            "ok": true
+          }
+        ]
+      }
+    },
+    {
+      "example": "features/rich-output/",
+      "condition": "fresh",
+      "run": 1,
+      "triggerMs": 159,
+      "outputMs": 5737.79999999702,
+      "latencyMs": 5737.79999999702,
+      "renderObserverDeltaMs": -4,
+      "main": {
+        "timeOrigin": 1788590364199.7,
+        "entries": [
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/index.DANjJwMU.css",
+            "entryType": "resource",
+            "startTime": 7.199999988079071,
+            "duration": 2.7000000029802322,
+            "initiatorType": "link",
+            "transferSize": 21909,
+            "encodedBodySize": 21609,
+            "decodedBodySize": 105367
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/page.Dwipeu-R.js",
+            "entryType": "resource",
+            "startTime": 7.5,
+            "duration": 6.0999999940395355,
+            "initiatorType": "script",
+            "transferSize": 1424,
+            "encodedBodySize": 1124,
+            "decodedBodySize": 2486
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/MobileTableOfContents.astro_astro_type_script_index_0_lang.BcSo_yiZ.js",
+            "entryType": "resource",
+            "startTime": 7.5,
+            "duration": 8,
+            "initiatorType": "script",
+            "transferSize": 664,
+            "encodedBodySize": 364,
+            "decodedBodySize": 622
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/Search.astro_astro_type_script_index_0_lang.DzL-jWp_.js",
+            "entryType": "resource",
+            "startTime": 7.5,
+            "duration": 8,
+            "initiatorType": "script",
+            "transferSize": 1245,
+            "encodedBodySize": 945,
+            "decodedBodySize": 1830
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/TableOfContents.astro_astro_type_script_index_0_lang.Csloo1VZ.js",
+            "entryType": "resource",
+            "startTime": 7.5,
+            "duration": 8.199999988079071,
+            "initiatorType": "script",
+            "transferSize": 356,
+            "encodedBodySize": 56,
+            "decodedBodySize": 36
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/ec.w36nc.css",
+            "entryType": "resource",
+            "startTime": 7.5999999940395355,
+            "duration": 7.700000002980232,
+            "initiatorType": "link",
+            "transferSize": 4246,
+            "encodedBodySize": 3946,
+            "decodedBodySize": 18292
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/ec.0vx5m.js",
+            "entryType": "resource",
+            "startTime": 7.5999999940395355,
+            "duration": 8.400000005960464,
+            "initiatorType": "script",
+            "transferSize": 1468,
+            "encodedBodySize": 1168,
+            "decodedBodySize": 2523
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/TwoColumnContent.astro_astro_type_script_index_0_lang.DPGAuL8N.js",
+            "entryType": "resource",
+            "startTime": 7.5999999940395355,
+            "duration": 11.900000005960464,
+            "initiatorType": "script",
+            "transferSize": 569,
+            "encodedBodySize": 269,
+            "decodedBodySize": 452
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/PageFrame.astro_astro_type_script_index_0_lang.iwTubUja.js",
+            "entryType": "resource",
+            "startTime": 7.5999999940395355,
+            "duration": 12.099999994039536,
+            "initiatorType": "script",
+            "transferSize": 557,
+            "encodedBodySize": 257,
+            "decodedBodySize": 392
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/print.ehPL0gv-.css",
+            "entryType": "resource",
+            "startTime": 12.5,
+            "duration": 7.299999997019768,
+            "initiatorType": "link",
+            "transferSize": 1296,
+            "encodedBodySize": 996,
+            "decodedBodySize": 3318
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/starlight-toc.CTCQXEge.js",
+            "entryType": "resource",
+            "startTime": 42,
+            "duration": 3.0999999940395355,
+            "initiatorType": "script",
+            "transferSize": 1251,
+            "encodedBodySize": 951,
+            "decodedBodySize": 1981
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/preload-helper.BnKG7j8P.js",
+            "entryType": "resource",
+            "startTime": 42.099999994039536,
+            "duration": 3.2000000029802322,
+            "initiatorType": "script",
+            "transferSize": 1037,
+            "encodedBodySize": 737,
+            "decodedBodySize": 1351
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/persistent-toggle.t6KkBAiq.js",
+            "entryType": "resource",
+            "startTime": 61.3999999910593,
+            "duration": 1.6000000089406967,
+            "initiatorType": "script",
+            "transferSize": 1005,
+            "encodedBodySize": 705,
+            "decodedBodySize": 2082
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/favicon.svg",
+            "entryType": "resource",
+            "startTime": 75.29999999701977,
+            "duration": 2,
+            "initiatorType": "other",
+            "transferSize": 559,
+            "encodedBodySize": 259,
+            "decodedBodySize": 331
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/ui-core.BwVUYzUq.js",
+            "entryType": "resource",
+            "startTime": 87.3999999910593,
+            "duration": 2.1000000089406967,
+            "initiatorType": "script",
+            "transferSize": 26419,
+            "encodedBodySize": 26119,
+            "decodedBodySize": 93799
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/InteractiveCell.DoOzatBM.js",
+            "entryType": "resource",
+            "startTime": 142.79999999701977,
+            "duration": 3.2000000029802322,
+            "initiatorType": "script",
+            "transferSize": 16684,
+            "encodedBodySize": 16384,
+            "decodedBodySize": 50227
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/client.BJAMOzhD.js",
+            "entryType": "resource",
+            "startTime": 142.8999999910593,
+            "duration": 2.9000000059604645,
+            "initiatorType": "script",
+            "transferSize": 1114,
+            "encodedBodySize": 814,
+            "decodedBodySize": 1412
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/preact.Bl7PEaKa.js",
+            "entryType": "resource",
+            "startTime": 146.79999999701977,
+            "duration": 2.2000000029802322,
+            "initiatorType": "script",
+            "transferSize": 4713,
+            "encodedBodySize": 4413,
+            "decodedBodySize": 10470
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/output-limits.vkaihnVu.js",
+            "entryType": "resource",
+            "startTime": 147.59999999403954,
+            "duration": 3.2000000029802322,
+            "initiatorType": "script",
+            "transferSize": 3959,
+            "encodedBodySize": 3659,
+            "decodedBodySize": 8969
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/hooks.ClbWuNs9.js",
+            "entryType": "resource",
+            "startTime": 147.69999998807907,
+            "duration": 3.2000000029802322,
+            "initiatorType": "script",
+            "transferSize": 1453,
+            "encodedBodySize": 1153,
+            "decodedBodySize": 2677
+          },
+          {
+            "name": "oxiquill:hydrated:features__rich-output__python-rich-outputs",
+            "entryType": "mark",
+            "startTime": 153.69999998807907,
+            "duration": 0
+          },
+          {
+            "name": "oxiquill:worker-start:python",
+            "entryType": "mark",
+            "startTime": 197.09999999403954,
+            "duration": 0
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/python-worker-CZmazRja.js",
+            "entryType": "resource",
+            "startTime": 201,
+            "duration": -1.5,
+            "initiatorType": "other",
+            "transferSize": 13324,
+            "encodedBodySize": 13024,
+            "decodedBodySize": 47679
+          },
+          {
+            "name": "oxiquill:output-rendered:features__rich-output__python-rich-outputs",
+            "entryType": "mark",
+            "startTime": 5737.79999999702,
+            "duration": 0
+          }
+        ]
+      },
+      "workers": [
+        {
+          "timeOrigin": 1788590364399,
+          "entries": [
+            {
+              "name": "oxiquill:worker-ready:python",
+              "entryType": "mark",
+              "startTime": 3.300000011920929,
+              "duration": 0
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pyodide.mjs",
+              "entryType": "resource",
+              "startTime": 10.100000008940697,
+              "duration": 1.7999999970197678,
+              "initiatorType": "fetch",
+              "transferSize": 7456,
+              "encodedBodySize": 7156,
+              "decodedBodySize": 17931
+            },
+            {
+              "name": "oxiquill:initialization:python",
+              "entryType": "measure",
+              "startTime": 14.900000005960464,
+              "duration": 1325.7000000029802
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pyodide-lock.json",
+              "entryType": "resource",
+              "startTime": 15.200000002980232,
+              "duration": 5,
+              "initiatorType": "fetch",
+              "transferSize": 26834,
+              "encodedBodySize": 26534,
+              "decodedBodySize": 114440
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/python_stdlib.zip",
+              "entryType": "resource",
+              "startTime": 15.600000008940697,
+              "duration": 22.899999991059303,
+              "initiatorType": "fetch",
+              "transferSize": 2503474,
+              "encodedBodySize": 2503174,
+              "decodedBodySize": 2545564
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pyodide.asm.wasm",
+              "entryType": "resource",
+              "startTime": 15.800000011920929,
+              "duration": 95.8999999910593,
+              "initiatorType": "fetch",
+              "transferSize": 3546429,
+              "encodedBodySize": 3546129,
+              "decodedBodySize": 9598218
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pyodide.asm.mjs",
+              "entryType": "resource",
+              "startTime": 15.900000005960464,
+              "duration": 12.5,
+              "initiatorType": "script",
+              "transferSize": 260407,
+              "encodedBodySize": 260107,
+              "decodedBodySize": 1250344
+            },
+            {
+              "name": "oxiquill:display-support:python",
+              "entryType": "measure",
+              "startTime": 1340.6000000089407,
+              "duration": 34
+            },
+            {
+              "name": "oxiquill:packages:features__rich-output__python-rich-outputs",
+              "entryType": "measure",
+              "startTime": 1374.7000000029802,
+              "duration": 868.9000000059605
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/matplotlib-3.10.8-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 1376.1000000089407,
+              "duration": 379.20000000298023,
+              "initiatorType": "fetch",
+              "transferSize": 6867585,
+              "encodedBodySize": 6867285,
+              "decodedBodySize": 6982033
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/contourpy-1.3.3-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 1376.300000011921,
+              "duration": 8.199999988079071,
+              "initiatorType": "fetch",
+              "transferSize": 117420,
+              "encodedBodySize": 117120,
+              "decodedBodySize": 118875
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/numpy-2.4.6-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 1376.4000000059605,
+              "duration": 143.70000000298023,
+              "initiatorType": "fetch",
+              "transferSize": 2882982,
+              "encodedBodySize": 2882682,
+              "decodedBodySize": 2918760
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/cycler-0.12.1-py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 1376.6000000089407,
+              "duration": 7.399999991059303,
+              "initiatorType": "fetch",
+              "transferSize": 8094,
+              "encodedBodySize": 7794,
+              "decodedBodySize": 8321
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/six-1.17.0-py2.py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 1376.7000000029802,
+              "duration": 7.4000000059604645,
+              "initiatorType": "fetch",
+              "transferSize": 10940,
+              "encodedBodySize": 10640,
+              "decodedBodySize": 11050
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/fonttools-4.62.1-py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 1376.800000011921,
+              "duration": 32.5,
+              "initiatorType": "fetch",
+              "transferSize": 1124839,
+              "encodedBodySize": 1124539,
+              "decodedBodySize": 1152647
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/kiwisolver-1.5.0-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 1377,
+              "duration": 86.80000001192093,
+              "initiatorType": "fetch",
+              "transferSize": 36187,
+              "encodedBodySize": 35887,
+              "decodedBodySize": 36616
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/packaging-26.1-py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 1377.1000000089407,
+              "duration": 87,
+              "initiatorType": "fetch",
+              "transferSize": 94497,
+              "encodedBodySize": 94197,
+              "decodedBodySize": 95852
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pillow-12.2.0-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 1377.2000000029802,
+              "duration": 109.90000000596046,
+              "initiatorType": "fetch",
+              "transferSize": 1029476,
+              "encodedBodySize": 1029176,
+              "decodedBodySize": 1037807
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pyparsing-3.3.2-py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 1377.4000000059605,
+              "duration": 114,
+              "initiatorType": "fetch",
+              "transferSize": 121460,
+              "encodedBodySize": 121160,
+              "decodedBodySize": 122781
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/python_dateutil-2.9.0.post0-py2.py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 1377.5,
+              "duration": 119.20000000298023,
+              "initiatorType": "fetch",
+              "transferSize": 228538,
+              "encodedBodySize": 228238,
+              "decodedBodySize": 229892
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pytz-2026.1.post1-py2.py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 1378.7000000029802,
+              "duration": 254.1000000089407,
+              "initiatorType": "fetch",
+              "transferSize": 377948,
+              "encodedBodySize": 377648,
+              "decodedBodySize": 510489
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pandas-3.0.2-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 1378.800000011921,
+              "duration": 412.3999999910593,
+              "initiatorType": "fetch",
+              "transferSize": 4141966,
+              "encodedBodySize": 4141666,
+              "decodedBodySize": 4177814
+            },
+            {
+              "name": "oxiquill:imports:features__rich-output__python-rich-outputs",
+              "entryType": "measure",
+              "startTime": 2243.7000000029802,
+              "duration": 0.9000000059604645
+            },
+            {
+              "name": "oxiquill:display-prepare:features__rich-output__python-rich-outputs",
+              "entryType": "measure",
+              "startTime": 2244.7000000029802,
+              "duration": 988.6000000089407
+            },
+            {
+              "name": "oxiquill:execution:features__rich-output__python-rich-outputs",
+              "entryType": "measure",
+              "startTime": 3233.6000000089407,
+              "duration": 2179.2000000029802
+            },
+            {
+              "name": "oxiquill:display-collect:features__rich-output__python-rich-outputs",
+              "entryType": "measure",
+              "startTime": 5414,
+              "duration": 110.6000000089407
+            }
+          ]
+        }
+      ],
+      "observed": {
+        "requests": [
+          {
+            "requestId": 1,
+            "at": 1788590364397.0999
+          }
+        ],
+        "responses": [
+          {
+            "requestId": 1,
+            "at": 1788590369941.5,
+            "ok": true
+          }
+        ]
+      }
+    },
+    {
+      "example": "features/rich-output/",
+      "condition": "reload",
+      "run": 1,
+      "triggerMs": 114.09999999403954,
+      "outputMs": 5983.70000000298,
+      "latencyMs": 5983.70000000298,
+      "renderObserverDeltaMs": -3.300048828125,
+      "main": {
+        "timeOrigin": 1788590369962.9,
+        "entries": [
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/index.DANjJwMU.css",
+            "entryType": "resource",
+            "startTime": 15.299999997019768,
+            "duration": 0,
+            "initiatorType": "link",
+            "transferSize": 0,
+            "encodedBodySize": 21609,
+            "decodedBodySize": 105367
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/page.Dwipeu-R.js",
+            "entryType": "resource",
+            "startTime": 15.400000005960464,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 1124,
+            "decodedBodySize": 2486
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/Search.astro_astro_type_script_index_0_lang.DzL-jWp_.js",
+            "entryType": "resource",
+            "startTime": 15.400000005960464,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 945,
+            "decodedBodySize": 1830
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/MobileTableOfContents.astro_astro_type_script_index_0_lang.BcSo_yiZ.js",
+            "entryType": "resource",
+            "startTime": 15.5,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 364,
+            "decodedBodySize": 622
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/TableOfContents.astro_astro_type_script_index_0_lang.Csloo1VZ.js",
+            "entryType": "resource",
+            "startTime": 15.5,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 56,
+            "decodedBodySize": 36
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/ec.w36nc.css",
+            "entryType": "resource",
+            "startTime": 15.599999994039536,
+            "duration": 0,
+            "initiatorType": "link",
+            "transferSize": 0,
+            "encodedBodySize": 3946,
+            "decodedBodySize": 18292
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/ec.0vx5m.js",
+            "entryType": "resource",
+            "startTime": 15.700000002980232,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 1168,
+            "decodedBodySize": 2523
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/TwoColumnContent.astro_astro_type_script_index_0_lang.DPGAuL8N.js",
+            "entryType": "resource",
+            "startTime": 15.700000002980232,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 269,
+            "decodedBodySize": 452
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/PageFrame.astro_astro_type_script_index_0_lang.iwTubUja.js",
+            "entryType": "resource",
+            "startTime": 15.799999997019768,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 257,
+            "decodedBodySize": 392
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/print.ehPL0gv-.css",
+            "entryType": "resource",
+            "startTime": 19.299999997019768,
+            "duration": 0,
+            "initiatorType": "link",
+            "transferSize": 0,
+            "encodedBodySize": 996,
+            "decodedBodySize": 3318
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/preload-helper.BnKG7j8P.js",
+            "entryType": "resource",
+            "startTime": 25.700000002980232,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 737,
+            "decodedBodySize": 1351
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/starlight-toc.CTCQXEge.js",
+            "entryType": "resource",
+            "startTime": 25.900000005960464,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 951,
+            "decodedBodySize": 1981
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/persistent-toggle.t6KkBAiq.js",
+            "entryType": "resource",
+            "startTime": 26.099999994039536,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 705,
+            "decodedBodySize": 2082
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/InteractiveCell.DoOzatBM.js",
+            "entryType": "resource",
+            "startTime": 50.20000000298023,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 16384,
+            "decodedBodySize": 50227
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/client.BJAMOzhD.js",
+            "entryType": "resource",
+            "startTime": 50.29999999701977,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 814,
+            "decodedBodySize": 1412
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/preact.Bl7PEaKa.js",
+            "entryType": "resource",
+            "startTime": 50.900000005960464,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 4413,
+            "decodedBodySize": 10470
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/output-limits.vkaihnVu.js",
+            "entryType": "resource",
+            "startTime": 51.099999994039536,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 3659,
+            "decodedBodySize": 8969
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/hooks.ClbWuNs9.js",
+            "entryType": "resource",
+            "startTime": 51.099999994039536,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 1153,
+            "decodedBodySize": 2677
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/favicon.svg",
+            "entryType": "resource",
+            "startTime": 51.29999999701977,
+            "duration": 1.2000000029802322,
+            "initiatorType": "other",
+            "transferSize": 0,
+            "encodedBodySize": 259,
+            "decodedBodySize": 331
+          },
+          {
+            "name": "oxiquill:hydrated:features__rich-output__python-rich-outputs",
+            "entryType": "mark",
+            "startTime": 52.70000000298023,
+            "duration": 0
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/ui-core.BwVUYzUq.js",
+            "entryType": "resource",
+            "startTime": 72.29999999701977,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 26119,
+            "decodedBodySize": 93799
+          },
+          {
+            "name": "oxiquill:worker-start:python",
+            "entryType": "mark",
+            "startTime": 148.5,
+            "duration": 0
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/python-worker-CZmazRja.js",
+            "entryType": "resource",
+            "startTime": 151.70000000298023,
+            "duration": -1.5,
+            "initiatorType": "other",
+            "transferSize": 0,
+            "encodedBodySize": 13024,
+            "decodedBodySize": 47679
+          },
+          {
+            "name": "oxiquill:output-rendered:features__rich-output__python-rich-outputs",
+            "entryType": "mark",
+            "startTime": 5983.70000000298,
+            "duration": 0
+          }
+        ]
+      },
+      "workers": [
+        {
+          "timeOrigin": 1788590370113,
+          "entries": [
+            {
+              "name": "oxiquill:worker-ready:python",
+              "entryType": "mark",
+              "startTime": 2.7000000029802322,
+              "duration": 0
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pyodide.mjs",
+              "entryType": "resource",
+              "startTime": 12.399999991059303,
+              "duration": 1.1000000089406967,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 7156,
+              "decodedBodySize": 17931
+            },
+            {
+              "name": "oxiquill:initialization:python",
+              "entryType": "measure",
+              "startTime": 16.5,
+              "duration": 1269.3999999910593
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pyodide-lock.json",
+              "entryType": "resource",
+              "startTime": 16.799999997019768,
+              "duration": 1.4000000059604645,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 26534,
+              "decodedBodySize": 114440
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/python_stdlib.zip",
+              "entryType": "resource",
+              "startTime": 17.200000002980232,
+              "duration": 16.19999998807907,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 2503174,
+              "decodedBodySize": 2545564
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pyodide.asm.wasm",
+              "entryType": "resource",
+              "startTime": 17.399999991059303,
+              "duration": 85,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 3546129,
+              "decodedBodySize": 9598218
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pyodide.asm.mjs",
+              "entryType": "resource",
+              "startTime": 17.5,
+              "duration": 9.399999991059303,
+              "initiatorType": "script",
+              "transferSize": 0,
+              "encodedBodySize": 260107,
+              "decodedBodySize": 1250344
+            },
+            {
+              "name": "oxiquill:display-support:python",
+              "entryType": "measure",
+              "startTime": 1285.8999999910593,
+              "duration": 32.400000005960464
+            },
+            {
+              "name": "oxiquill:packages:features__rich-output__python-rich-outputs",
+              "entryType": "measure",
+              "startTime": 1318.3999999910593,
+              "duration": 894.4000000059605
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/matplotlib-3.10.8-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 1319.7999999970198,
+              "duration": 387.09999999403954,
+              "initiatorType": "fetch",
+              "transferSize": 6867585,
+              "encodedBodySize": 6867285,
+              "decodedBodySize": 6982033
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/contourpy-1.3.3-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 1320.0999999940395,
+              "duration": 14.400000005960464,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 117120,
+              "decodedBodySize": 118875
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/numpy-2.4.6-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 1320.2000000029802,
+              "duration": 72.29999999701977,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 2882682,
+              "decodedBodySize": 2918760
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/cycler-0.12.1-py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 1320.3999999910593,
+              "duration": 7.100000008940697,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 7794,
+              "decodedBodySize": 8321
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/six-1.17.0-py2.py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 1320.5,
+              "duration": 11.399999991059303,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 10640,
+              "decodedBodySize": 11050
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/fonttools-4.62.1-py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 1320.5999999940395,
+              "duration": 29.799999997019768,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 1124539,
+              "decodedBodySize": 1152647
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/kiwisolver-1.5.0-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 1320.7000000029802,
+              "duration": 13.599999994039536,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 35887,
+              "decodedBodySize": 36616
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/packaging-26.1-py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 1320.7999999970198,
+              "duration": 14.5,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 94197,
+              "decodedBodySize": 95852
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pillow-12.2.0-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 1321,
+              "duration": 27.899999991059303,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 1029176,
+              "decodedBodySize": 1037807
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pyparsing-3.3.2-py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 1321.0999999940395,
+              "duration": 15.100000008940697,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 121160,
+              "decodedBodySize": 122781
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/python_dateutil-2.9.0.post0-py2.py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 1321.2999999970198,
+              "duration": 17,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 228238,
+              "decodedBodySize": 229892
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pytz-2026.1.post1-py2.py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 1322.0999999940395,
+              "duration": 18.799999997019768,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 377648,
+              "decodedBodySize": 510489
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pandas-3.0.2-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 1322.2999999970198,
+              "duration": 88.90000000596046,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 4141666,
+              "decodedBodySize": 4177814
+            },
+            {
+              "name": "oxiquill:imports:features__rich-output__python-rich-outputs",
+              "entryType": "measure",
+              "startTime": 2212.8999999910593,
+              "duration": 0.9000000059604645
+            },
+            {
+              "name": "oxiquill:display-prepare:features__rich-output__python-rich-outputs",
+              "entryType": "measure",
+              "startTime": 2213.8999999910593,
+              "duration": 1013.3000000119209
+            },
+            {
+              "name": "oxiquill:execution:features__rich-output__python-rich-outputs",
+              "entryType": "measure",
+              "startTime": 3227.5,
+              "duration": 2469.2000000029802
+            },
+            {
+              "name": "oxiquill:display-collect:features__rich-output__python-rich-outputs",
+              "entryType": "measure",
+              "startTime": 5697.79999999702,
+              "duration": 130.20000000298023
+            }
+          ]
+        }
+      ],
+      "observed": {
+        "requests": [
+          {
+            "requestId": 1,
+            "at": 1788590370111.5999
+          }
+        ],
+        "responses": [
+          {
+            "requestId": 1,
+            "at": 1788590375949.9,
+            "ok": true
+          }
+        ]
+      }
+    },
+    {
+      "example": "features/rich-output/",
+      "condition": "repeat",
+      "run": 1,
+      "triggerMs": 6048,
+      "outputMs": 6165.9000000059605,
+      "latencyMs": 117.90000000596046,
+      "renderObserverDeltaMs": -2.2001953125,
+      "main": {
+        "timeOrigin": 1788590369962.9,
+        "entries": [
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/index.DANjJwMU.css",
+            "entryType": "resource",
+            "startTime": 15.299999997019768,
+            "duration": 0,
+            "initiatorType": "link",
+            "transferSize": 0,
+            "encodedBodySize": 21609,
+            "decodedBodySize": 105367
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/page.Dwipeu-R.js",
+            "entryType": "resource",
+            "startTime": 15.400000005960464,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 1124,
+            "decodedBodySize": 2486
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/Search.astro_astro_type_script_index_0_lang.DzL-jWp_.js",
+            "entryType": "resource",
+            "startTime": 15.400000005960464,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 945,
+            "decodedBodySize": 1830
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/MobileTableOfContents.astro_astro_type_script_index_0_lang.BcSo_yiZ.js",
+            "entryType": "resource",
+            "startTime": 15.5,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 364,
+            "decodedBodySize": 622
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/TableOfContents.astro_astro_type_script_index_0_lang.Csloo1VZ.js",
+            "entryType": "resource",
+            "startTime": 15.5,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 56,
+            "decodedBodySize": 36
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/ec.w36nc.css",
+            "entryType": "resource",
+            "startTime": 15.599999994039536,
+            "duration": 0,
+            "initiatorType": "link",
+            "transferSize": 0,
+            "encodedBodySize": 3946,
+            "decodedBodySize": 18292
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/ec.0vx5m.js",
+            "entryType": "resource",
+            "startTime": 15.700000002980232,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 1168,
+            "decodedBodySize": 2523
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/TwoColumnContent.astro_astro_type_script_index_0_lang.DPGAuL8N.js",
+            "entryType": "resource",
+            "startTime": 15.700000002980232,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 269,
+            "decodedBodySize": 452
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/PageFrame.astro_astro_type_script_index_0_lang.iwTubUja.js",
+            "entryType": "resource",
+            "startTime": 15.799999997019768,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 257,
+            "decodedBodySize": 392
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/print.ehPL0gv-.css",
+            "entryType": "resource",
+            "startTime": 19.299999997019768,
+            "duration": 0,
+            "initiatorType": "link",
+            "transferSize": 0,
+            "encodedBodySize": 996,
+            "decodedBodySize": 3318
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/preload-helper.BnKG7j8P.js",
+            "entryType": "resource",
+            "startTime": 25.700000002980232,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 737,
+            "decodedBodySize": 1351
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/starlight-toc.CTCQXEge.js",
+            "entryType": "resource",
+            "startTime": 25.900000005960464,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 951,
+            "decodedBodySize": 1981
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/persistent-toggle.t6KkBAiq.js",
+            "entryType": "resource",
+            "startTime": 26.099999994039536,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 705,
+            "decodedBodySize": 2082
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/InteractiveCell.DoOzatBM.js",
+            "entryType": "resource",
+            "startTime": 50.20000000298023,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 16384,
+            "decodedBodySize": 50227
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/client.BJAMOzhD.js",
+            "entryType": "resource",
+            "startTime": 50.29999999701977,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 814,
+            "decodedBodySize": 1412
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/preact.Bl7PEaKa.js",
+            "entryType": "resource",
+            "startTime": 50.900000005960464,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 4413,
+            "decodedBodySize": 10470
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/output-limits.vkaihnVu.js",
+            "entryType": "resource",
+            "startTime": 51.099999994039536,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 3659,
+            "decodedBodySize": 8969
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/hooks.ClbWuNs9.js",
+            "entryType": "resource",
+            "startTime": 51.099999994039536,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 1153,
+            "decodedBodySize": 2677
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/favicon.svg",
+            "entryType": "resource",
+            "startTime": 51.29999999701977,
+            "duration": 1.2000000029802322,
+            "initiatorType": "other",
+            "transferSize": 0,
+            "encodedBodySize": 259,
+            "decodedBodySize": 331
+          },
+          {
+            "name": "oxiquill:hydrated:features__rich-output__python-rich-outputs",
+            "entryType": "mark",
+            "startTime": 52.70000000298023,
+            "duration": 0
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/ui-core.BwVUYzUq.js",
+            "entryType": "resource",
+            "startTime": 72.29999999701977,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 26119,
+            "decodedBodySize": 93799
+          },
+          {
+            "name": "oxiquill:worker-start:python",
+            "entryType": "mark",
+            "startTime": 148.5,
+            "duration": 0
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/python-worker-CZmazRja.js",
+            "entryType": "resource",
+            "startTime": 151.70000000298023,
+            "duration": -1.5,
+            "initiatorType": "other",
+            "transferSize": 0,
+            "encodedBodySize": 13024,
+            "decodedBodySize": 47679
+          },
+          {
+            "name": "oxiquill:output-rendered:features__rich-output__python-rich-outputs",
+            "entryType": "mark",
+            "startTime": 6165.9000000059605,
+            "duration": 0
+          }
+        ]
+      },
+      "workers": [
+        {
+          "timeOrigin": 1788590370113,
+          "entries": [
+            {
+              "name": "oxiquill:worker-ready:python",
+              "entryType": "mark",
+              "startTime": 2.7000000029802322,
+              "duration": 0
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pyodide.mjs",
+              "entryType": "resource",
+              "startTime": 12.399999991059303,
+              "duration": 1.1000000089406967,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 7156,
+              "decodedBodySize": 17931
+            },
+            {
+              "name": "oxiquill:initialization:python",
+              "entryType": "measure",
+              "startTime": 16.5,
+              "duration": 1269.3999999910593
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pyodide-lock.json",
+              "entryType": "resource",
+              "startTime": 16.799999997019768,
+              "duration": 1.4000000059604645,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 26534,
+              "decodedBodySize": 114440
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/python_stdlib.zip",
+              "entryType": "resource",
+              "startTime": 17.200000002980232,
+              "duration": 16.19999998807907,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 2503174,
+              "decodedBodySize": 2545564
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pyodide.asm.wasm",
+              "entryType": "resource",
+              "startTime": 17.399999991059303,
+              "duration": 85,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 3546129,
+              "decodedBodySize": 9598218
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pyodide.asm.mjs",
+              "entryType": "resource",
+              "startTime": 17.5,
+              "duration": 9.399999991059303,
+              "initiatorType": "script",
+              "transferSize": 0,
+              "encodedBodySize": 260107,
+              "decodedBodySize": 1250344
+            },
+            {
+              "name": "oxiquill:display-support:python",
+              "entryType": "measure",
+              "startTime": 1285.8999999910593,
+              "duration": 32.400000005960464
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/matplotlib-3.10.8-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 1319.7999999970198,
+              "duration": 387.09999999403954,
+              "initiatorType": "fetch",
+              "transferSize": 6867585,
+              "encodedBodySize": 6867285,
+              "decodedBodySize": 6982033
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/contourpy-1.3.3-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 1320.0999999940395,
+              "duration": 14.400000005960464,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 117120,
+              "decodedBodySize": 118875
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/numpy-2.4.6-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 1320.2000000029802,
+              "duration": 72.29999999701977,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 2882682,
+              "decodedBodySize": 2918760
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/cycler-0.12.1-py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 1320.3999999910593,
+              "duration": 7.100000008940697,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 7794,
+              "decodedBodySize": 8321
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/six-1.17.0-py2.py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 1320.5,
+              "duration": 11.399999991059303,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 10640,
+              "decodedBodySize": 11050
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/fonttools-4.62.1-py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 1320.5999999940395,
+              "duration": 29.799999997019768,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 1124539,
+              "decodedBodySize": 1152647
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/kiwisolver-1.5.0-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 1320.7000000029802,
+              "duration": 13.599999994039536,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 35887,
+              "decodedBodySize": 36616
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/packaging-26.1-py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 1320.7999999970198,
+              "duration": 14.5,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 94197,
+              "decodedBodySize": 95852
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pillow-12.2.0-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 1321,
+              "duration": 27.899999991059303,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 1029176,
+              "decodedBodySize": 1037807
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pyparsing-3.3.2-py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 1321.0999999940395,
+              "duration": 15.100000008940697,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 121160,
+              "decodedBodySize": 122781
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/python_dateutil-2.9.0.post0-py2.py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 1321.2999999970198,
+              "duration": 17,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 228238,
+              "decodedBodySize": 229892
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pytz-2026.1.post1-py2.py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 1322.0999999940395,
+              "duration": 18.799999997019768,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 377648,
+              "decodedBodySize": 510489
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pandas-3.0.2-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 1322.2999999970198,
+              "duration": 88.90000000596046,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 4141666,
+              "decodedBodySize": 4177814
+            },
+            {
+              "name": "oxiquill:packages:features__rich-output__python-rich-outputs",
+              "entryType": "measure",
+              "startTime": 5931.899999991059,
+              "duration": 0.20000000298023224
+            },
+            {
+              "name": "oxiquill:imports:features__rich-output__python-rich-outputs",
+              "entryType": "measure",
+              "startTime": 5932.0999999940395,
+              "duration": 0.7999999970197678
+            },
+            {
+              "name": "oxiquill:display-prepare:features__rich-output__python-rich-outputs",
+              "entryType": "measure",
+              "startTime": 5933,
+              "duration": 0.29999999701976776
+            },
+            {
+              "name": "oxiquill:execution:features__rich-output__python-rich-outputs",
+              "entryType": "measure",
+              "startTime": 5933.5,
+              "duration": 12.299999997019768
+            },
+            {
+              "name": "oxiquill:display-collect:features__rich-output__python-rich-outputs",
+              "entryType": "measure",
+              "startTime": 5946.5,
+              "duration": 67.3999999910593
+            }
+          ]
+        }
+      ],
+      "observed": {
+        "requests": [
+          {
+            "requestId": 1,
+            "at": 1788590370111.5999
+          },
+          {
+            "requestId": 2,
+            "at": 1788590376044.7998
+          }
+        ],
+        "responses": [
+          {
+            "requestId": 1,
+            "at": 1788590375949.9,
+            "ok": true
+          },
+          {
+            "requestId": 2,
+            "at": 1788590376131,
+            "ok": true
+          }
+        ]
+      }
+    },
+    {
+      "example": "features/rich-output/",
+      "condition": "fresh",
+      "run": 2,
+      "triggerMs": 164.29999999701977,
+      "outputMs": 8998.39999999106,
+      "latencyMs": 8998.39999999106,
+      "renderObserverDeltaMs": -3.400146484375,
+      "main": {
+        "timeOrigin": 1788590376210.5,
+        "entries": [
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/index.DANjJwMU.css",
+            "entryType": "resource",
+            "startTime": 6.399999991059303,
+            "duration": 2.6000000089406967,
+            "initiatorType": "link",
+            "transferSize": 21909,
+            "encodedBodySize": 21609,
+            "decodedBodySize": 105367
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/page.Dwipeu-R.js",
+            "entryType": "resource",
+            "startTime": 6.700000002980232,
+            "duration": 8.5,
+            "initiatorType": "script",
+            "transferSize": 1424,
+            "encodedBodySize": 1124,
+            "decodedBodySize": 2486
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/Search.astro_astro_type_script_index_0_lang.DzL-jWp_.js",
+            "entryType": "resource",
+            "startTime": 6.700000002980232,
+            "duration": 8.599999994039536,
+            "initiatorType": "script",
+            "transferSize": 1245,
+            "encodedBodySize": 945,
+            "decodedBodySize": 1830
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/MobileTableOfContents.astro_astro_type_script_index_0_lang.BcSo_yiZ.js",
+            "entryType": "resource",
+            "startTime": 6.700000002980232,
+            "duration": 8.599999994039536,
+            "initiatorType": "script",
+            "transferSize": 664,
+            "encodedBodySize": 364,
+            "decodedBodySize": 622
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/ec.w36nc.css",
+            "entryType": "resource",
+            "startTime": 6.799999997019768,
+            "duration": 8,
+            "initiatorType": "link",
+            "transferSize": 4246,
+            "encodedBodySize": 3946,
+            "decodedBodySize": 18292
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/TableOfContents.astro_astro_type_script_index_0_lang.Csloo1VZ.js",
+            "entryType": "resource",
+            "startTime": 6.799999997019768,
+            "duration": 8.700000002980232,
+            "initiatorType": "script",
+            "transferSize": 356,
+            "encodedBodySize": 56,
+            "decodedBodySize": 36
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/ec.0vx5m.js",
+            "entryType": "resource",
+            "startTime": 6.899999991059303,
+            "duration": 8.700000002980232,
+            "initiatorType": "script",
+            "transferSize": 1468,
+            "encodedBodySize": 1168,
+            "decodedBodySize": 2523
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/TwoColumnContent.astro_astro_type_script_index_0_lang.DPGAuL8N.js",
+            "entryType": "resource",
+            "startTime": 6.899999991059303,
+            "duration": 11.800000011920929,
+            "initiatorType": "script",
+            "transferSize": 569,
+            "encodedBodySize": 269,
+            "decodedBodySize": 452
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/PageFrame.astro_astro_type_script_index_0_lang.iwTubUja.js",
+            "entryType": "resource",
+            "startTime": 6.899999991059303,
+            "duration": 12.100000008940697,
+            "initiatorType": "script",
+            "transferSize": 557,
+            "encodedBodySize": 257,
+            "decodedBodySize": 392
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/print.ehPL0gv-.css",
+            "entryType": "resource",
+            "startTime": 11.899999991059303,
+            "duration": 7.200000002980232,
+            "initiatorType": "link",
+            "transferSize": 1296,
+            "encodedBodySize": 996,
+            "decodedBodySize": 3318
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/preload-helper.BnKG7j8P.js",
+            "entryType": "resource",
+            "startTime": 43.5,
+            "duration": 2.7000000029802322,
+            "initiatorType": "script",
+            "transferSize": 1037,
+            "encodedBodySize": 737,
+            "decodedBodySize": 1351
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/starlight-toc.CTCQXEge.js",
+            "entryType": "resource",
+            "startTime": 43.79999999701977,
+            "duration": 2.5,
+            "initiatorType": "script",
+            "transferSize": 1251,
+            "encodedBodySize": 951,
+            "decodedBodySize": 1981
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/persistent-toggle.t6KkBAiq.js",
+            "entryType": "resource",
+            "startTime": 60.8999999910593,
+            "duration": 3,
+            "initiatorType": "script",
+            "transferSize": 1005,
+            "encodedBodySize": 705,
+            "decodedBodySize": 2082
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/favicon.svg",
+            "entryType": "resource",
+            "startTime": 76.70000000298023,
+            "duration": 2.0999999940395355,
+            "initiatorType": "other",
+            "transferSize": 559,
+            "encodedBodySize": 259,
+            "decodedBodySize": 331
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/ui-core.BwVUYzUq.js",
+            "entryType": "resource",
+            "startTime": 88.5,
+            "duration": 2.0999999940395355,
+            "initiatorType": "script",
+            "transferSize": 26419,
+            "encodedBodySize": 26119,
+            "decodedBodySize": 93799
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/InteractiveCell.DoOzatBM.js",
+            "entryType": "resource",
+            "startTime": 148.5,
+            "duration": 3.7000000029802322,
+            "initiatorType": "script",
+            "transferSize": 16684,
+            "encodedBodySize": 16384,
+            "decodedBodySize": 50227
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/client.BJAMOzhD.js",
+            "entryType": "resource",
+            "startTime": 148.59999999403954,
+            "duration": 3.2999999970197678,
+            "initiatorType": "script",
+            "transferSize": 1114,
+            "encodedBodySize": 814,
+            "decodedBodySize": 1412
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/preact.Bl7PEaKa.js",
+            "entryType": "resource",
+            "startTime": 152.79999999701977,
+            "duration": 2.5,
+            "initiatorType": "script",
+            "transferSize": 4713,
+            "encodedBodySize": 4413,
+            "decodedBodySize": 10470
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/hooks.ClbWuNs9.js",
+            "entryType": "resource",
+            "startTime": 153.8999999910593,
+            "duration": 3.7000000029802322,
+            "initiatorType": "script",
+            "transferSize": 1453,
+            "encodedBodySize": 1153,
+            "decodedBodySize": 2677
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/output-limits.vkaihnVu.js",
+            "entryType": "resource",
+            "startTime": 153.8999999910593,
+            "duration": 3.5,
+            "initiatorType": "script",
+            "transferSize": 3959,
+            "encodedBodySize": 3659,
+            "decodedBodySize": 8969
+          },
+          {
+            "name": "oxiquill:hydrated:features__rich-output__python-rich-outputs",
+            "entryType": "mark",
+            "startTime": 160.3999999910593,
+            "duration": 0
+          },
+          {
+            "name": "oxiquill:worker-start:python",
+            "entryType": "mark",
+            "startTime": 201.70000000298023,
+            "duration": 0
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/python-worker-CZmazRja.js",
+            "entryType": "resource",
+            "startTime": 205.8999999910593,
+            "duration": -1.5,
+            "initiatorType": "other",
+            "transferSize": 13324,
+            "encodedBodySize": 13024,
+            "decodedBodySize": 47679
+          },
+          {
+            "name": "oxiquill:output-rendered:features__rich-output__python-rich-outputs",
+            "entryType": "mark",
+            "startTime": 8998.39999999106,
+            "duration": 0
+          }
+        ]
+      },
+      "workers": [
+        {
+          "timeOrigin": 1788590376414.6,
+          "entries": [
+            {
+              "name": "oxiquill:worker-ready:python",
+              "entryType": "mark",
+              "startTime": 3.5,
+              "duration": 0
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pyodide.mjs",
+              "entryType": "resource",
+              "startTime": 10.700000002980232,
+              "duration": 2,
+              "initiatorType": "fetch",
+              "transferSize": 7456,
+              "encodedBodySize": 7156,
+              "decodedBodySize": 17931
+            },
+            {
+              "name": "oxiquill:initialization:python",
+              "entryType": "measure",
+              "startTime": 16.200000002980232,
+              "duration": 1345.5
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pyodide-lock.json",
+              "entryType": "resource",
+              "startTime": 16.600000008940697,
+              "duration": 5.299999997019768,
+              "initiatorType": "fetch",
+              "transferSize": 26834,
+              "encodedBodySize": 26534,
+              "decodedBodySize": 114440
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/python_stdlib.zip",
+              "entryType": "resource",
+              "startTime": 16.900000005960464,
+              "duration": 23.200000002980232,
+              "initiatorType": "fetch",
+              "transferSize": 2503474,
+              "encodedBodySize": 2503174,
+              "decodedBodySize": 2545564
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pyodide.asm.wasm",
+              "entryType": "resource",
+              "startTime": 17.100000008940697,
+              "duration": 98.29999999701977,
+              "initiatorType": "fetch",
+              "transferSize": 3546429,
+              "encodedBodySize": 3546129,
+              "decodedBodySize": 9598218
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pyodide.asm.mjs",
+              "entryType": "resource",
+              "startTime": 17.400000005960464,
+              "duration": 12.899999991059303,
+              "initiatorType": "script",
+              "transferSize": 260407,
+              "encodedBodySize": 260107,
+              "decodedBodySize": 1250344
+            },
+            {
+              "name": "oxiquill:display-support:python",
+              "entryType": "measure",
+              "startTime": 1361.7999999970198,
+              "duration": 32.70000000298023
+            },
+            {
+              "name": "oxiquill:packages:features__rich-output__python-rich-outputs",
+              "entryType": "measure",
+              "startTime": 1394.7000000029802,
+              "duration": 3708.4000000059605
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/matplotlib-3.10.8-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 1396,
+              "duration": 3030.9000000059605,
+              "initiatorType": "fetch",
+              "transferSize": 6867585,
+              "encodedBodySize": 6867285,
+              "decodedBodySize": 6982033
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/contourpy-1.3.3-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 1396.2999999970198,
+              "duration": 10.5,
+              "initiatorType": "fetch",
+              "transferSize": 117420,
+              "encodedBodySize": 117120,
+              "decodedBodySize": 118875
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/numpy-2.4.6-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 1396.4000000059605,
+              "duration": 76.8999999910593,
+              "initiatorType": "fetch",
+              "transferSize": 2882982,
+              "encodedBodySize": 2882682,
+              "decodedBodySize": 2918760
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/cycler-0.12.1-py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 1396.5,
+              "duration": 8.200000002980232,
+              "initiatorType": "fetch",
+              "transferSize": 8094,
+              "encodedBodySize": 7794,
+              "decodedBodySize": 8321
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/six-1.17.0-py2.py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 1396.6000000089407,
+              "duration": 8.199999988079071,
+              "initiatorType": "fetch",
+              "transferSize": 10940,
+              "encodedBodySize": 10640,
+              "decodedBodySize": 11050
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/fonttools-4.62.1-py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 1396.7999999970198,
+              "duration": 39.80000001192093,
+              "initiatorType": "fetch",
+              "transferSize": 1124839,
+              "encodedBodySize": 1124539,
+              "decodedBodySize": 1152647
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/kiwisolver-1.5.0-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 1396.9000000059605,
+              "duration": 14,
+              "initiatorType": "fetch",
+              "transferSize": 36187,
+              "encodedBodySize": 35887,
+              "decodedBodySize": 36616
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/packaging-26.1-py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 1397.1000000089407,
+              "duration": 15.899999991059303,
+              "initiatorType": "fetch",
+              "transferSize": 94497,
+              "encodedBodySize": 94197,
+              "decodedBodySize": 95852
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pillow-12.2.0-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 1397.2000000029802,
+              "duration": 41.70000000298023,
+              "initiatorType": "fetch",
+              "transferSize": 1029476,
+              "encodedBodySize": 1029176,
+              "decodedBodySize": 1037807
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pyparsing-3.3.2-py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 1397.4000000059605,
+              "duration": 20.899999991059303,
+              "initiatorType": "fetch",
+              "transferSize": 121460,
+              "encodedBodySize": 121160,
+              "decodedBodySize": 122781
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/python_dateutil-2.9.0.post0-py2.py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 1397.5,
+              "duration": 26.400000005960464,
+              "initiatorType": "fetch",
+              "transferSize": 228538,
+              "encodedBodySize": 228238,
+              "decodedBodySize": 229892
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pytz-2026.1.post1-py2.py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 1397.6000000089407,
+              "duration": 34.599999994039536,
+              "initiatorType": "fetch",
+              "transferSize": 377948,
+              "encodedBodySize": 377648,
+              "decodedBodySize": 510489
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pandas-3.0.2-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 1398,
+              "duration": 2918.7999999970198,
+              "initiatorType": "fetch",
+              "transferSize": 4141966,
+              "encodedBodySize": 4141666,
+              "decodedBodySize": 4177814
+            },
+            {
+              "name": "oxiquill:imports:features__rich-output__python-rich-outputs",
+              "entryType": "measure",
+              "startTime": 5103.100000008941,
+              "duration": 0.8999999910593033
+            },
+            {
+              "name": "oxiquill:display-prepare:features__rich-output__python-rich-outputs",
+              "entryType": "measure",
+              "startTime": 5104.100000008941,
+              "duration": 1199.8999999910593
+            },
+            {
+              "name": "oxiquill:execution:features__rich-output__python-rich-outputs",
+              "entryType": "measure",
+              "startTime": 6306.5,
+              "duration": 2349.1000000089407
+            },
+            {
+              "name": "oxiquill:display-collect:features__rich-output__python-rich-outputs",
+              "entryType": "measure",
+              "startTime": 8656.60000000894,
+              "duration": 124
+            }
+          ]
+        }
+      ],
+      "observed": {
+        "requests": [
+          {
+            "requestId": 1,
+            "at": 1788590376412.5
+          }
+        ],
+        "responses": [
+          {
+            "requestId": 1,
+            "at": 1788590385212.3,
+            "ok": true
+          }
+        ]
+      }
+    },
+    {
+      "example": "features/rich-output/",
+      "condition": "reload",
+      "run": 2,
+      "triggerMs": 106,
+      "outputMs": 6444.0999999940395,
+      "latencyMs": 6444.0999999940395,
+      "renderObserverDeltaMs": -5.5,
+      "main": {
+        "timeOrigin": 1788590385236.8,
+        "entries": [
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/index.DANjJwMU.css",
+            "entryType": "resource",
+            "startTime": 14.599999994039536,
+            "duration": 0,
+            "initiatorType": "link",
+            "transferSize": 0,
+            "encodedBodySize": 21609,
+            "decodedBodySize": 105367
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/page.Dwipeu-R.js",
+            "entryType": "resource",
+            "startTime": 14.599999994039536,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 1124,
+            "decodedBodySize": 2486
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/Search.astro_astro_type_script_index_0_lang.DzL-jWp_.js",
+            "entryType": "resource",
+            "startTime": 14.700000002980232,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 945,
+            "decodedBodySize": 1830
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/MobileTableOfContents.astro_astro_type_script_index_0_lang.BcSo_yiZ.js",
+            "entryType": "resource",
+            "startTime": 14.900000005960464,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 364,
+            "decodedBodySize": 622
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/TableOfContents.astro_astro_type_script_index_0_lang.Csloo1VZ.js",
+            "entryType": "resource",
+            "startTime": 14.900000005960464,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 56,
+            "decodedBodySize": 36
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/ec.w36nc.css",
+            "entryType": "resource",
+            "startTime": 15,
+            "duration": 0,
+            "initiatorType": "link",
+            "transferSize": 0,
+            "encodedBodySize": 3946,
+            "decodedBodySize": 18292
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/ec.0vx5m.js",
+            "entryType": "resource",
+            "startTime": 15.099999994039536,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 1168,
+            "decodedBodySize": 2523
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/TwoColumnContent.astro_astro_type_script_index_0_lang.DPGAuL8N.js",
+            "entryType": "resource",
+            "startTime": 15.099999994039536,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 269,
+            "decodedBodySize": 452
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/PageFrame.astro_astro_type_script_index_0_lang.iwTubUja.js",
+            "entryType": "resource",
+            "startTime": 15.099999994039536,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 257,
+            "decodedBodySize": 392
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/print.ehPL0gv-.css",
+            "entryType": "resource",
+            "startTime": 18.900000005960464,
+            "duration": 0,
+            "initiatorType": "link",
+            "transferSize": 0,
+            "encodedBodySize": 996,
+            "decodedBodySize": 3318
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/preload-helper.BnKG7j8P.js",
+            "entryType": "resource",
+            "startTime": 25.599999994039536,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 737,
+            "decodedBodySize": 1351
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/starlight-toc.CTCQXEge.js",
+            "entryType": "resource",
+            "startTime": 25.700000002980232,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 951,
+            "decodedBodySize": 1981
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/persistent-toggle.t6KkBAiq.js",
+            "entryType": "resource",
+            "startTime": 25.900000005960464,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 705,
+            "decodedBodySize": 2082
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/InteractiveCell.DoOzatBM.js",
+            "entryType": "resource",
+            "startTime": 52.79999999701977,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 16384,
+            "decodedBodySize": 50227
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/client.BJAMOzhD.js",
+            "entryType": "resource",
+            "startTime": 53,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 814,
+            "decodedBodySize": 1412
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/preact.Bl7PEaKa.js",
+            "entryType": "resource",
+            "startTime": 54.70000000298023,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 4413,
+            "decodedBodySize": 10470
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/output-limits.vkaihnVu.js",
+            "entryType": "resource",
+            "startTime": 54.79999999701977,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 3659,
+            "decodedBodySize": 8969
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/hooks.ClbWuNs9.js",
+            "entryType": "resource",
+            "startTime": 54.79999999701977,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 1153,
+            "decodedBodySize": 2677
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/favicon.svg",
+            "entryType": "resource",
+            "startTime": 55.099999994039536,
+            "duration": 1.1000000089406967,
+            "initiatorType": "other",
+            "transferSize": 0,
+            "encodedBodySize": 259,
+            "decodedBodySize": 331
+          },
+          {
+            "name": "oxiquill:hydrated:features__rich-output__python-rich-outputs",
+            "entryType": "mark",
+            "startTime": 61.900000005960464,
+            "duration": 0
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/ui-core.BwVUYzUq.js",
+            "entryType": "resource",
+            "startTime": 85.29999999701977,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 26119,
+            "decodedBodySize": 93799
+          },
+          {
+            "name": "oxiquill:worker-start:python",
+            "entryType": "mark",
+            "startTime": 140.70000000298023,
+            "duration": 0
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/python-worker-CZmazRja.js",
+            "entryType": "resource",
+            "startTime": 144,
+            "duration": -1.7000000029802322,
+            "initiatorType": "other",
+            "transferSize": 0,
+            "encodedBodySize": 13024,
+            "decodedBodySize": 47679
+          },
+          {
+            "name": "oxiquill:output-rendered:features__rich-output__python-rich-outputs",
+            "entryType": "mark",
+            "startTime": 6444.0999999940395,
+            "duration": 0
+          }
+        ]
+      },
+      "workers": [
+        {
+          "timeOrigin": 1788590385379.1,
+          "entries": [
+            {
+              "name": "oxiquill:worker-ready:python",
+              "entryType": "mark",
+              "startTime": 3.0999999940395355,
+              "duration": 0
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pyodide.mjs",
+              "entryType": "resource",
+              "startTime": 12.5,
+              "duration": 1.2000000029802322,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 7156,
+              "decodedBodySize": 17931
+            },
+            {
+              "name": "oxiquill:initialization:python",
+              "entryType": "measure",
+              "startTime": 16.599999994039536,
+              "duration": 1331.4000000059605
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pyodide-lock.json",
+              "entryType": "resource",
+              "startTime": 16.899999991059303,
+              "duration": 1.5,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 26534,
+              "decodedBodySize": 114440
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/python_stdlib.zip",
+              "entryType": "resource",
+              "startTime": 17.200000002980232,
+              "duration": 15.799999997019768,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 2503174,
+              "decodedBodySize": 2545564
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pyodide.asm.wasm",
+              "entryType": "resource",
+              "startTime": 17.599999994039536,
+              "duration": 84.29999999701977,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 3546129,
+              "decodedBodySize": 9598218
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pyodide.asm.mjs",
+              "entryType": "resource",
+              "startTime": 17.799999997019768,
+              "duration": 8.599999994039536,
+              "initiatorType": "script",
+              "transferSize": 0,
+              "encodedBodySize": 260107,
+              "decodedBodySize": 1250344
+            },
+            {
+              "name": "oxiquill:display-support:python",
+              "entryType": "measure",
+              "startTime": 1348,
+              "duration": 33.29999999701977
+            },
+            {
+              "name": "oxiquill:packages:features__rich-output__python-rich-outputs",
+              "entryType": "measure",
+              "startTime": 1381.5999999940395,
+              "duration": 844.6000000089407
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/matplotlib-3.10.8-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 1383.2000000029802,
+              "duration": 279.29999999701977,
+              "initiatorType": "fetch",
+              "transferSize": 6867585,
+              "encodedBodySize": 6867285,
+              "decodedBodySize": 6982033
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/contourpy-1.3.3-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 1383.3999999910593,
+              "duration": 15.400000005960464,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 117120,
+              "decodedBodySize": 118875
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/numpy-2.4.6-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 1383.5,
+              "duration": 83.5,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 2882682,
+              "decodedBodySize": 2918760
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/cycler-0.12.1-py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 1383.7000000029802,
+              "duration": 10.599999994039536,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 7794,
+              "decodedBodySize": 8321
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/six-1.17.0-py2.py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 1383.8999999910593,
+              "duration": 13.900000005960464,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 10640,
+              "decodedBodySize": 11050
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/fonttools-4.62.1-py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 1384.2000000029802,
+              "duration": 30.799999997019768,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 1124539,
+              "decodedBodySize": 1152647
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/kiwisolver-1.5.0-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 1384.3999999910593,
+              "duration": 14.600000008940697,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 35887,
+              "decodedBodySize": 36616
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/packaging-26.1-py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 1384.5,
+              "duration": 15.299999997019768,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 94197,
+              "decodedBodySize": 95852
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pillow-12.2.0-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 1384.5999999940395,
+              "duration": 28.900000005960464,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 1029176,
+              "decodedBodySize": 1037807
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pyparsing-3.3.2-py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 1384.7999999970198,
+              "duration": 16,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 121160,
+              "decodedBodySize": 122781
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/python_dateutil-2.9.0.post0-py2.py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 1385,
+              "duration": 17.899999991059303,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 228238,
+              "decodedBodySize": 229892
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pytz-2026.1.post1-py2.py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 1385.2999999970198,
+              "duration": 20.200000002980232,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 377648,
+              "decodedBodySize": 510489
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pandas-3.0.2-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 1385.5999999940395,
+              "duration": 86.6000000089407,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 4141666,
+              "decodedBodySize": 4177814
+            },
+            {
+              "name": "oxiquill:imports:features__rich-output__python-rich-outputs",
+              "entryType": "measure",
+              "startTime": 2226.2000000029802,
+              "duration": 1
+            },
+            {
+              "name": "oxiquill:display-prepare:features__rich-output__python-rich-outputs",
+              "entryType": "measure",
+              "startTime": 2227.2000000029802,
+              "duration": 1175.8999999910593
+            },
+            {
+              "name": "oxiquill:execution:features__rich-output__python-rich-outputs",
+              "entryType": "measure",
+              "startTime": 3403.2999999970198,
+              "duration": 2574.5
+            },
+            {
+              "name": "oxiquill:display-collect:features__rich-output__python-rich-outputs",
+              "entryType": "measure",
+              "startTime": 5980,
+              "duration": 302.5
+            }
+          ]
+        }
+      ],
+      "observed": {
+        "requests": [
+          {
+            "requestId": 1,
+            "at": 1788590385377.7
+          }
+        ],
+        "responses": [
+          {
+            "requestId": 1,
+            "at": 1788590391686.4001,
+            "ok": true
+          }
+        ]
+      }
+    },
+    {
+      "example": "features/rich-output/",
+      "condition": "repeat",
+      "run": 2,
+      "triggerMs": 6540,
+      "outputMs": 6680.5999999940395,
+      "latencyMs": 140.59999999403954,
+      "renderObserverDeltaMs": -2.699951171875,
+      "main": {
+        "timeOrigin": 1788590385236.8,
+        "entries": [
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/index.DANjJwMU.css",
+            "entryType": "resource",
+            "startTime": 14.599999994039536,
+            "duration": 0,
+            "initiatorType": "link",
+            "transferSize": 0,
+            "encodedBodySize": 21609,
+            "decodedBodySize": 105367
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/page.Dwipeu-R.js",
+            "entryType": "resource",
+            "startTime": 14.599999994039536,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 1124,
+            "decodedBodySize": 2486
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/Search.astro_astro_type_script_index_0_lang.DzL-jWp_.js",
+            "entryType": "resource",
+            "startTime": 14.700000002980232,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 945,
+            "decodedBodySize": 1830
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/MobileTableOfContents.astro_astro_type_script_index_0_lang.BcSo_yiZ.js",
+            "entryType": "resource",
+            "startTime": 14.900000005960464,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 364,
+            "decodedBodySize": 622
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/TableOfContents.astro_astro_type_script_index_0_lang.Csloo1VZ.js",
+            "entryType": "resource",
+            "startTime": 14.900000005960464,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 56,
+            "decodedBodySize": 36
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/ec.w36nc.css",
+            "entryType": "resource",
+            "startTime": 15,
+            "duration": 0,
+            "initiatorType": "link",
+            "transferSize": 0,
+            "encodedBodySize": 3946,
+            "decodedBodySize": 18292
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/ec.0vx5m.js",
+            "entryType": "resource",
+            "startTime": 15.099999994039536,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 1168,
+            "decodedBodySize": 2523
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/TwoColumnContent.astro_astro_type_script_index_0_lang.DPGAuL8N.js",
+            "entryType": "resource",
+            "startTime": 15.099999994039536,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 269,
+            "decodedBodySize": 452
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/PageFrame.astro_astro_type_script_index_0_lang.iwTubUja.js",
+            "entryType": "resource",
+            "startTime": 15.099999994039536,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 257,
+            "decodedBodySize": 392
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/print.ehPL0gv-.css",
+            "entryType": "resource",
+            "startTime": 18.900000005960464,
+            "duration": 0,
+            "initiatorType": "link",
+            "transferSize": 0,
+            "encodedBodySize": 996,
+            "decodedBodySize": 3318
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/preload-helper.BnKG7j8P.js",
+            "entryType": "resource",
+            "startTime": 25.599999994039536,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 737,
+            "decodedBodySize": 1351
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/starlight-toc.CTCQXEge.js",
+            "entryType": "resource",
+            "startTime": 25.700000002980232,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 951,
+            "decodedBodySize": 1981
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/persistent-toggle.t6KkBAiq.js",
+            "entryType": "resource",
+            "startTime": 25.900000005960464,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 705,
+            "decodedBodySize": 2082
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/InteractiveCell.DoOzatBM.js",
+            "entryType": "resource",
+            "startTime": 52.79999999701977,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 16384,
+            "decodedBodySize": 50227
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/client.BJAMOzhD.js",
+            "entryType": "resource",
+            "startTime": 53,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 814,
+            "decodedBodySize": 1412
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/preact.Bl7PEaKa.js",
+            "entryType": "resource",
+            "startTime": 54.70000000298023,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 4413,
+            "decodedBodySize": 10470
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/output-limits.vkaihnVu.js",
+            "entryType": "resource",
+            "startTime": 54.79999999701977,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 3659,
+            "decodedBodySize": 8969
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/hooks.ClbWuNs9.js",
+            "entryType": "resource",
+            "startTime": 54.79999999701977,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 1153,
+            "decodedBodySize": 2677
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/favicon.svg",
+            "entryType": "resource",
+            "startTime": 55.099999994039536,
+            "duration": 1.1000000089406967,
+            "initiatorType": "other",
+            "transferSize": 0,
+            "encodedBodySize": 259,
+            "decodedBodySize": 331
+          },
+          {
+            "name": "oxiquill:hydrated:features__rich-output__python-rich-outputs",
+            "entryType": "mark",
+            "startTime": 61.900000005960464,
+            "duration": 0
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/ui-core.BwVUYzUq.js",
+            "entryType": "resource",
+            "startTime": 85.29999999701977,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 26119,
+            "decodedBodySize": 93799
+          },
+          {
+            "name": "oxiquill:worker-start:python",
+            "entryType": "mark",
+            "startTime": 140.70000000298023,
+            "duration": 0
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/python-worker-CZmazRja.js",
+            "entryType": "resource",
+            "startTime": 144,
+            "duration": -1.7000000029802322,
+            "initiatorType": "other",
+            "transferSize": 0,
+            "encodedBodySize": 13024,
+            "decodedBodySize": 47679
+          },
+          {
+            "name": "oxiquill:output-rendered:features__rich-output__python-rich-outputs",
+            "entryType": "mark",
+            "startTime": 6680.5999999940395,
+            "duration": 0
+          }
+        ]
+      },
+      "workers": [
+        {
+          "timeOrigin": 1788590385379.1,
+          "entries": [
+            {
+              "name": "oxiquill:worker-ready:python",
+              "entryType": "mark",
+              "startTime": 3.0999999940395355,
+              "duration": 0
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pyodide.mjs",
+              "entryType": "resource",
+              "startTime": 12.5,
+              "duration": 1.2000000029802322,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 7156,
+              "decodedBodySize": 17931
+            },
+            {
+              "name": "oxiquill:initialization:python",
+              "entryType": "measure",
+              "startTime": 16.599999994039536,
+              "duration": 1331.4000000059605
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pyodide-lock.json",
+              "entryType": "resource",
+              "startTime": 16.899999991059303,
+              "duration": 1.5,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 26534,
+              "decodedBodySize": 114440
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/python_stdlib.zip",
+              "entryType": "resource",
+              "startTime": 17.200000002980232,
+              "duration": 15.799999997019768,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 2503174,
+              "decodedBodySize": 2545564
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pyodide.asm.wasm",
+              "entryType": "resource",
+              "startTime": 17.599999994039536,
+              "duration": 84.29999999701977,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 3546129,
+              "decodedBodySize": 9598218
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pyodide.asm.mjs",
+              "entryType": "resource",
+              "startTime": 17.799999997019768,
+              "duration": 8.599999994039536,
+              "initiatorType": "script",
+              "transferSize": 0,
+              "encodedBodySize": 260107,
+              "decodedBodySize": 1250344
+            },
+            {
+              "name": "oxiquill:display-support:python",
+              "entryType": "measure",
+              "startTime": 1348,
+              "duration": 33.29999999701977
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/matplotlib-3.10.8-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 1383.2000000029802,
+              "duration": 279.29999999701977,
+              "initiatorType": "fetch",
+              "transferSize": 6867585,
+              "encodedBodySize": 6867285,
+              "decodedBodySize": 6982033
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/contourpy-1.3.3-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 1383.3999999910593,
+              "duration": 15.400000005960464,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 117120,
+              "decodedBodySize": 118875
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/numpy-2.4.6-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 1383.5,
+              "duration": 83.5,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 2882682,
+              "decodedBodySize": 2918760
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/cycler-0.12.1-py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 1383.7000000029802,
+              "duration": 10.599999994039536,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 7794,
+              "decodedBodySize": 8321
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/six-1.17.0-py2.py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 1383.8999999910593,
+              "duration": 13.900000005960464,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 10640,
+              "decodedBodySize": 11050
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/fonttools-4.62.1-py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 1384.2000000029802,
+              "duration": 30.799999997019768,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 1124539,
+              "decodedBodySize": 1152647
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/kiwisolver-1.5.0-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 1384.3999999910593,
+              "duration": 14.600000008940697,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 35887,
+              "decodedBodySize": 36616
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/packaging-26.1-py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 1384.5,
+              "duration": 15.299999997019768,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 94197,
+              "decodedBodySize": 95852
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pillow-12.2.0-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 1384.5999999940395,
+              "duration": 28.900000005960464,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 1029176,
+              "decodedBodySize": 1037807
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pyparsing-3.3.2-py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 1384.7999999970198,
+              "duration": 16,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 121160,
+              "decodedBodySize": 122781
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/python_dateutil-2.9.0.post0-py2.py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 1385,
+              "duration": 17.899999991059303,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 228238,
+              "decodedBodySize": 229892
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pytz-2026.1.post1-py2.py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 1385.2999999970198,
+              "duration": 20.200000002980232,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 377648,
+              "decodedBodySize": 510489
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pandas-3.0.2-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 1385.5999999940395,
+              "duration": 86.6000000089407,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 4141666,
+              "decodedBodySize": 4177814
+            },
+            {
+              "name": "oxiquill:packages:features__rich-output__python-rich-outputs",
+              "entryType": "measure",
+              "startTime": 6432.20000000298,
+              "duration": 0.19999998807907104
+            },
+            {
+              "name": "oxiquill:imports:features__rich-output__python-rich-outputs",
+              "entryType": "measure",
+              "startTime": 6432.399999991059,
+              "duration": 0.9000000059604645
+            },
+            {
+              "name": "oxiquill:display-prepare:features__rich-output__python-rich-outputs",
+              "entryType": "measure",
+              "startTime": 6433.399999991059,
+              "duration": 0.4000000059604645
+            },
+            {
+              "name": "oxiquill:execution:features__rich-output__python-rich-outputs",
+              "entryType": "measure",
+              "startTime": 6433.899999991059,
+              "duration": 14.800000011920929
+            },
+            {
+              "name": "oxiquill:display-collect:features__rich-output__python-rich-outputs",
+              "entryType": "measure",
+              "startTime": 6449.5,
+              "duration": 87
+            }
+          ]
+        }
+      ],
+      "observed": {
+        "requests": [
+          {
+            "requestId": 1,
+            "at": 1788590385377.7
+          },
+          {
+            "requestId": 2,
+            "at": 1788590391810.8
+          }
+        ],
+        "responses": [
+          {
+            "requestId": 1,
+            "at": 1788590391686.4001,
+            "ok": true
+          },
+          {
+            "requestId": 2,
+            "at": 1788590391920.1,
+            "ok": true
+          }
+        ]
+      }
+    },
+    {
+      "example": "features/rich-output/",
+      "condition": "fresh",
+      "run": 3,
+      "triggerMs": 280.1000000089407,
+      "outputMs": 9378.10000000894,
+      "latencyMs": 9378.10000000894,
+      "renderObserverDeltaMs": -3,
+      "main": {
+        "timeOrigin": 1788590392025.7,
+        "entries": [
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/index.DANjJwMU.css",
+            "entryType": "resource",
+            "startTime": 25.600000008940697,
+            "duration": 4.899999991059303,
+            "initiatorType": "link",
+            "transferSize": 21909,
+            "encodedBodySize": 21609,
+            "decodedBodySize": 105367
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/page.Dwipeu-R.js",
+            "entryType": "resource",
+            "startTime": 25.700000002980232,
+            "duration": 14.299999997019768,
+            "initiatorType": "script",
+            "transferSize": 1424,
+            "encodedBodySize": 1124,
+            "decodedBodySize": 2486
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/Search.astro_astro_type_script_index_0_lang.DzL-jWp_.js",
+            "entryType": "resource",
+            "startTime": 25.900000005960464,
+            "duration": 14.299999997019768,
+            "initiatorType": "script",
+            "transferSize": 1245,
+            "encodedBodySize": 945,
+            "decodedBodySize": 1830
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/ec.w36nc.css",
+            "entryType": "resource",
+            "startTime": 26,
+            "duration": 13.700000002980232,
+            "initiatorType": "link",
+            "transferSize": 4246,
+            "encodedBodySize": 3946,
+            "decodedBodySize": 18292
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/TableOfContents.astro_astro_type_script_index_0_lang.Csloo1VZ.js",
+            "entryType": "resource",
+            "startTime": 26,
+            "duration": 14.400000005960464,
+            "initiatorType": "script",
+            "transferSize": 356,
+            "encodedBodySize": 56,
+            "decodedBodySize": 36
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/MobileTableOfContents.astro_astro_type_script_index_0_lang.BcSo_yiZ.js",
+            "entryType": "resource",
+            "startTime": 26,
+            "duration": 14.299999997019768,
+            "initiatorType": "script",
+            "transferSize": 664,
+            "encodedBodySize": 364,
+            "decodedBodySize": 622
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/ec.0vx5m.js",
+            "entryType": "resource",
+            "startTime": 26.100000008940697,
+            "duration": 14.399999991059303,
+            "initiatorType": "script",
+            "transferSize": 1468,
+            "encodedBodySize": 1168,
+            "decodedBodySize": 2523
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/TwoColumnContent.astro_astro_type_script_index_0_lang.DPGAuL8N.js",
+            "entryType": "resource",
+            "startTime": 26.400000005960464,
+            "duration": 23.700000002980232,
+            "initiatorType": "script",
+            "transferSize": 569,
+            "encodedBodySize": 269,
+            "decodedBodySize": 452
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/PageFrame.astro_astro_type_script_index_0_lang.iwTubUja.js",
+            "entryType": "resource",
+            "startTime": 26.400000005960464,
+            "duration": 24.200000002980232,
+            "initiatorType": "script",
+            "transferSize": 557,
+            "encodedBodySize": 257,
+            "decodedBodySize": 392
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/print.ehPL0gv-.css",
+            "entryType": "resource",
+            "startTime": 37.1000000089407,
+            "duration": 13.799999997019768,
+            "initiatorType": "link",
+            "transferSize": 1296,
+            "encodedBodySize": 996,
+            "decodedBodySize": 3318
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/starlight-toc.CTCQXEge.js",
+            "entryType": "resource",
+            "startTime": 51.900000005960464,
+            "duration": 5,
+            "initiatorType": "script",
+            "transferSize": 1251,
+            "encodedBodySize": 951,
+            "decodedBodySize": 1981
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/preload-helper.BnKG7j8P.js",
+            "entryType": "resource",
+            "startTime": 52.1000000089407,
+            "duration": 6.0999999940395355,
+            "initiatorType": "script",
+            "transferSize": 1037,
+            "encodedBodySize": 737,
+            "decodedBodySize": 1351
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/persistent-toggle.t6KkBAiq.js",
+            "entryType": "resource",
+            "startTime": 109.6000000089407,
+            "duration": 3.7999999970197678,
+            "initiatorType": "script",
+            "transferSize": 1005,
+            "encodedBodySize": 705,
+            "decodedBodySize": 2082
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/favicon.svg",
+            "entryType": "resource",
+            "startTime": 131.20000000298023,
+            "duration": 4.5,
+            "initiatorType": "other",
+            "transferSize": 559,
+            "encodedBodySize": 259,
+            "decodedBodySize": 331
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/ui-core.BwVUYzUq.js",
+            "entryType": "resource",
+            "startTime": 147.79999999701977,
+            "duration": 6.300000011920929,
+            "initiatorType": "script",
+            "transferSize": 26419,
+            "encodedBodySize": 26119,
+            "decodedBodySize": 93799
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/InteractiveCell.DoOzatBM.js",
+            "entryType": "resource",
+            "startTime": 234.79999999701977,
+            "duration": 5.200000002980232,
+            "initiatorType": "script",
+            "transferSize": 16684,
+            "encodedBodySize": 16384,
+            "decodedBodySize": 50227
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/client.BJAMOzhD.js",
+            "entryType": "resource",
+            "startTime": 235.40000000596046,
+            "duration": 6.5,
+            "initiatorType": "script",
+            "transferSize": 1114,
+            "encodedBodySize": 814,
+            "decodedBodySize": 1412
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/preact.Bl7PEaKa.js",
+            "entryType": "resource",
+            "startTime": 243.79999999701977,
+            "duration": 3,
+            "initiatorType": "script",
+            "transferSize": 4713,
+            "encodedBodySize": 4413,
+            "decodedBodySize": 10470
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/output-limits.vkaihnVu.js",
+            "entryType": "resource",
+            "startTime": 244.40000000596046,
+            "duration": 5.799999997019768,
+            "initiatorType": "script",
+            "transferSize": 3959,
+            "encodedBodySize": 3659,
+            "decodedBodySize": 8969
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/hooks.ClbWuNs9.js",
+            "entryType": "resource",
+            "startTime": 244.40000000596046,
+            "duration": 5.899999991059303,
+            "initiatorType": "script",
+            "transferSize": 1453,
+            "encodedBodySize": 1153,
+            "decodedBodySize": 2677
+          },
+          {
+            "name": "oxiquill:hydrated:features__rich-output__python-rich-outputs",
+            "entryType": "mark",
+            "startTime": 265.70000000298023,
+            "duration": 0
+          },
+          {
+            "name": "oxiquill:worker-start:python",
+            "entryType": "mark",
+            "startTime": 325.70000000298023,
+            "duration": 0
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/python-worker-CZmazRja.js",
+            "entryType": "resource",
+            "startTime": 337.29999999701977,
+            "duration": -5.0999999940395355,
+            "initiatorType": "other",
+            "transferSize": 13324,
+            "encodedBodySize": 13024,
+            "decodedBodySize": 47679
+          },
+          {
+            "name": "oxiquill:output-rendered:features__rich-output__python-rich-outputs",
+            "entryType": "mark",
+            "startTime": 9378.10000000894,
+            "duration": 0
+          }
+        ]
+      },
+      "workers": [
+        {
+          "timeOrigin": 1788590392359.4,
+          "entries": [
+            {
+              "name": "oxiquill:worker-ready:python",
+              "entryType": "mark",
+              "startTime": 8.100000008940697,
+              "duration": 0
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pyodide.mjs",
+              "entryType": "resource",
+              "startTime": 9.700000002980232,
+              "duration": 2.9000000059604645,
+              "initiatorType": "fetch",
+              "transferSize": 7456,
+              "encodedBodySize": 7156,
+              "decodedBodySize": 17931
+            },
+            {
+              "name": "oxiquill:initialization:python",
+              "entryType": "measure",
+              "startTime": 19.100000008940697,
+              "duration": 2040.8999999910593
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pyodide-lock.json",
+              "entryType": "resource",
+              "startTime": 19.600000008940697,
+              "duration": 6.299999997019768,
+              "initiatorType": "fetch",
+              "transferSize": 26834,
+              "encodedBodySize": 26534,
+              "decodedBodySize": 114440
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/python_stdlib.zip",
+              "entryType": "resource",
+              "startTime": 20.100000008940697,
+              "duration": 25,
+              "initiatorType": "fetch",
+              "transferSize": 2503474,
+              "encodedBodySize": 2503174,
+              "decodedBodySize": 2545564
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pyodide.asm.wasm",
+              "entryType": "resource",
+              "startTime": 20.30000001192093,
+              "duration": 132.69999998807907,
+              "initiatorType": "fetch",
+              "transferSize": 3546429,
+              "encodedBodySize": 3546129,
+              "decodedBodySize": 9598218
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pyodide.asm.mjs",
+              "entryType": "resource",
+              "startTime": 20.5,
+              "duration": 14.400000005960464,
+              "initiatorType": "script",
+              "transferSize": 260407,
+              "encodedBodySize": 260107,
+              "decodedBodySize": 1250344
+            },
+            {
+              "name": "oxiquill:display-support:python",
+              "entryType": "measure",
+              "startTime": 2060.1000000089407,
+              "duration": 162.29999999701977
+            },
+            {
+              "name": "oxiquill:packages:features__rich-output__python-rich-outputs",
+              "entryType": "measure",
+              "startTime": 2222.7000000029802,
+              "duration": 1615.5
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/matplotlib-3.10.8-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 2224.300000011921,
+              "duration": 404.19999998807907,
+              "initiatorType": "fetch",
+              "transferSize": 6867585,
+              "encodedBodySize": 6867285,
+              "decodedBodySize": 6982033
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/contourpy-1.3.3-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 2225.4000000059605,
+              "duration": 43.79999999701977,
+              "initiatorType": "fetch",
+              "transferSize": 117420,
+              "encodedBodySize": 117120,
+              "decodedBodySize": 118875
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/numpy-2.4.6-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 2227.4000000059605,
+              "duration": 204.79999999701977,
+              "initiatorType": "fetch",
+              "transferSize": 2882982,
+              "encodedBodySize": 2882682,
+              "decodedBodySize": 2918760
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/cycler-0.12.1-py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 2228.1000000089407,
+              "duration": 38,
+              "initiatorType": "fetch",
+              "transferSize": 8094,
+              "encodedBodySize": 7794,
+              "decodedBodySize": 8321
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/six-1.17.0-py2.py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 2231.7000000029802,
+              "duration": 35.79999999701977,
+              "initiatorType": "fetch",
+              "transferSize": 10940,
+              "encodedBodySize": 10640,
+              "decodedBodySize": 11050
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/fonttools-4.62.1-py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 2232,
+              "duration": 83.90000000596046,
+              "initiatorType": "fetch",
+              "transferSize": 1124839,
+              "encodedBodySize": 1124539,
+              "decodedBodySize": 1152647
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/kiwisolver-1.5.0-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 2232.2000000029802,
+              "duration": 49.20000000298023,
+              "initiatorType": "fetch",
+              "transferSize": 36187,
+              "encodedBodySize": 35887,
+              "decodedBodySize": 36616
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/packaging-26.1-py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 2232.300000011921,
+              "duration": 52.79999999701977,
+              "initiatorType": "fetch",
+              "transferSize": 94497,
+              "encodedBodySize": 94197,
+              "decodedBodySize": 95852
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pillow-12.2.0-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 2232.5,
+              "duration": 89.1000000089407,
+              "initiatorType": "fetch",
+              "transferSize": 1029476,
+              "encodedBodySize": 1029176,
+              "decodedBodySize": 1037807
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pyparsing-3.3.2-py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 2232.7000000029802,
+              "duration": 61.6000000089407,
+              "initiatorType": "fetch",
+              "transferSize": 121460,
+              "encodedBodySize": 121160,
+              "decodedBodySize": 122781
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/python_dateutil-2.9.0.post0-py2.py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 2232.800000011921,
+              "duration": 69.69999998807907,
+              "initiatorType": "fetch",
+              "transferSize": 228538,
+              "encodedBodySize": 228238,
+              "decodedBodySize": 229892
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pytz-2026.1.post1-py2.py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 2232.9000000059605,
+              "duration": 82.40000000596046,
+              "initiatorType": "fetch",
+              "transferSize": 377948,
+              "encodedBodySize": 377648,
+              "decodedBodySize": 510489
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pandas-3.0.2-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 2233.1000000089407,
+              "duration": 400.5,
+              "initiatorType": "fetch",
+              "transferSize": 4141966,
+              "encodedBodySize": 4141666,
+              "decodedBodySize": 4177814
+            },
+            {
+              "name": "oxiquill:imports:features__rich-output__python-rich-outputs",
+              "entryType": "measure",
+              "startTime": 3838.2000000029802,
+              "duration": 1
+            },
+            {
+              "name": "oxiquill:display-prepare:features__rich-output__python-rich-outputs",
+              "entryType": "measure",
+              "startTime": 3839.2000000029802,
+              "duration": 1143.4000000059605
+            },
+            {
+              "name": "oxiquill:execution:features__rich-output__python-rich-outputs",
+              "entryType": "measure",
+              "startTime": 4982.800000011921,
+              "duration": 3926.5999999940395
+            },
+            {
+              "name": "oxiquill:display-collect:features__rich-output__python-rich-outputs",
+              "entryType": "measure",
+              "startTime": 8911,
+              "duration": 118.70000000298023
+            }
+          ]
+        }
+      ],
+      "observed": {
+        "requests": [
+          {
+            "requestId": 1,
+            "at": 1788590392352
+          }
+        ],
+        "responses": [
+          {
+            "requestId": 1,
+            "at": 1788590401406.8,
+            "ok": true
+          }
+        ]
+      }
+    },
+    {
+      "example": "features/rich-output/",
+      "condition": "reload",
+      "run": 3,
+      "triggerMs": 127.09999999403954,
+      "outputMs": 7485.79999999702,
+      "latencyMs": 7485.79999999702,
+      "renderObserverDeltaMs": -3.699951171875,
+      "main": {
+        "timeOrigin": 1788590401431.7,
+        "entries": [
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/index.DANjJwMU.css",
+            "entryType": "resource",
+            "startTime": 16.200000002980232,
+            "duration": 0,
+            "initiatorType": "link",
+            "transferSize": 0,
+            "encodedBodySize": 21609,
+            "decodedBodySize": 105367
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/page.Dwipeu-R.js",
+            "entryType": "resource",
+            "startTime": 16.200000002980232,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 1124,
+            "decodedBodySize": 2486
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/Search.astro_astro_type_script_index_0_lang.DzL-jWp_.js",
+            "entryType": "resource",
+            "startTime": 16.200000002980232,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 945,
+            "decodedBodySize": 1830
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/MobileTableOfContents.astro_astro_type_script_index_0_lang.BcSo_yiZ.js",
+            "entryType": "resource",
+            "startTime": 16.400000005960464,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 364,
+            "decodedBodySize": 622
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/TableOfContents.astro_astro_type_script_index_0_lang.Csloo1VZ.js",
+            "entryType": "resource",
+            "startTime": 16.400000005960464,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 56,
+            "decodedBodySize": 36
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/ec.w36nc.css",
+            "entryType": "resource",
+            "startTime": 16.5,
+            "duration": 0,
+            "initiatorType": "link",
+            "transferSize": 0,
+            "encodedBodySize": 3946,
+            "decodedBodySize": 18292
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/ec.0vx5m.js",
+            "entryType": "resource",
+            "startTime": 16.599999994039536,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 1168,
+            "decodedBodySize": 2523
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/TwoColumnContent.astro_astro_type_script_index_0_lang.DPGAuL8N.js",
+            "entryType": "resource",
+            "startTime": 16.900000005960464,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 269,
+            "decodedBodySize": 452
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/PageFrame.astro_astro_type_script_index_0_lang.iwTubUja.js",
+            "entryType": "resource",
+            "startTime": 16.900000005960464,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 257,
+            "decodedBodySize": 392
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/print.ehPL0gv-.css",
+            "entryType": "resource",
+            "startTime": 20.400000005960464,
+            "duration": 0,
+            "initiatorType": "link",
+            "transferSize": 0,
+            "encodedBodySize": 996,
+            "decodedBodySize": 3318
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/preload-helper.BnKG7j8P.js",
+            "entryType": "resource",
+            "startTime": 27.700000002980232,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 737,
+            "decodedBodySize": 1351
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/starlight-toc.CTCQXEge.js",
+            "entryType": "resource",
+            "startTime": 27.900000005960464,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 951,
+            "decodedBodySize": 1981
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/persistent-toggle.t6KkBAiq.js",
+            "entryType": "resource",
+            "startTime": 28,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 705,
+            "decodedBodySize": 2082
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/InteractiveCell.DoOzatBM.js",
+            "entryType": "resource",
+            "startTime": 55.599999994039536,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 16384,
+            "decodedBodySize": 50227
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/client.BJAMOzhD.js",
+            "entryType": "resource",
+            "startTime": 55.70000000298023,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 814,
+            "decodedBodySize": 1412
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/preact.Bl7PEaKa.js",
+            "entryType": "resource",
+            "startTime": 56.400000005960464,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 4413,
+            "decodedBodySize": 10470
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/output-limits.vkaihnVu.js",
+            "entryType": "resource",
+            "startTime": 56.5,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 3659,
+            "decodedBodySize": 8969
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/hooks.ClbWuNs9.js",
+            "entryType": "resource",
+            "startTime": 56.599999994039536,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 1153,
+            "decodedBodySize": 2677
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/favicon.svg",
+            "entryType": "resource",
+            "startTime": 56.79999999701977,
+            "duration": 1.4000000059604645,
+            "initiatorType": "other",
+            "transferSize": 0,
+            "encodedBodySize": 259,
+            "decodedBodySize": 331
+          },
+          {
+            "name": "oxiquill:hydrated:features__rich-output__python-rich-outputs",
+            "entryType": "mark",
+            "startTime": 58,
+            "duration": 0
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/ui-core.BwVUYzUq.js",
+            "entryType": "resource",
+            "startTime": 78.79999999701977,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 26119,
+            "decodedBodySize": 93799
+          },
+          {
+            "name": "oxiquill:worker-start:python",
+            "entryType": "mark",
+            "startTime": 162,
+            "duration": 0
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/python-worker-CZmazRja.js",
+            "entryType": "resource",
+            "startTime": 165.29999999701977,
+            "duration": -1.2999999970197678,
+            "initiatorType": "other",
+            "transferSize": 0,
+            "encodedBodySize": 13024,
+            "decodedBodySize": 47679
+          },
+          {
+            "name": "oxiquill:output-rendered:features__rich-output__python-rich-outputs",
+            "entryType": "mark",
+            "startTime": 7485.79999999702,
+            "duration": 0
+          }
+        ]
+      },
+      "workers": [
+        {
+          "timeOrigin": 1788590401595.7,
+          "entries": [
+            {
+              "name": "oxiquill:worker-ready:python",
+              "entryType": "mark",
+              "startTime": 3,
+              "duration": 0
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pyodide.mjs",
+              "entryType": "resource",
+              "startTime": 12,
+              "duration": 1.3999999910593033,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 7156,
+              "decodedBodySize": 17931
+            },
+            {
+              "name": "oxiquill:initialization:python",
+              "entryType": "measure",
+              "startTime": 16.5,
+              "duration": 1605.5999999940395
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pyodide-lock.json",
+              "entryType": "resource",
+              "startTime": 16.899999991059303,
+              "duration": 1.4000000059604645,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 26534,
+              "decodedBodySize": 114440
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/python_stdlib.zip",
+              "entryType": "resource",
+              "startTime": 17.19999998807907,
+              "duration": 17.200000002980232,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 2503174,
+              "decodedBodySize": 2545564
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pyodide.asm.wasm",
+              "entryType": "resource",
+              "startTime": 17.5,
+              "duration": 94.09999999403954,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 3546129,
+              "decodedBodySize": 9598218
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pyodide.asm.mjs",
+              "entryType": "resource",
+              "startTime": 17.69999998807907,
+              "duration": 9.900000005960464,
+              "initiatorType": "script",
+              "transferSize": 0,
+              "encodedBodySize": 260107,
+              "decodedBodySize": 1250344
+            },
+            {
+              "name": "oxiquill:display-support:python",
+              "entryType": "measure",
+              "startTime": 1622.0999999940395,
+              "duration": 323.20000000298023
+            },
+            {
+              "name": "oxiquill:packages:features__rich-output__python-rich-outputs",
+              "entryType": "measure",
+              "startTime": 1945.3999999910593,
+              "duration": 1365.7999999970198
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/matplotlib-3.10.8-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 1946.7999999970198,
+              "duration": 865.5,
+              "initiatorType": "fetch",
+              "transferSize": 6867585,
+              "encodedBodySize": 6867285,
+              "decodedBodySize": 6982033
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/contourpy-1.3.3-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 1947.0999999940395,
+              "duration": 434.90000000596046,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 117120,
+              "decodedBodySize": 118875
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/numpy-2.4.6-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 1947.2999999970198,
+              "duration": 519.0999999940395,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 2882682,
+              "decodedBodySize": 2918760
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/cycler-0.12.1-py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 1947.3999999910593,
+              "duration": 425.1000000089407,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 7794,
+              "decodedBodySize": 8321
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/six-1.17.0-py2.py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 1947.5,
+              "duration": 431.09999999403954,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 10640,
+              "decodedBodySize": 11050
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/fonttools-4.62.1-py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 1947.699999988079,
+              "duration": 451.1000000089407,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 1124539,
+              "decodedBodySize": 1152647
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/kiwisolver-1.5.0-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 1947.7999999970198,
+              "duration": 434.3999999910593,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 35887,
+              "decodedBodySize": 36616
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/packaging-26.1-py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 1947.8999999910593,
+              "duration": 435.20000000298023,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 94197,
+              "decodedBodySize": 95852
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pillow-12.2.0-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 1948,
+              "duration": 449.59999999403954,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 1029176,
+              "decodedBodySize": 1037807
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pyparsing-3.3.2-py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 1949.5999999940395,
+              "duration": 434.40000000596046,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 121160,
+              "decodedBodySize": 122781
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/python_dateutil-2.9.0.post0-py2.py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 1949.699999988079,
+              "duration": 436.6000000089407,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 228238,
+              "decodedBodySize": 229892
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pytz-2026.1.post1-py2.py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 1950.0999999940395,
+              "duration": 439.20000000298023,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 377648,
+              "decodedBodySize": 510489
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pandas-3.0.2-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 1950.2999999970198,
+              "duration": 553.8999999910593,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 4141666,
+              "decodedBodySize": 4177814
+            },
+            {
+              "name": "oxiquill:imports:features__rich-output__python-rich-outputs",
+              "entryType": "measure",
+              "startTime": 3311.2999999970198,
+              "duration": 0.8999999910593033
+            },
+            {
+              "name": "oxiquill:display-prepare:features__rich-output__python-rich-outputs",
+              "entryType": "measure",
+              "startTime": 3312.2999999970198,
+              "duration": 1074.5999999940395
+            },
+            {
+              "name": "oxiquill:execution:features__rich-output__python-rich-outputs",
+              "entryType": "measure",
+              "startTime": 4387.199999988079,
+              "duration": 2786
+            },
+            {
+              "name": "oxiquill:display-collect:features__rich-output__python-rich-outputs",
+              "entryType": "measure",
+              "startTime": 7174.0999999940395,
+              "duration": 143.20000000298023
+            }
+          ]
+        }
+      ],
+      "observed": {
+        "requests": [
+          {
+            "requestId": 1,
+            "at": 1788590401593.9
+          }
+        ],
+        "responses": [
+          {
+            "requestId": 1,
+            "at": 1788590408921.2,
+            "ok": true
+          }
+        ]
+      }
+    },
+    {
+      "example": "features/rich-output/",
+      "condition": "repeat",
+      "run": 3,
+      "triggerMs": 7561.5999999940395,
+      "outputMs": 7704.79999999702,
+      "latencyMs": 143.20000000298023,
+      "renderObserverDeltaMs": -3,
+      "main": {
+        "timeOrigin": 1788590401431.7,
+        "entries": [
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/index.DANjJwMU.css",
+            "entryType": "resource",
+            "startTime": 16.200000002980232,
+            "duration": 0,
+            "initiatorType": "link",
+            "transferSize": 0,
+            "encodedBodySize": 21609,
+            "decodedBodySize": 105367
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/page.Dwipeu-R.js",
+            "entryType": "resource",
+            "startTime": 16.200000002980232,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 1124,
+            "decodedBodySize": 2486
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/Search.astro_astro_type_script_index_0_lang.DzL-jWp_.js",
+            "entryType": "resource",
+            "startTime": 16.200000002980232,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 945,
+            "decodedBodySize": 1830
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/MobileTableOfContents.astro_astro_type_script_index_0_lang.BcSo_yiZ.js",
+            "entryType": "resource",
+            "startTime": 16.400000005960464,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 364,
+            "decodedBodySize": 622
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/TableOfContents.astro_astro_type_script_index_0_lang.Csloo1VZ.js",
+            "entryType": "resource",
+            "startTime": 16.400000005960464,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 56,
+            "decodedBodySize": 36
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/ec.w36nc.css",
+            "entryType": "resource",
+            "startTime": 16.5,
+            "duration": 0,
+            "initiatorType": "link",
+            "transferSize": 0,
+            "encodedBodySize": 3946,
+            "decodedBodySize": 18292
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/ec.0vx5m.js",
+            "entryType": "resource",
+            "startTime": 16.599999994039536,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 1168,
+            "decodedBodySize": 2523
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/TwoColumnContent.astro_astro_type_script_index_0_lang.DPGAuL8N.js",
+            "entryType": "resource",
+            "startTime": 16.900000005960464,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 269,
+            "decodedBodySize": 452
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/PageFrame.astro_astro_type_script_index_0_lang.iwTubUja.js",
+            "entryType": "resource",
+            "startTime": 16.900000005960464,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 257,
+            "decodedBodySize": 392
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/print.ehPL0gv-.css",
+            "entryType": "resource",
+            "startTime": 20.400000005960464,
+            "duration": 0,
+            "initiatorType": "link",
+            "transferSize": 0,
+            "encodedBodySize": 996,
+            "decodedBodySize": 3318
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/preload-helper.BnKG7j8P.js",
+            "entryType": "resource",
+            "startTime": 27.700000002980232,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 737,
+            "decodedBodySize": 1351
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/starlight-toc.CTCQXEge.js",
+            "entryType": "resource",
+            "startTime": 27.900000005960464,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 951,
+            "decodedBodySize": 1981
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/persistent-toggle.t6KkBAiq.js",
+            "entryType": "resource",
+            "startTime": 28,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 705,
+            "decodedBodySize": 2082
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/InteractiveCell.DoOzatBM.js",
+            "entryType": "resource",
+            "startTime": 55.599999994039536,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 16384,
+            "decodedBodySize": 50227
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/client.BJAMOzhD.js",
+            "entryType": "resource",
+            "startTime": 55.70000000298023,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 814,
+            "decodedBodySize": 1412
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/preact.Bl7PEaKa.js",
+            "entryType": "resource",
+            "startTime": 56.400000005960464,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 4413,
+            "decodedBodySize": 10470
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/output-limits.vkaihnVu.js",
+            "entryType": "resource",
+            "startTime": 56.5,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 3659,
+            "decodedBodySize": 8969
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/hooks.ClbWuNs9.js",
+            "entryType": "resource",
+            "startTime": 56.599999994039536,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 1153,
+            "decodedBodySize": 2677
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/favicon.svg",
+            "entryType": "resource",
+            "startTime": 56.79999999701977,
+            "duration": 1.4000000059604645,
+            "initiatorType": "other",
+            "transferSize": 0,
+            "encodedBodySize": 259,
+            "decodedBodySize": 331
+          },
+          {
+            "name": "oxiquill:hydrated:features__rich-output__python-rich-outputs",
+            "entryType": "mark",
+            "startTime": 58,
+            "duration": 0
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/ui-core.BwVUYzUq.js",
+            "entryType": "resource",
+            "startTime": 78.79999999701977,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 26119,
+            "decodedBodySize": 93799
+          },
+          {
+            "name": "oxiquill:worker-start:python",
+            "entryType": "mark",
+            "startTime": 162,
+            "duration": 0
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/python-worker-CZmazRja.js",
+            "entryType": "resource",
+            "startTime": 165.29999999701977,
+            "duration": -1.2999999970197678,
+            "initiatorType": "other",
+            "transferSize": 0,
+            "encodedBodySize": 13024,
+            "decodedBodySize": 47679
+          },
+          {
+            "name": "oxiquill:output-rendered:features__rich-output__python-rich-outputs",
+            "entryType": "mark",
+            "startTime": 7704.79999999702,
+            "duration": 0
+          }
+        ]
+      },
+      "workers": [
+        {
+          "timeOrigin": 1788590401595.7,
+          "entries": [
+            {
+              "name": "oxiquill:worker-ready:python",
+              "entryType": "mark",
+              "startTime": 3,
+              "duration": 0
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pyodide.mjs",
+              "entryType": "resource",
+              "startTime": 12,
+              "duration": 1.3999999910593033,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 7156,
+              "decodedBodySize": 17931
+            },
+            {
+              "name": "oxiquill:initialization:python",
+              "entryType": "measure",
+              "startTime": 16.5,
+              "duration": 1605.5999999940395
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pyodide-lock.json",
+              "entryType": "resource",
+              "startTime": 16.899999991059303,
+              "duration": 1.4000000059604645,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 26534,
+              "decodedBodySize": 114440
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/python_stdlib.zip",
+              "entryType": "resource",
+              "startTime": 17.19999998807907,
+              "duration": 17.200000002980232,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 2503174,
+              "decodedBodySize": 2545564
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pyodide.asm.wasm",
+              "entryType": "resource",
+              "startTime": 17.5,
+              "duration": 94.09999999403954,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 3546129,
+              "decodedBodySize": 9598218
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pyodide.asm.mjs",
+              "entryType": "resource",
+              "startTime": 17.69999998807907,
+              "duration": 9.900000005960464,
+              "initiatorType": "script",
+              "transferSize": 0,
+              "encodedBodySize": 260107,
+              "decodedBodySize": 1250344
+            },
+            {
+              "name": "oxiquill:display-support:python",
+              "entryType": "measure",
+              "startTime": 1622.0999999940395,
+              "duration": 323.20000000298023
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/matplotlib-3.10.8-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 1946.7999999970198,
+              "duration": 865.5,
+              "initiatorType": "fetch",
+              "transferSize": 6867585,
+              "encodedBodySize": 6867285,
+              "decodedBodySize": 6982033
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/contourpy-1.3.3-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 1947.0999999940395,
+              "duration": 434.90000000596046,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 117120,
+              "decodedBodySize": 118875
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/numpy-2.4.6-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 1947.2999999970198,
+              "duration": 519.0999999940395,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 2882682,
+              "decodedBodySize": 2918760
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/cycler-0.12.1-py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 1947.3999999910593,
+              "duration": 425.1000000089407,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 7794,
+              "decodedBodySize": 8321
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/six-1.17.0-py2.py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 1947.5,
+              "duration": 431.09999999403954,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 10640,
+              "decodedBodySize": 11050
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/fonttools-4.62.1-py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 1947.699999988079,
+              "duration": 451.1000000089407,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 1124539,
+              "decodedBodySize": 1152647
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/kiwisolver-1.5.0-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 1947.7999999970198,
+              "duration": 434.3999999910593,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 35887,
+              "decodedBodySize": 36616
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/packaging-26.1-py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 1947.8999999910593,
+              "duration": 435.20000000298023,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 94197,
+              "decodedBodySize": 95852
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pillow-12.2.0-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 1948,
+              "duration": 449.59999999403954,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 1029176,
+              "decodedBodySize": 1037807
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pyparsing-3.3.2-py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 1949.5999999940395,
+              "duration": 434.40000000596046,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 121160,
+              "decodedBodySize": 122781
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/python_dateutil-2.9.0.post0-py2.py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 1949.699999988079,
+              "duration": 436.6000000089407,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 228238,
+              "decodedBodySize": 229892
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pytz-2026.1.post1-py2.py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 1950.0999999940395,
+              "duration": 439.20000000298023,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 377648,
+              "decodedBodySize": 510489
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pandas-3.0.2-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 1950.2999999970198,
+              "duration": 553.8999999910593,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 4141666,
+              "decodedBodySize": 4177814
+            },
+            {
+              "name": "oxiquill:packages:features__rich-output__python-rich-outputs",
+              "entryType": "measure",
+              "startTime": 7432.5999999940395,
+              "duration": 0.20000000298023224
+            },
+            {
+              "name": "oxiquill:imports:features__rich-output__python-rich-outputs",
+              "entryType": "measure",
+              "startTime": 7432.79999999702,
+              "duration": 0.7999999970197678
+            },
+            {
+              "name": "oxiquill:display-prepare:features__rich-output__python-rich-outputs",
+              "entryType": "measure",
+              "startTime": 7433.699999988079,
+              "duration": 0.4000000059604645
+            },
+            {
+              "name": "oxiquill:execution:features__rich-output__python-rich-outputs",
+              "entryType": "measure",
+              "startTime": 7434.199999988079,
+              "duration": 16.400000005960464
+            },
+            {
+              "name": "oxiquill:display-collect:features__rich-output__python-rich-outputs",
+              "entryType": "measure",
+              "startTime": 7451.29999999702,
+              "duration": 86.8999999910593
+            }
+          ]
+        }
+      ],
+      "observed": {
+        "requests": [
+          {
+            "requestId": 1,
+            "at": 1788590401593.9
+          },
+          {
+            "requestId": 2,
+            "at": 1788590409027.5999
+          }
+        ],
+        "responses": [
+          {
+            "requestId": 1,
+            "at": 1788590408921.2,
+            "ok": true
+          },
+          {
+            "requestId": 2,
+            "at": 1788590409139.5,
+            "ok": true
+          }
+        ]
+      }
+    },
+    {
+      "example": "features/rich-output/",
+      "condition": "fresh",
+      "run": 4,
+      "triggerMs": 165.79999999701977,
+      "outputMs": 11262.5,
+      "latencyMs": 11262.5,
+      "renderObserverDeltaMs": -12.5,
+      "main": {
+        "timeOrigin": 1788590409224.5,
+        "entries": [
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/index.DANjJwMU.css",
+            "entryType": "resource",
+            "startTime": 8.299999997019768,
+            "duration": 4.0999999940395355,
+            "initiatorType": "link",
+            "transferSize": 21909,
+            "encodedBodySize": 21609,
+            "decodedBodySize": 105367
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/page.Dwipeu-R.js",
+            "entryType": "resource",
+            "startTime": 8.599999994039536,
+            "duration": 11.100000008940697,
+            "initiatorType": "script",
+            "transferSize": 1424,
+            "encodedBodySize": 1124,
+            "decodedBodySize": 2486
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/Search.astro_astro_type_script_index_0_lang.DzL-jWp_.js",
+            "entryType": "resource",
+            "startTime": 8.599999994039536,
+            "duration": 11.200000002980232,
+            "initiatorType": "script",
+            "transferSize": 1245,
+            "encodedBodySize": 945,
+            "decodedBodySize": 1830
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/MobileTableOfContents.astro_astro_type_script_index_0_lang.BcSo_yiZ.js",
+            "entryType": "resource",
+            "startTime": 8.599999994039536,
+            "duration": 11.400000005960464,
+            "initiatorType": "script",
+            "transferSize": 664,
+            "encodedBodySize": 364,
+            "decodedBodySize": 622
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/TableOfContents.astro_astro_type_script_index_0_lang.Csloo1VZ.js",
+            "entryType": "resource",
+            "startTime": 8.599999994039536,
+            "duration": 11.5,
+            "initiatorType": "script",
+            "transferSize": 356,
+            "encodedBodySize": 56,
+            "decodedBodySize": 36
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/ec.w36nc.css",
+            "entryType": "resource",
+            "startTime": 8.700000002980232,
+            "duration": 10.799999997019768,
+            "initiatorType": "link",
+            "transferSize": 4246,
+            "encodedBodySize": 3946,
+            "decodedBodySize": 18292
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/ec.0vx5m.js",
+            "entryType": "resource",
+            "startTime": 8.700000002980232,
+            "duration": 11.5,
+            "initiatorType": "script",
+            "transferSize": 1468,
+            "encodedBodySize": 1168,
+            "decodedBodySize": 2523
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/TwoColumnContent.astro_astro_type_script_index_0_lang.DPGAuL8N.js",
+            "entryType": "resource",
+            "startTime": 8.799999997019768,
+            "duration": 14.700000002980232,
+            "initiatorType": "script",
+            "transferSize": 569,
+            "encodedBodySize": 269,
+            "decodedBodySize": 452
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/PageFrame.astro_astro_type_script_index_0_lang.iwTubUja.js",
+            "entryType": "resource",
+            "startTime": 8.799999997019768,
+            "duration": 14.900000005960464,
+            "initiatorType": "script",
+            "transferSize": 557,
+            "encodedBodySize": 257,
+            "decodedBodySize": 392
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/print.ehPL0gv-.css",
+            "entryType": "resource",
+            "startTime": 13.899999991059303,
+            "duration": 9.900000005960464,
+            "initiatorType": "link",
+            "transferSize": 1296,
+            "encodedBodySize": 996,
+            "decodedBodySize": 3318
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/preload-helper.BnKG7j8P.js",
+            "entryType": "resource",
+            "startTime": 32.3999999910593,
+            "duration": 2.9000000059604645,
+            "initiatorType": "script",
+            "transferSize": 1037,
+            "encodedBodySize": 737,
+            "decodedBodySize": 1351
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/starlight-toc.CTCQXEge.js",
+            "entryType": "resource",
+            "startTime": 32.599999994039536,
+            "duration": 2.9000000059604645,
+            "initiatorType": "script",
+            "transferSize": 1251,
+            "encodedBodySize": 951,
+            "decodedBodySize": 1981
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/persistent-toggle.t6KkBAiq.js",
+            "entryType": "resource",
+            "startTime": 65.3999999910593,
+            "duration": 2,
+            "initiatorType": "script",
+            "transferSize": 1005,
+            "encodedBodySize": 705,
+            "decodedBodySize": 2082
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/favicon.svg",
+            "entryType": "resource",
+            "startTime": 83,
+            "duration": 2.0999999940395355,
+            "initiatorType": "other",
+            "transferSize": 559,
+            "encodedBodySize": 259,
+            "decodedBodySize": 331
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/ui-core.BwVUYzUq.js",
+            "entryType": "resource",
+            "startTime": 96.3999999910593,
+            "duration": 2.9000000059604645,
+            "initiatorType": "script",
+            "transferSize": 26419,
+            "encodedBodySize": 26119,
+            "decodedBodySize": 93799
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/InteractiveCell.DoOzatBM.js",
+            "entryType": "resource",
+            "startTime": 149.79999999701977,
+            "duration": 3.4000000059604645,
+            "initiatorType": "script",
+            "transferSize": 16684,
+            "encodedBodySize": 16384,
+            "decodedBodySize": 50227
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/client.BJAMOzhD.js",
+            "entryType": "resource",
+            "startTime": 149.8999999910593,
+            "duration": 3.2000000029802322,
+            "initiatorType": "script",
+            "transferSize": 1114,
+            "encodedBodySize": 814,
+            "decodedBodySize": 1412
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/preact.Bl7PEaKa.js",
+            "entryType": "resource",
+            "startTime": 153.79999999701977,
+            "duration": 2.5,
+            "initiatorType": "script",
+            "transferSize": 4713,
+            "encodedBodySize": 4413,
+            "decodedBodySize": 10470
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/output-limits.vkaihnVu.js",
+            "entryType": "resource",
+            "startTime": 154.70000000298023,
+            "duration": 3.7999999970197678,
+            "initiatorType": "script",
+            "transferSize": 3959,
+            "encodedBodySize": 3659,
+            "decodedBodySize": 8969
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/hooks.ClbWuNs9.js",
+            "entryType": "resource",
+            "startTime": 154.70000000298023,
+            "duration": 4,
+            "initiatorType": "script",
+            "transferSize": 1453,
+            "encodedBodySize": 1153,
+            "decodedBodySize": 2677
+          },
+          {
+            "name": "oxiquill:hydrated:features__rich-output__python-rich-outputs",
+            "entryType": "mark",
+            "startTime": 161.8999999910593,
+            "duration": 0
+          },
+          {
+            "name": "oxiquill:worker-start:python",
+            "entryType": "mark",
+            "startTime": 203.70000000298023,
+            "duration": 0
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/python-worker-CZmazRja.js",
+            "entryType": "resource",
+            "startTime": 208.70000000298023,
+            "duration": -1.800000011920929,
+            "initiatorType": "other",
+            "transferSize": 13324,
+            "encodedBodySize": 13024,
+            "decodedBodySize": 47679
+          },
+          {
+            "name": "oxiquill:output-rendered:features__rich-output__python-rich-outputs",
+            "entryType": "mark",
+            "startTime": 11262.5,
+            "duration": 0
+          }
+        ]
+      },
+      "workers": [
+        {
+          "timeOrigin": 1788590409431.2,
+          "entries": [
+            {
+              "name": "oxiquill:worker-ready:python",
+              "entryType": "mark",
+              "startTime": 3.7999999970197678,
+              "duration": 0
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pyodide.mjs",
+              "entryType": "resource",
+              "startTime": 9.900000005960464,
+              "duration": 2,
+              "initiatorType": "fetch",
+              "transferSize": 7456,
+              "encodedBodySize": 7156,
+              "decodedBodySize": 17931
+            },
+            {
+              "name": "oxiquill:initialization:python",
+              "entryType": "measure",
+              "startTime": 15.299999997019768,
+              "duration": 2091.800000011921
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pyodide-lock.json",
+              "entryType": "resource",
+              "startTime": 15.600000008940697,
+              "duration": 6.0999999940395355,
+              "initiatorType": "fetch",
+              "transferSize": 26834,
+              "encodedBodySize": 26534,
+              "decodedBodySize": 114440
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/python_stdlib.zip",
+              "entryType": "resource",
+              "startTime": 16,
+              "duration": 25.100000008940697,
+              "initiatorType": "fetch",
+              "transferSize": 2503474,
+              "encodedBodySize": 2503174,
+              "decodedBodySize": 2545564
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pyodide.asm.wasm",
+              "entryType": "resource",
+              "startTime": 16.200000002980232,
+              "duration": 99.09999999403954,
+              "initiatorType": "fetch",
+              "transferSize": 3546429,
+              "encodedBodySize": 3546129,
+              "decodedBodySize": 9598218
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pyodide.asm.mjs",
+              "entryType": "resource",
+              "startTime": 16.299999997019768,
+              "duration": 13.800000011920929,
+              "initiatorType": "script",
+              "transferSize": 260407,
+              "encodedBodySize": 260107,
+              "decodedBodySize": 1250344
+            },
+            {
+              "name": "oxiquill:display-support:python",
+              "entryType": "measure",
+              "startTime": 2107.2000000029802,
+              "duration": 43.599999994039536
+            },
+            {
+              "name": "oxiquill:packages:features__rich-output__python-rich-outputs",
+              "entryType": "measure",
+              "startTime": 2150.9000000059605,
+              "duration": 1812.2000000029802
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/matplotlib-3.10.8-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 2152.7000000029802,
+              "duration": 300.40000000596046,
+              "initiatorType": "fetch",
+              "transferSize": 6867585,
+              "encodedBodySize": 6867285,
+              "decodedBodySize": 6982033
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/contourpy-1.3.3-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 2153,
+              "duration": 13.600000008940697,
+              "initiatorType": "fetch",
+              "transferSize": 117420,
+              "encodedBodySize": 117120,
+              "decodedBodySize": 118875
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/numpy-2.4.6-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 2153.2999999970198,
+              "duration": 105.5,
+              "initiatorType": "fetch",
+              "transferSize": 2882982,
+              "encodedBodySize": 2882682,
+              "decodedBodySize": 2918760
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/cycler-0.12.1-py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 2153.5,
+              "duration": 10.799999997019768,
+              "initiatorType": "fetch",
+              "transferSize": 8094,
+              "encodedBodySize": 7794,
+              "decodedBodySize": 8321
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/six-1.17.0-py2.py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 2153.7000000029802,
+              "duration": 10.700000002980232,
+              "initiatorType": "fetch",
+              "transferSize": 10940,
+              "encodedBodySize": 10640,
+              "decodedBodySize": 11050
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/fonttools-4.62.1-py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 2153.9000000059605,
+              "duration": 50.5,
+              "initiatorType": "fetch",
+              "transferSize": 1124839,
+              "encodedBodySize": 1124539,
+              "decodedBodySize": 1152647
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/kiwisolver-1.5.0-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 2153.9000000059605,
+              "duration": 17.399999991059303,
+              "initiatorType": "fetch",
+              "transferSize": 36187,
+              "encodedBodySize": 35887,
+              "decodedBodySize": 36616
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/packaging-26.1-py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 2154.1000000089407,
+              "duration": 21.5,
+              "initiatorType": "fetch",
+              "transferSize": 94497,
+              "encodedBodySize": 94197,
+              "decodedBodySize": 95852
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pillow-12.2.0-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 2154.4000000059605,
+              "duration": 52,
+              "initiatorType": "fetch",
+              "transferSize": 1029476,
+              "encodedBodySize": 1029176,
+              "decodedBodySize": 1037807
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pyparsing-3.3.2-py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 2155.2000000029802,
+              "duration": 26.799999997019768,
+              "initiatorType": "fetch",
+              "transferSize": 121460,
+              "encodedBodySize": 121160,
+              "decodedBodySize": 122781
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/python_dateutil-2.9.0.post0-py2.py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 2155.4000000059605,
+              "duration": 32.29999999701977,
+              "initiatorType": "fetch",
+              "transferSize": 228538,
+              "encodedBodySize": 228238,
+              "decodedBodySize": 229892
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pytz-2026.1.post1-py2.py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 2155.9000000059605,
+              "duration": 44.20000000298023,
+              "initiatorType": "fetch",
+              "transferSize": 377948,
+              "encodedBodySize": 377648,
+              "decodedBodySize": 510489
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pandas-3.0.2-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 2156.1000000089407,
+              "duration": 301.5,
+              "initiatorType": "fetch",
+              "transferSize": 4141966,
+              "encodedBodySize": 4141666,
+              "decodedBodySize": 4177814
+            },
+            {
+              "name": "oxiquill:imports:features__rich-output__python-rich-outputs",
+              "entryType": "measure",
+              "startTime": 3963.2000000029802,
+              "duration": 1.2000000029802322
+            },
+            {
+              "name": "oxiquill:display-prepare:features__rich-output__python-rich-outputs",
+              "entryType": "measure",
+              "startTime": 3964.5,
+              "duration": 1598.6000000089407
+            },
+            {
+              "name": "oxiquill:execution:features__rich-output__python-rich-outputs",
+              "entryType": "measure",
+              "startTime": 5563.4000000059605,
+              "duration": 5087.899999991059
+            },
+            {
+              "name": "oxiquill:display-collect:features__rich-output__python-rich-outputs",
+              "entryType": "measure",
+              "startTime": 10652.90000000596,
+              "duration": 367.20000000298023
+            }
+          ]
+        }
+      ],
+      "observed": {
+        "requests": [
+          {
+            "requestId": 1,
+            "at": 1788590409428.5
+          }
+        ],
+        "responses": [
+          {
+            "requestId": 1,
+            "at": 1788590420499.5,
+            "ok": true
+          }
+        ]
+      }
+    },
+    {
+      "example": "features/rich-output/",
+      "condition": "reload",
+      "run": 4,
+      "triggerMs": 460.70000000298023,
+      "outputMs": 7641.5,
+      "latencyMs": 7641.5,
+      "renderObserverDeltaMs": -2.39990234375,
+      "main": {
+        "timeOrigin": 1788590420568.1,
+        "entries": [
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/index.DANjJwMU.css",
+            "entryType": "resource",
+            "startTime": 50.70000000298023,
+            "duration": 0,
+            "initiatorType": "link",
+            "transferSize": 0,
+            "encodedBodySize": 21609,
+            "decodedBodySize": 105367
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/page.Dwipeu-R.js",
+            "entryType": "resource",
+            "startTime": 50.900000005960464,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 1124,
+            "decodedBodySize": 2486
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/Search.astro_astro_type_script_index_0_lang.DzL-jWp_.js",
+            "entryType": "resource",
+            "startTime": 51.1000000089407,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 945,
+            "decodedBodySize": 1830
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/MobileTableOfContents.astro_astro_type_script_index_0_lang.BcSo_yiZ.js",
+            "entryType": "resource",
+            "startTime": 51.20000000298023,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 364,
+            "decodedBodySize": 622
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/TableOfContents.astro_astro_type_script_index_0_lang.Csloo1VZ.js",
+            "entryType": "resource",
+            "startTime": 51.20000000298023,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 56,
+            "decodedBodySize": 36
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/ec.w36nc.css",
+            "entryType": "resource",
+            "startTime": 51.400000005960464,
+            "duration": 0,
+            "initiatorType": "link",
+            "transferSize": 0,
+            "encodedBodySize": 3946,
+            "decodedBodySize": 18292
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/ec.0vx5m.js",
+            "entryType": "resource",
+            "startTime": 51.70000000298023,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 1168,
+            "decodedBodySize": 2523
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/TwoColumnContent.astro_astro_type_script_index_0_lang.DPGAuL8N.js",
+            "entryType": "resource",
+            "startTime": 51.70000000298023,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 269,
+            "decodedBodySize": 452
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/PageFrame.astro_astro_type_script_index_0_lang.iwTubUja.js",
+            "entryType": "resource",
+            "startTime": 51.900000005960464,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 257,
+            "decodedBodySize": 392
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/print.ehPL0gv-.css",
+            "entryType": "resource",
+            "startTime": 235.6000000089407,
+            "duration": 0,
+            "initiatorType": "link",
+            "transferSize": 0,
+            "encodedBodySize": 996,
+            "decodedBodySize": 3318
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/preload-helper.BnKG7j8P.js",
+            "entryType": "resource",
+            "startTime": 272,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 737,
+            "decodedBodySize": 1351
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/starlight-toc.CTCQXEge.js",
+            "entryType": "resource",
+            "startTime": 305.79999999701977,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 951,
+            "decodedBodySize": 1981
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/persistent-toggle.t6KkBAiq.js",
+            "entryType": "resource",
+            "startTime": 315.1000000089407,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 705,
+            "decodedBodySize": 2082
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/InteractiveCell.DoOzatBM.js",
+            "entryType": "resource",
+            "startTime": 340.1000000089407,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 16384,
+            "decodedBodySize": 50227
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/client.BJAMOzhD.js",
+            "entryType": "resource",
+            "startTime": 340.5,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 814,
+            "decodedBodySize": 1412
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/preact.Bl7PEaKa.js",
+            "entryType": "resource",
+            "startTime": 341.70000000298023,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 4413,
+            "decodedBodySize": 10470
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/output-limits.vkaihnVu.js",
+            "entryType": "resource",
+            "startTime": 341.79999999701977,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 3659,
+            "decodedBodySize": 8969
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/hooks.ClbWuNs9.js",
+            "entryType": "resource",
+            "startTime": 342,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 1153,
+            "decodedBodySize": 2677
+          },
+          {
+            "name": "oxiquill:hydrated:features__rich-output__python-rich-outputs",
+            "entryType": "mark",
+            "startTime": 344.1000000089407,
+            "duration": 0
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/favicon.svg",
+            "entryType": "resource",
+            "startTime": 349.1000000089407,
+            "duration": 3.8999999910593033,
+            "initiatorType": "other",
+            "transferSize": 0,
+            "encodedBodySize": 259,
+            "decodedBodySize": 331
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/ui-core.BwVUYzUq.js",
+            "entryType": "resource",
+            "startTime": 398.20000000298023,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 26119,
+            "decodedBodySize": 93799
+          },
+          {
+            "name": "oxiquill:worker-start:python",
+            "entryType": "mark",
+            "startTime": 547,
+            "duration": 0
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/python-worker-CZmazRja.js",
+            "entryType": "resource",
+            "startTime": 563.7999999970198,
+            "duration": -13.799999997019768,
+            "initiatorType": "other",
+            "transferSize": 0,
+            "encodedBodySize": 13024,
+            "decodedBodySize": 47679
+          },
+          {
+            "name": "oxiquill:output-rendered:features__rich-output__python-rich-outputs",
+            "entryType": "mark",
+            "startTime": 7641.5,
+            "duration": 0
+          }
+        ]
+      },
+      "workers": [
+        {
+          "timeOrigin": 1788590421124.9,
+          "entries": [
+            {
+              "name": "oxiquill:worker-ready:python",
+              "entryType": "mark",
+              "startTime": 14.400000005960464,
+              "duration": 0
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pyodide.mjs",
+              "entryType": "resource",
+              "startTime": 20.200000002980232,
+              "duration": 2.2999999970197678,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 7156,
+              "decodedBodySize": 17931
+            },
+            {
+              "name": "oxiquill:initialization:python",
+              "entryType": "measure",
+              "startTime": 37.900000005960464,
+              "duration": 2027.2000000029802
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pyodide-lock.json",
+              "entryType": "resource",
+              "startTime": 38.80000001192093,
+              "duration": 4.5,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 26534,
+              "decodedBodySize": 114440
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/python_stdlib.zip",
+              "entryType": "resource",
+              "startTime": 40.400000005960464,
+              "duration": 48.79999999701977,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 2503174,
+              "decodedBodySize": 2545564
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pyodide.asm.wasm",
+              "entryType": "resource",
+              "startTime": 44.5,
+              "duration": 194.40000000596046,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 3546129,
+              "decodedBodySize": 9598218
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pyodide.asm.mjs",
+              "entryType": "resource",
+              "startTime": 45.30000001192093,
+              "duration": 27,
+              "initiatorType": "script",
+              "transferSize": 0,
+              "encodedBodySize": 260107,
+              "decodedBodySize": 1250344
+            },
+            {
+              "name": "oxiquill:display-support:python",
+              "entryType": "measure",
+              "startTime": 2065.1000000089407,
+              "duration": 36.599999994039536
+            },
+            {
+              "name": "oxiquill:packages:features__rich-output__python-rich-outputs",
+              "entryType": "measure",
+              "startTime": 2101.9000000059605,
+              "duration": 905.5
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/matplotlib-3.10.8-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 2103.4000000059605,
+              "duration": 406.09999999403954,
+              "initiatorType": "fetch",
+              "transferSize": 6867585,
+              "encodedBodySize": 6867285,
+              "decodedBodySize": 6982033
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/contourpy-1.3.3-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 2103.7000000029802,
+              "duration": 17.100000008940697,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 117120,
+              "decodedBodySize": 118875
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/numpy-2.4.6-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 2103.800000011921,
+              "duration": 80.79999999701977,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 2882682,
+              "decodedBodySize": 2918760
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/cycler-0.12.1-py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 2104,
+              "duration": 14.900000005960464,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 7794,
+              "decodedBodySize": 8321
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/six-1.17.0-py2.py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 2104.2000000029802,
+              "duration": 14.900000005960464,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 10640,
+              "decodedBodySize": 11050
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/fonttools-4.62.1-py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 2104.6000000089407,
+              "duration": 33.70000000298023,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 1124539,
+              "decodedBodySize": 1152647
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/kiwisolver-1.5.0-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 2105.1000000089407,
+              "duration": 16,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 35887,
+              "decodedBodySize": 36616
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/packaging-26.1-py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 2105.4000000059605,
+              "duration": 17.200000002980232,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 94197,
+              "decodedBodySize": 95852
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pillow-12.2.0-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 2106,
+              "duration": 31.400000005960464,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 1029176,
+              "decodedBodySize": 1037807
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pyparsing-3.3.2-py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 2106.7000000029802,
+              "duration": 16.900000005960464,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 121160,
+              "decodedBodySize": 122781
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/python_dateutil-2.9.0.post0-py2.py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 2107.6000000089407,
+              "duration": 18.200000002980232,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 228238,
+              "decodedBodySize": 229892
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pytz-2026.1.post1-py2.py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 2108.1000000089407,
+              "duration": 20.599999994039536,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 377648,
+              "decodedBodySize": 510489
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pandas-3.0.2-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 2108.4000000059605,
+              "duration": 97.09999999403954,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 4141666,
+              "decodedBodySize": 4177814
+            },
+            {
+              "name": "oxiquill:imports:features__rich-output__python-rich-outputs",
+              "entryType": "measure",
+              "startTime": 3007.5,
+              "duration": 0.9000000059604645
+            },
+            {
+              "name": "oxiquill:display-prepare:features__rich-output__python-rich-outputs",
+              "entryType": "measure",
+              "startTime": 3008.4000000059605,
+              "duration": 1035.7000000029802
+            },
+            {
+              "name": "oxiquill:execution:features__rich-output__python-rich-outputs",
+              "entryType": "measure",
+              "startTime": 4044.300000011921,
+              "duration": 2904.3999999910593
+            },
+            {
+              "name": "oxiquill:display-collect:features__rich-output__python-rich-outputs",
+              "entryType": "measure",
+              "startTime": 6950.100000008941,
+              "duration": 129.79999999701977
+            }
+          ]
+        }
+      ],
+      "observed": {
+        "requests": [
+          {
+            "requestId": 1,
+            "at": 1788590421115.4001
+          }
+        ],
+        "responses": [
+          {
+            "requestId": 1,
+            "at": 1788590428212,
+            "ok": true
+          }
+        ]
+      }
+    },
+    {
+      "example": "features/rich-output/",
+      "condition": "repeat",
+      "run": 4,
+      "triggerMs": 10174,
+      "outputMs": 10289.5,
+      "latencyMs": 115.5,
+      "renderObserverDeltaMs": -2.199951171875,
+      "main": {
+        "timeOrigin": 1788590420568.1,
+        "entries": [
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/index.DANjJwMU.css",
+            "entryType": "resource",
+            "startTime": 50.70000000298023,
+            "duration": 0,
+            "initiatorType": "link",
+            "transferSize": 0,
+            "encodedBodySize": 21609,
+            "decodedBodySize": 105367
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/page.Dwipeu-R.js",
+            "entryType": "resource",
+            "startTime": 50.900000005960464,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 1124,
+            "decodedBodySize": 2486
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/Search.astro_astro_type_script_index_0_lang.DzL-jWp_.js",
+            "entryType": "resource",
+            "startTime": 51.1000000089407,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 945,
+            "decodedBodySize": 1830
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/MobileTableOfContents.astro_astro_type_script_index_0_lang.BcSo_yiZ.js",
+            "entryType": "resource",
+            "startTime": 51.20000000298023,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 364,
+            "decodedBodySize": 622
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/TableOfContents.astro_astro_type_script_index_0_lang.Csloo1VZ.js",
+            "entryType": "resource",
+            "startTime": 51.20000000298023,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 56,
+            "decodedBodySize": 36
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/ec.w36nc.css",
+            "entryType": "resource",
+            "startTime": 51.400000005960464,
+            "duration": 0,
+            "initiatorType": "link",
+            "transferSize": 0,
+            "encodedBodySize": 3946,
+            "decodedBodySize": 18292
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/ec.0vx5m.js",
+            "entryType": "resource",
+            "startTime": 51.70000000298023,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 1168,
+            "decodedBodySize": 2523
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/TwoColumnContent.astro_astro_type_script_index_0_lang.DPGAuL8N.js",
+            "entryType": "resource",
+            "startTime": 51.70000000298023,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 269,
+            "decodedBodySize": 452
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/PageFrame.astro_astro_type_script_index_0_lang.iwTubUja.js",
+            "entryType": "resource",
+            "startTime": 51.900000005960464,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 257,
+            "decodedBodySize": 392
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/print.ehPL0gv-.css",
+            "entryType": "resource",
+            "startTime": 235.6000000089407,
+            "duration": 0,
+            "initiatorType": "link",
+            "transferSize": 0,
+            "encodedBodySize": 996,
+            "decodedBodySize": 3318
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/preload-helper.BnKG7j8P.js",
+            "entryType": "resource",
+            "startTime": 272,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 737,
+            "decodedBodySize": 1351
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/starlight-toc.CTCQXEge.js",
+            "entryType": "resource",
+            "startTime": 305.79999999701977,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 951,
+            "decodedBodySize": 1981
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/persistent-toggle.t6KkBAiq.js",
+            "entryType": "resource",
+            "startTime": 315.1000000089407,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 705,
+            "decodedBodySize": 2082
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/InteractiveCell.DoOzatBM.js",
+            "entryType": "resource",
+            "startTime": 340.1000000089407,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 16384,
+            "decodedBodySize": 50227
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/client.BJAMOzhD.js",
+            "entryType": "resource",
+            "startTime": 340.5,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 814,
+            "decodedBodySize": 1412
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/preact.Bl7PEaKa.js",
+            "entryType": "resource",
+            "startTime": 341.70000000298023,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 4413,
+            "decodedBodySize": 10470
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/output-limits.vkaihnVu.js",
+            "entryType": "resource",
+            "startTime": 341.79999999701977,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 3659,
+            "decodedBodySize": 8969
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/hooks.ClbWuNs9.js",
+            "entryType": "resource",
+            "startTime": 342,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 1153,
+            "decodedBodySize": 2677
+          },
+          {
+            "name": "oxiquill:hydrated:features__rich-output__python-rich-outputs",
+            "entryType": "mark",
+            "startTime": 344.1000000089407,
+            "duration": 0
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/favicon.svg",
+            "entryType": "resource",
+            "startTime": 349.1000000089407,
+            "duration": 3.8999999910593033,
+            "initiatorType": "other",
+            "transferSize": 0,
+            "encodedBodySize": 259,
+            "decodedBodySize": 331
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/ui-core.BwVUYzUq.js",
+            "entryType": "resource",
+            "startTime": 398.20000000298023,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 26119,
+            "decodedBodySize": 93799
+          },
+          {
+            "name": "oxiquill:worker-start:python",
+            "entryType": "mark",
+            "startTime": 547,
+            "duration": 0
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/python-worker-CZmazRja.js",
+            "entryType": "resource",
+            "startTime": 563.7999999970198,
+            "duration": -13.799999997019768,
+            "initiatorType": "other",
+            "transferSize": 0,
+            "encodedBodySize": 13024,
+            "decodedBodySize": 47679
+          },
+          {
+            "name": "oxiquill:output-rendered:features__rich-output__python-rich-outputs",
+            "entryType": "mark",
+            "startTime": 10289.5,
+            "duration": 0
+          }
+        ]
+      },
+      "workers": [
+        {
+          "timeOrigin": 1788590421124.9,
+          "entries": [
+            {
+              "name": "oxiquill:worker-ready:python",
+              "entryType": "mark",
+              "startTime": 14.400000005960464,
+              "duration": 0
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pyodide.mjs",
+              "entryType": "resource",
+              "startTime": 20.200000002980232,
+              "duration": 2.2999999970197678,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 7156,
+              "decodedBodySize": 17931
+            },
+            {
+              "name": "oxiquill:initialization:python",
+              "entryType": "measure",
+              "startTime": 37.900000005960464,
+              "duration": 2027.2000000029802
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pyodide-lock.json",
+              "entryType": "resource",
+              "startTime": 38.80000001192093,
+              "duration": 4.5,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 26534,
+              "decodedBodySize": 114440
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/python_stdlib.zip",
+              "entryType": "resource",
+              "startTime": 40.400000005960464,
+              "duration": 48.79999999701977,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 2503174,
+              "decodedBodySize": 2545564
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pyodide.asm.wasm",
+              "entryType": "resource",
+              "startTime": 44.5,
+              "duration": 194.40000000596046,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 3546129,
+              "decodedBodySize": 9598218
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pyodide.asm.mjs",
+              "entryType": "resource",
+              "startTime": 45.30000001192093,
+              "duration": 27,
+              "initiatorType": "script",
+              "transferSize": 0,
+              "encodedBodySize": 260107,
+              "decodedBodySize": 1250344
+            },
+            {
+              "name": "oxiquill:display-support:python",
+              "entryType": "measure",
+              "startTime": 2065.1000000089407,
+              "duration": 36.599999994039536
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/matplotlib-3.10.8-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 2103.4000000059605,
+              "duration": 406.09999999403954,
+              "initiatorType": "fetch",
+              "transferSize": 6867585,
+              "encodedBodySize": 6867285,
+              "decodedBodySize": 6982033
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/contourpy-1.3.3-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 2103.7000000029802,
+              "duration": 17.100000008940697,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 117120,
+              "decodedBodySize": 118875
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/numpy-2.4.6-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 2103.800000011921,
+              "duration": 80.79999999701977,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 2882682,
+              "decodedBodySize": 2918760
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/cycler-0.12.1-py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 2104,
+              "duration": 14.900000005960464,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 7794,
+              "decodedBodySize": 8321
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/six-1.17.0-py2.py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 2104.2000000029802,
+              "duration": 14.900000005960464,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 10640,
+              "decodedBodySize": 11050
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/fonttools-4.62.1-py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 2104.6000000089407,
+              "duration": 33.70000000298023,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 1124539,
+              "decodedBodySize": 1152647
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/kiwisolver-1.5.0-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 2105.1000000089407,
+              "duration": 16,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 35887,
+              "decodedBodySize": 36616
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/packaging-26.1-py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 2105.4000000059605,
+              "duration": 17.200000002980232,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 94197,
+              "decodedBodySize": 95852
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pillow-12.2.0-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 2106,
+              "duration": 31.400000005960464,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 1029176,
+              "decodedBodySize": 1037807
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pyparsing-3.3.2-py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 2106.7000000029802,
+              "duration": 16.900000005960464,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 121160,
+              "decodedBodySize": 122781
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/python_dateutil-2.9.0.post0-py2.py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 2107.6000000089407,
+              "duration": 18.200000002980232,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 228238,
+              "decodedBodySize": 229892
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pytz-2026.1.post1-py2.py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 2108.1000000089407,
+              "duration": 20.599999994039536,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 377648,
+              "decodedBodySize": 510489
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pandas-3.0.2-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 2108.4000000059605,
+              "duration": 97.09999999403954,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 4141666,
+              "decodedBodySize": 4177814
+            },
+            {
+              "name": "oxiquill:packages:features__rich-output__python-rich-outputs",
+              "entryType": "measure",
+              "startTime": 9650.70000000298,
+              "duration": 0.10000000894069672
+            },
+            {
+              "name": "oxiquill:imports:features__rich-output__python-rich-outputs",
+              "entryType": "measure",
+              "startTime": 9650.800000011921,
+              "duration": 0.8999999910593033
+            },
+            {
+              "name": "oxiquill:display-prepare:features__rich-output__python-rich-outputs",
+              "entryType": "measure",
+              "startTime": 9651.70000000298,
+              "duration": 0.5
+            },
+            {
+              "name": "oxiquill:execution:features__rich-output__python-rich-outputs",
+              "entryType": "measure",
+              "startTime": 9652.300000011921,
+              "duration": 12.5
+            },
+            {
+              "name": "oxiquill:display-collect:features__rich-output__python-rich-outputs",
+              "entryType": "measure",
+              "startTime": 9665.5,
+              "duration": 65.30000001192093
+            }
+          ]
+        }
+      ],
+      "observed": {
+        "requests": [
+          {
+            "requestId": 1,
+            "at": 1788590421115.4001
+          },
+          {
+            "requestId": 2,
+            "at": 1788590430775.3
+          }
+        ],
+        "responses": [
+          {
+            "requestId": 1,
+            "at": 1788590428212,
+            "ok": true
+          },
+          {
+            "requestId": 2,
+            "at": 1788590430859.8,
+            "ok": true
+          }
+        ]
+      }
+    },
+    {
+      "example": "features/rich-output/",
+      "condition": "fresh",
+      "run": 5,
+      "triggerMs": 2462,
+      "outputMs": 8483.29999999702,
+      "latencyMs": 8483.29999999702,
+      "renderObserverDeltaMs": -2.699951171875,
+      "main": {
+        "timeOrigin": 1788590430943.9,
+        "entries": [
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/index.DANjJwMU.css",
+            "entryType": "resource",
+            "startTime": 5.9000000059604645,
+            "duration": 2.3999999910593033,
+            "initiatorType": "link",
+            "transferSize": 21909,
+            "encodedBodySize": 21609,
+            "decodedBodySize": 105367
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/page.Dwipeu-R.js",
+            "entryType": "resource",
+            "startTime": 6,
+            "duration": 7.799999997019768,
+            "initiatorType": "script",
+            "transferSize": 1424,
+            "encodedBodySize": 1124,
+            "decodedBodySize": 2486
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/MobileTableOfContents.astro_astro_type_script_index_0_lang.BcSo_yiZ.js",
+            "entryType": "resource",
+            "startTime": 6.0999999940395355,
+            "duration": 8,
+            "initiatorType": "script",
+            "transferSize": 664,
+            "encodedBodySize": 364,
+            "decodedBodySize": 622
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/Search.astro_astro_type_script_index_0_lang.DzL-jWp_.js",
+            "entryType": "resource",
+            "startTime": 6.0999999940395355,
+            "duration": 7.800000011920929,
+            "initiatorType": "script",
+            "transferSize": 1245,
+            "encodedBodySize": 945,
+            "decodedBodySize": 1830
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/TableOfContents.astro_astro_type_script_index_0_lang.Csloo1VZ.js",
+            "entryType": "resource",
+            "startTime": 6.0999999940395355,
+            "duration": 8.100000008940697,
+            "initiatorType": "script",
+            "transferSize": 356,
+            "encodedBodySize": 56,
+            "decodedBodySize": 36
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/ec.w36nc.css",
+            "entryType": "resource",
+            "startTime": 6.200000002980232,
+            "duration": 7.299999997019768,
+            "initiatorType": "link",
+            "transferSize": 4246,
+            "encodedBodySize": 3946,
+            "decodedBodySize": 18292
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/ec.0vx5m.js",
+            "entryType": "resource",
+            "startTime": 6.200000002980232,
+            "duration": 8.099999994039536,
+            "initiatorType": "script",
+            "transferSize": 1468,
+            "encodedBodySize": 1168,
+            "decodedBodySize": 2523
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/TwoColumnContent.astro_astro_type_script_index_0_lang.DPGAuL8N.js",
+            "entryType": "resource",
+            "startTime": 6.200000002980232,
+            "duration": 11.099999994039536,
+            "initiatorType": "script",
+            "transferSize": 569,
+            "encodedBodySize": 269,
+            "decodedBodySize": 452
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/PageFrame.astro_astro_type_script_index_0_lang.iwTubUja.js",
+            "entryType": "resource",
+            "startTime": 6.200000002980232,
+            "duration": 11.299999997019768,
+            "initiatorType": "script",
+            "transferSize": 557,
+            "encodedBodySize": 257,
+            "decodedBodySize": 392
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/print.ehPL0gv-.css",
+            "entryType": "resource",
+            "startTime": 11.099999994039536,
+            "duration": 6.5,
+            "initiatorType": "link",
+            "transferSize": 1296,
+            "encodedBodySize": 996,
+            "decodedBodySize": 3318
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/starlight-toc.CTCQXEge.js",
+            "entryType": "resource",
+            "startTime": 41.099999994039536,
+            "duration": 2.7000000029802322,
+            "initiatorType": "script",
+            "transferSize": 1251,
+            "encodedBodySize": 951,
+            "decodedBodySize": 1981
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/preload-helper.BnKG7j8P.js",
+            "entryType": "resource",
+            "startTime": 41.20000000298023,
+            "duration": 2.7999999970197678,
+            "initiatorType": "script",
+            "transferSize": 1037,
+            "encodedBodySize": 737,
+            "decodedBodySize": 1351
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/persistent-toggle.t6KkBAiq.js",
+            "entryType": "resource",
+            "startTime": 59.20000000298023,
+            "duration": 2.0999999940395355,
+            "initiatorType": "script",
+            "transferSize": 1005,
+            "encodedBodySize": 705,
+            "decodedBodySize": 2082
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/favicon.svg",
+            "entryType": "resource",
+            "startTime": 74.20000000298023,
+            "duration": 1.5999999940395355,
+            "initiatorType": "other",
+            "transferSize": 559,
+            "encodedBodySize": 259,
+            "decodedBodySize": 331
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/ui-core.BwVUYzUq.js",
+            "entryType": "resource",
+            "startTime": 2382.5,
+            "duration": 2.2999999970197678,
+            "initiatorType": "script",
+            "transferSize": 26419,
+            "encodedBodySize": 26119,
+            "decodedBodySize": 93799
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/InteractiveCell.DoOzatBM.js",
+            "entryType": "resource",
+            "startTime": 2446,
+            "duration": 3.2999999970197678,
+            "initiatorType": "script",
+            "transferSize": 16684,
+            "encodedBodySize": 16384,
+            "decodedBodySize": 50227
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/client.BJAMOzhD.js",
+            "entryType": "resource",
+            "startTime": 2446.0999999940395,
+            "duration": 3.2000000029802322,
+            "initiatorType": "script",
+            "transferSize": 1114,
+            "encodedBodySize": 814,
+            "decodedBodySize": 1412
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/preact.Bl7PEaKa.js",
+            "entryType": "resource",
+            "startTime": 2449.9000000059605,
+            "duration": 2.0999999940395355,
+            "initiatorType": "script",
+            "transferSize": 4713,
+            "encodedBodySize": 4413,
+            "decodedBodySize": 10470
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/output-limits.vkaihnVu.js",
+            "entryType": "resource",
+            "startTime": 2451,
+            "duration": 2.7999999970197678,
+            "initiatorType": "script",
+            "transferSize": 3959,
+            "encodedBodySize": 3659,
+            "decodedBodySize": 8969
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/hooks.ClbWuNs9.js",
+            "entryType": "resource",
+            "startTime": 2451,
+            "duration": 3,
+            "initiatorType": "script",
+            "transferSize": 1453,
+            "encodedBodySize": 1153,
+            "decodedBodySize": 2677
+          },
+          {
+            "name": "oxiquill:hydrated:features__rich-output__python-rich-outputs",
+            "entryType": "mark",
+            "startTime": 2457,
+            "duration": 0
+          },
+          {
+            "name": "oxiquill:worker-start:python",
+            "entryType": "mark",
+            "startTime": 2499.2000000029802,
+            "duration": 0
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/python-worker-CZmazRja.js",
+            "entryType": "resource",
+            "startTime": 2503.5,
+            "duration": -1.4000000059604645,
+            "initiatorType": "other",
+            "transferSize": 13324,
+            "encodedBodySize": 13024,
+            "decodedBodySize": 47679
+          },
+          {
+            "name": "oxiquill:output-rendered:features__rich-output__python-rich-outputs",
+            "entryType": "mark",
+            "startTime": 8483.29999999702,
+            "duration": 0
+          }
+        ]
+      },
+      "workers": [
+        {
+          "timeOrigin": 1788590433445.4,
+          "entries": [
+            {
+              "name": "oxiquill:worker-ready:python",
+              "entryType": "mark",
+              "startTime": 3.4000000059604645,
+              "duration": 0
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pyodide.mjs",
+              "entryType": "resource",
+              "startTime": 10.700000002980232,
+              "duration": 1.7999999970197678,
+              "initiatorType": "fetch",
+              "transferSize": 7456,
+              "encodedBodySize": 7156,
+              "decodedBodySize": 17931
+            },
+            {
+              "name": "oxiquill:initialization:python",
+              "entryType": "measure",
+              "startTime": 15.5,
+              "duration": 1308.4000000059605
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pyodide-lock.json",
+              "entryType": "resource",
+              "startTime": 15.900000005960464,
+              "duration": 3,
+              "initiatorType": "fetch",
+              "transferSize": 26834,
+              "encodedBodySize": 26534,
+              "decodedBodySize": 114440
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/python_stdlib.zip",
+              "entryType": "resource",
+              "startTime": 16.200000002980232,
+              "duration": 23.600000008940697,
+              "initiatorType": "fetch",
+              "transferSize": 2503474,
+              "encodedBodySize": 2503174,
+              "decodedBodySize": 2545564
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pyodide.asm.wasm",
+              "entryType": "resource",
+              "startTime": 16.400000005960464,
+              "duration": 104.40000000596046,
+              "initiatorType": "fetch",
+              "transferSize": 3546429,
+              "encodedBodySize": 3546129,
+              "decodedBodySize": 9598218
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pyodide.asm.mjs",
+              "entryType": "resource",
+              "startTime": 16.5,
+              "duration": 13,
+              "initiatorType": "script",
+              "transferSize": 260407,
+              "encodedBodySize": 260107,
+              "decodedBodySize": 1250344
+            },
+            {
+              "name": "oxiquill:display-support:python",
+              "entryType": "measure",
+              "startTime": 1323.9000000059605,
+              "duration": 32.599999994039536
+            },
+            {
+              "name": "oxiquill:packages:features__rich-output__python-rich-outputs",
+              "entryType": "measure",
+              "startTime": 1356.7000000029802,
+              "duration": 1197.7000000029802
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/matplotlib-3.10.8-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 1358.1000000089407,
+              "duration": 286.79999999701977,
+              "initiatorType": "fetch",
+              "transferSize": 6867585,
+              "encodedBodySize": 6867285,
+              "decodedBodySize": 6982033
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/contourpy-1.3.3-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 1358.4000000059605,
+              "duration": 11.400000005960464,
+              "initiatorType": "fetch",
+              "transferSize": 117420,
+              "encodedBodySize": 117120,
+              "decodedBodySize": 118875
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/numpy-2.4.6-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 1359.9000000059605,
+              "duration": 81,
+              "initiatorType": "fetch",
+              "transferSize": 2882982,
+              "encodedBodySize": 2882682,
+              "decodedBodySize": 2918760
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/cycler-0.12.1-py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 1360.300000011921,
+              "duration": 8.399999991059303,
+              "initiatorType": "fetch",
+              "transferSize": 8094,
+              "encodedBodySize": 7794,
+              "decodedBodySize": 8321
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/six-1.17.0-py2.py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 1360.5,
+              "duration": 8.300000011920929,
+              "initiatorType": "fetch",
+              "transferSize": 10940,
+              "encodedBodySize": 10640,
+              "decodedBodySize": 11050
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/fonttools-4.62.1-py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 1360.6000000089407,
+              "duration": 38.79999999701977,
+              "initiatorType": "fetch",
+              "transferSize": 1124839,
+              "encodedBodySize": 1124539,
+              "decodedBodySize": 1152647
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/kiwisolver-1.5.0-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 1360.7000000029802,
+              "duration": 13.5,
+              "initiatorType": "fetch",
+              "transferSize": 36187,
+              "encodedBodySize": 35887,
+              "decodedBodySize": 36616
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/packaging-26.1-py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 1361,
+              "duration": 14.900000005960464,
+              "initiatorType": "fetch",
+              "transferSize": 94497,
+              "encodedBodySize": 94197,
+              "decodedBodySize": 95852
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pillow-12.2.0-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 1361.300000011921,
+              "duration": 41.099999994039536,
+              "initiatorType": "fetch",
+              "transferSize": 1029476,
+              "encodedBodySize": 1029176,
+              "decodedBodySize": 1037807
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pyparsing-3.3.2-py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 1361.4000000059605,
+              "duration": 20,
+              "initiatorType": "fetch",
+              "transferSize": 121460,
+              "encodedBodySize": 121160,
+              "decodedBodySize": 122781
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/python_dateutil-2.9.0.post0-py2.py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 1361.7000000029802,
+              "duration": 25.200000002980232,
+              "initiatorType": "fetch",
+              "transferSize": 228538,
+              "encodedBodySize": 228238,
+              "decodedBodySize": 229892
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pytz-2026.1.post1-py2.py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 1361.9000000059605,
+              "duration": 33.400000005960464,
+              "initiatorType": "fetch",
+              "transferSize": 377948,
+              "encodedBodySize": 377648,
+              "decodedBodySize": 510489
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pandas-3.0.2-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 1362.2000000029802,
+              "duration": 171.90000000596046,
+              "initiatorType": "fetch",
+              "transferSize": 4141966,
+              "encodedBodySize": 4141666,
+              "decodedBodySize": 4177814
+            },
+            {
+              "name": "oxiquill:imports:features__rich-output__python-rich-outputs",
+              "entryType": "measure",
+              "startTime": 2554.4000000059605,
+              "duration": 1
+            },
+            {
+              "name": "oxiquill:display-prepare:features__rich-output__python-rich-outputs",
+              "entryType": "measure",
+              "startTime": 2555.5,
+              "duration": 1043.7000000029802
+            },
+            {
+              "name": "oxiquill:execution:features__rich-output__python-rich-outputs",
+              "entryType": "measure",
+              "startTime": 3599.4000000059605,
+              "duration": 2242.2999999970198
+            },
+            {
+              "name": "oxiquill:display-collect:features__rich-output__python-rich-outputs",
+              "entryType": "measure",
+              "startTime": 5842.5,
+              "duration": 124.90000000596046
+            }
+          ]
+        }
+      ],
+      "observed": {
+        "requests": [
+          {
+            "requestId": 1,
+            "at": 1788590433443.2
+          }
+        ],
+        "responses": [
+          {
+            "requestId": 1,
+            "at": 1788590439429.9,
+            "ok": true
+          }
+        ]
+      }
+    },
+    {
+      "example": "features/rich-output/",
+      "condition": "reload",
+      "run": 5,
+      "triggerMs": 116.20000000298023,
+      "outputMs": 5944.20000000298,
+      "latencyMs": 5944.20000000298,
+      "renderObserverDeltaMs": -3.10009765625,
+      "main": {
+        "timeOrigin": 1788590439457.7,
+        "entries": [
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/index.DANjJwMU.css",
+            "entryType": "resource",
+            "startTime": 14.900000005960464,
+            "duration": 0,
+            "initiatorType": "link",
+            "transferSize": 0,
+            "encodedBodySize": 21609,
+            "decodedBodySize": 105367
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/page.Dwipeu-R.js",
+            "entryType": "resource",
+            "startTime": 15,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 1124,
+            "decodedBodySize": 2486
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/Search.astro_astro_type_script_index_0_lang.DzL-jWp_.js",
+            "entryType": "resource",
+            "startTime": 15,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 945,
+            "decodedBodySize": 1830
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/MobileTableOfContents.astro_astro_type_script_index_0_lang.BcSo_yiZ.js",
+            "entryType": "resource",
+            "startTime": 15.100000008940697,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 364,
+            "decodedBodySize": 622
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/TableOfContents.astro_astro_type_script_index_0_lang.Csloo1VZ.js",
+            "entryType": "resource",
+            "startTime": 15.100000008940697,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 56,
+            "decodedBodySize": 36
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/ec.w36nc.css",
+            "entryType": "resource",
+            "startTime": 15.100000008940697,
+            "duration": 0,
+            "initiatorType": "link",
+            "transferSize": 0,
+            "encodedBodySize": 3946,
+            "decodedBodySize": 18292
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/ec.0vx5m.js",
+            "entryType": "resource",
+            "startTime": 15.100000008940697,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 1168,
+            "decodedBodySize": 2523
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/TwoColumnContent.astro_astro_type_script_index_0_lang.DPGAuL8N.js",
+            "entryType": "resource",
+            "startTime": 15.200000002980232,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 269,
+            "decodedBodySize": 452
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/PageFrame.astro_astro_type_script_index_0_lang.iwTubUja.js",
+            "entryType": "resource",
+            "startTime": 15.299999997019768,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 257,
+            "decodedBodySize": 392
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/print.ehPL0gv-.css",
+            "entryType": "resource",
+            "startTime": 18.900000005960464,
+            "duration": 0,
+            "initiatorType": "link",
+            "transferSize": 0,
+            "encodedBodySize": 996,
+            "decodedBodySize": 3318
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/preload-helper.BnKG7j8P.js",
+            "entryType": "resource",
+            "startTime": 24.799999997019768,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 737,
+            "decodedBodySize": 1351
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/starlight-toc.CTCQXEge.js",
+            "entryType": "resource",
+            "startTime": 25.100000008940697,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 951,
+            "decodedBodySize": 1981
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/persistent-toggle.t6KkBAiq.js",
+            "entryType": "resource",
+            "startTime": 25.200000002980232,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 705,
+            "decodedBodySize": 2082
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/InteractiveCell.DoOzatBM.js",
+            "entryType": "resource",
+            "startTime": 52.5,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 16384,
+            "decodedBodySize": 50227
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/client.BJAMOzhD.js",
+            "entryType": "resource",
+            "startTime": 52.6000000089407,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 814,
+            "decodedBodySize": 1412
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/preact.Bl7PEaKa.js",
+            "entryType": "resource",
+            "startTime": 53.29999999701977,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 4413,
+            "decodedBodySize": 10470
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/output-limits.vkaihnVu.js",
+            "entryType": "resource",
+            "startTime": 53.29999999701977,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 3659,
+            "decodedBodySize": 8969
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/hooks.ClbWuNs9.js",
+            "entryType": "resource",
+            "startTime": 53.400000005960464,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 1153,
+            "decodedBodySize": 2677
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/favicon.svg",
+            "entryType": "resource",
+            "startTime": 53.6000000089407,
+            "duration": 1.699999988079071,
+            "initiatorType": "other",
+            "transferSize": 0,
+            "encodedBodySize": 259,
+            "decodedBodySize": 331
+          },
+          {
+            "name": "oxiquill:hydrated:features__rich-output__python-rich-outputs",
+            "entryType": "mark",
+            "startTime": 54.6000000089407,
+            "duration": 0
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/ui-core.BwVUYzUq.js",
+            "entryType": "resource",
+            "startTime": 74,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 26119,
+            "decodedBodySize": 93799
+          },
+          {
+            "name": "oxiquill:worker-start:python",
+            "entryType": "mark",
+            "startTime": 150.40000000596046,
+            "duration": 0
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/python-worker-CZmazRja.js",
+            "entryType": "resource",
+            "startTime": 153.6000000089407,
+            "duration": -1.4000000059604645,
+            "initiatorType": "other",
+            "transferSize": 0,
+            "encodedBodySize": 13024,
+            "decodedBodySize": 47679
+          },
+          {
+            "name": "oxiquill:output-rendered:features__rich-output__python-rich-outputs",
+            "entryType": "mark",
+            "startTime": 5944.20000000298,
+            "duration": 0
+          }
+        ]
+      },
+      "workers": [
+        {
+          "timeOrigin": 1788590439609.6,
+          "entries": [
+            {
+              "name": "oxiquill:worker-ready:python",
+              "entryType": "mark",
+              "startTime": 3,
+              "duration": 0
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pyodide.mjs",
+              "entryType": "resource",
+              "startTime": 12.900000005960464,
+              "duration": 1.2999999970197678,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 7156,
+              "decodedBodySize": 17931
+            },
+            {
+              "name": "oxiquill:initialization:python",
+              "entryType": "measure",
+              "startTime": 18.400000005960464,
+              "duration": 1308.2000000029802
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pyodide-lock.json",
+              "entryType": "resource",
+              "startTime": 18.700000002980232,
+              "duration": 1.5,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 26534,
+              "decodedBodySize": 114440
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/python_stdlib.zip",
+              "entryType": "resource",
+              "startTime": 19.100000008940697,
+              "duration": 16.5,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 2503174,
+              "decodedBodySize": 2545564
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pyodide.asm.wasm",
+              "entryType": "resource",
+              "startTime": 19.299999997019768,
+              "duration": 88.30000001192093,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 3546129,
+              "decodedBodySize": 9598218
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pyodide.asm.mjs",
+              "entryType": "resource",
+              "startTime": 19.5,
+              "duration": 9.5,
+              "initiatorType": "script",
+              "transferSize": 0,
+              "encodedBodySize": 260107,
+              "decodedBodySize": 1250344
+            },
+            {
+              "name": "oxiquill:display-support:python",
+              "entryType": "measure",
+              "startTime": 1326.7000000029802,
+              "duration": 34.900000005960464
+            },
+            {
+              "name": "oxiquill:packages:features__rich-output__python-rich-outputs",
+              "entryType": "measure",
+              "startTime": 1361.7000000029802,
+              "duration": 1031.5999999940395
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/matplotlib-3.10.8-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 1363.2000000029802,
+              "duration": 539.4000000059605,
+              "initiatorType": "fetch",
+              "transferSize": 6867585,
+              "encodedBodySize": 6867285,
+              "decodedBodySize": 6982033
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/contourpy-1.3.3-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 1363.2999999970198,
+              "duration": 195.30000001192093,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 117120,
+              "decodedBodySize": 118875
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/numpy-2.4.6-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 1363.5,
+              "duration": 253.1000000089407,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 2882682,
+              "decodedBodySize": 2918760
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/cycler-0.12.1-py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 1363.6000000089407,
+              "duration": 188,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 7794,
+              "decodedBodySize": 8321
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/six-1.17.0-py2.py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 1363.7999999970198,
+              "duration": 188,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 10640,
+              "decodedBodySize": 11050
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/kiwisolver-1.5.0-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 1363.9000000059605,
+              "duration": 194.59999999403954,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 35887,
+              "decodedBodySize": 36616
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/fonttools-4.62.1-py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 1363.9000000059605,
+              "duration": 210.8999999910593,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 1124539,
+              "decodedBodySize": 1152647
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/packaging-26.1-py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 1364.1000000089407,
+              "duration": 195.69999998807907,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 94197,
+              "decodedBodySize": 95852
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pillow-12.2.0-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 1365.2000000029802,
+              "duration": 208.29999999701977,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 1029176,
+              "decodedBodySize": 1037807
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pyparsing-3.3.2-py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 1365.2999999970198,
+              "duration": 195.30000001192093,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 121160,
+              "decodedBodySize": 122781
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/python_dateutil-2.9.0.post0-py2.py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 1365.5,
+              "duration": 197.29999999701977,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 228238,
+              "decodedBodySize": 229892
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pytz-2026.1.post1-py2.py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 1365.6000000089407,
+              "duration": 199.69999998807907,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 377648,
+              "decodedBodySize": 510489
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pandas-3.0.2-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 1365.9000000059605,
+              "duration": 268.79999999701977,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 4141666,
+              "decodedBodySize": 4177814
+            },
+            {
+              "name": "oxiquill:imports:features__rich-output__python-rich-outputs",
+              "entryType": "measure",
+              "startTime": 2393.2999999970198,
+              "duration": 0.9000000059604645
+            },
+            {
+              "name": "oxiquill:display-prepare:features__rich-output__python-rich-outputs",
+              "entryType": "measure",
+              "startTime": 2394.2999999970198,
+              "duration": 1023.4000000059605
+            },
+            {
+              "name": "oxiquill:execution:features__rich-output__python-rich-outputs",
+              "entryType": "measure",
+              "startTime": 3418,
+              "duration": 2245
+            },
+            {
+              "name": "oxiquill:display-collect:features__rich-output__python-rich-outputs",
+              "entryType": "measure",
+              "startTime": 5663.9000000059605,
+              "duration": 123.59999999403954
+            }
+          ]
+        }
+      ],
+      "observed": {
+        "requests": [
+          {
+            "requestId": 1,
+            "at": 1788590439608.3
+          }
+        ],
+        "responses": [
+          {
+            "requestId": 1,
+            "at": 1788590445405,
+            "ok": true
+          }
+        ]
+      }
+    },
+    {
+      "example": "features/rich-output/",
+      "condition": "repeat",
+      "run": 5,
+      "triggerMs": 6000.70000000298,
+      "outputMs": 6118.4000000059605,
+      "latencyMs": 117.70000000298023,
+      "renderObserverDeltaMs": -2.2001953125,
+      "main": {
+        "timeOrigin": 1788590439457.7,
+        "entries": [
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/index.DANjJwMU.css",
+            "entryType": "resource",
+            "startTime": 14.900000005960464,
+            "duration": 0,
+            "initiatorType": "link",
+            "transferSize": 0,
+            "encodedBodySize": 21609,
+            "decodedBodySize": 105367
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/page.Dwipeu-R.js",
+            "entryType": "resource",
+            "startTime": 15,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 1124,
+            "decodedBodySize": 2486
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/Search.astro_astro_type_script_index_0_lang.DzL-jWp_.js",
+            "entryType": "resource",
+            "startTime": 15,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 945,
+            "decodedBodySize": 1830
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/MobileTableOfContents.astro_astro_type_script_index_0_lang.BcSo_yiZ.js",
+            "entryType": "resource",
+            "startTime": 15.100000008940697,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 364,
+            "decodedBodySize": 622
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/TableOfContents.astro_astro_type_script_index_0_lang.Csloo1VZ.js",
+            "entryType": "resource",
+            "startTime": 15.100000008940697,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 56,
+            "decodedBodySize": 36
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/ec.w36nc.css",
+            "entryType": "resource",
+            "startTime": 15.100000008940697,
+            "duration": 0,
+            "initiatorType": "link",
+            "transferSize": 0,
+            "encodedBodySize": 3946,
+            "decodedBodySize": 18292
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/ec.0vx5m.js",
+            "entryType": "resource",
+            "startTime": 15.100000008940697,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 1168,
+            "decodedBodySize": 2523
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/TwoColumnContent.astro_astro_type_script_index_0_lang.DPGAuL8N.js",
+            "entryType": "resource",
+            "startTime": 15.200000002980232,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 269,
+            "decodedBodySize": 452
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/PageFrame.astro_astro_type_script_index_0_lang.iwTubUja.js",
+            "entryType": "resource",
+            "startTime": 15.299999997019768,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 257,
+            "decodedBodySize": 392
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/print.ehPL0gv-.css",
+            "entryType": "resource",
+            "startTime": 18.900000005960464,
+            "duration": 0,
+            "initiatorType": "link",
+            "transferSize": 0,
+            "encodedBodySize": 996,
+            "decodedBodySize": 3318
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/preload-helper.BnKG7j8P.js",
+            "entryType": "resource",
+            "startTime": 24.799999997019768,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 737,
+            "decodedBodySize": 1351
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/starlight-toc.CTCQXEge.js",
+            "entryType": "resource",
+            "startTime": 25.100000008940697,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 951,
+            "decodedBodySize": 1981
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/persistent-toggle.t6KkBAiq.js",
+            "entryType": "resource",
+            "startTime": 25.200000002980232,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 705,
+            "decodedBodySize": 2082
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/InteractiveCell.DoOzatBM.js",
+            "entryType": "resource",
+            "startTime": 52.5,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 16384,
+            "decodedBodySize": 50227
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/client.BJAMOzhD.js",
+            "entryType": "resource",
+            "startTime": 52.6000000089407,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 814,
+            "decodedBodySize": 1412
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/preact.Bl7PEaKa.js",
+            "entryType": "resource",
+            "startTime": 53.29999999701977,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 4413,
+            "decodedBodySize": 10470
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/output-limits.vkaihnVu.js",
+            "entryType": "resource",
+            "startTime": 53.29999999701977,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 3659,
+            "decodedBodySize": 8969
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/hooks.ClbWuNs9.js",
+            "entryType": "resource",
+            "startTime": 53.400000005960464,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 1153,
+            "decodedBodySize": 2677
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/favicon.svg",
+            "entryType": "resource",
+            "startTime": 53.6000000089407,
+            "duration": 1.699999988079071,
+            "initiatorType": "other",
+            "transferSize": 0,
+            "encodedBodySize": 259,
+            "decodedBodySize": 331
+          },
+          {
+            "name": "oxiquill:hydrated:features__rich-output__python-rich-outputs",
+            "entryType": "mark",
+            "startTime": 54.6000000089407,
+            "duration": 0
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/ui-core.BwVUYzUq.js",
+            "entryType": "resource",
+            "startTime": 74,
+            "duration": 0,
+            "initiatorType": "script",
+            "transferSize": 0,
+            "encodedBodySize": 26119,
+            "decodedBodySize": 93799
+          },
+          {
+            "name": "oxiquill:worker-start:python",
+            "entryType": "mark",
+            "startTime": 150.40000000596046,
+            "duration": 0
+          },
+          {
+            "name": "http://127.0.0.1:38277/oxiquill/_astro/python-worker-CZmazRja.js",
+            "entryType": "resource",
+            "startTime": 153.6000000089407,
+            "duration": -1.4000000059604645,
+            "initiatorType": "other",
+            "transferSize": 0,
+            "encodedBodySize": 13024,
+            "decodedBodySize": 47679
+          },
+          {
+            "name": "oxiquill:output-rendered:features__rich-output__python-rich-outputs",
+            "entryType": "mark",
+            "startTime": 6118.4000000059605,
+            "duration": 0
+          }
+        ]
+      },
+      "workers": [
+        {
+          "timeOrigin": 1788590439609.6,
+          "entries": [
+            {
+              "name": "oxiquill:worker-ready:python",
+              "entryType": "mark",
+              "startTime": 3,
+              "duration": 0
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pyodide.mjs",
+              "entryType": "resource",
+              "startTime": 12.900000005960464,
+              "duration": 1.2999999970197678,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 7156,
+              "decodedBodySize": 17931
+            },
+            {
+              "name": "oxiquill:initialization:python",
+              "entryType": "measure",
+              "startTime": 18.400000005960464,
+              "duration": 1308.2000000029802
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pyodide-lock.json",
+              "entryType": "resource",
+              "startTime": 18.700000002980232,
+              "duration": 1.5,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 26534,
+              "decodedBodySize": 114440
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/python_stdlib.zip",
+              "entryType": "resource",
+              "startTime": 19.100000008940697,
+              "duration": 16.5,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 2503174,
+              "decodedBodySize": 2545564
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pyodide.asm.wasm",
+              "entryType": "resource",
+              "startTime": 19.299999997019768,
+              "duration": 88.30000001192093,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 3546129,
+              "decodedBodySize": 9598218
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pyodide.asm.mjs",
+              "entryType": "resource",
+              "startTime": 19.5,
+              "duration": 9.5,
+              "initiatorType": "script",
+              "transferSize": 0,
+              "encodedBodySize": 260107,
+              "decodedBodySize": 1250344
+            },
+            {
+              "name": "oxiquill:display-support:python",
+              "entryType": "measure",
+              "startTime": 1326.7000000029802,
+              "duration": 34.900000005960464
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/matplotlib-3.10.8-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 1363.2000000029802,
+              "duration": 539.4000000059605,
+              "initiatorType": "fetch",
+              "transferSize": 6867585,
+              "encodedBodySize": 6867285,
+              "decodedBodySize": 6982033
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/contourpy-1.3.3-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 1363.2999999970198,
+              "duration": 195.30000001192093,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 117120,
+              "decodedBodySize": 118875
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/numpy-2.4.6-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 1363.5,
+              "duration": 253.1000000089407,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 2882682,
+              "decodedBodySize": 2918760
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/cycler-0.12.1-py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 1363.6000000089407,
+              "duration": 188,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 7794,
+              "decodedBodySize": 8321
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/six-1.17.0-py2.py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 1363.7999999970198,
+              "duration": 188,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 10640,
+              "decodedBodySize": 11050
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/kiwisolver-1.5.0-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 1363.9000000059605,
+              "duration": 194.59999999403954,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 35887,
+              "decodedBodySize": 36616
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/fonttools-4.62.1-py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 1363.9000000059605,
+              "duration": 210.8999999910593,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 1124539,
+              "decodedBodySize": 1152647
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/packaging-26.1-py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 1364.1000000089407,
+              "duration": 195.69999998807907,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 94197,
+              "decodedBodySize": 95852
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pillow-12.2.0-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 1365.2000000029802,
+              "duration": 208.29999999701977,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 1029176,
+              "decodedBodySize": 1037807
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pyparsing-3.3.2-py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 1365.2999999970198,
+              "duration": 195.30000001192093,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 121160,
+              "decodedBodySize": 122781
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/python_dateutil-2.9.0.post0-py2.py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 1365.5,
+              "duration": 197.29999999701977,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 228238,
+              "decodedBodySize": 229892
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pytz-2026.1.post1-py2.py3-none-any.whl",
+              "entryType": "resource",
+              "startTime": 1365.6000000089407,
+              "duration": 199.69999998807907,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 377648,
+              "decodedBodySize": 510489
+            },
+            {
+              "name": "http://127.0.0.1:38277/oxiquill/oxiquill/pyodide/pandas-3.0.2-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+              "entryType": "resource",
+              "startTime": 1365.9000000059605,
+              "duration": 268.79999999701977,
+              "initiatorType": "fetch",
+              "transferSize": 0,
+              "encodedBodySize": 4141666,
+              "decodedBodySize": 4177814
+            },
+            {
+              "name": "oxiquill:packages:features__rich-output__python-rich-outputs",
+              "entryType": "measure",
+              "startTime": 5882.100000008941,
+              "duration": 0.19999998807907104
+            },
+            {
+              "name": "oxiquill:imports:features__rich-output__python-rich-outputs",
+              "entryType": "measure",
+              "startTime": 5882.4000000059605,
+              "duration": 0.7999999970197678
+            },
+            {
+              "name": "oxiquill:display-prepare:features__rich-output__python-rich-outputs",
+              "entryType": "measure",
+              "startTime": 5883.20000000298,
+              "duration": 0.5
+            },
+            {
+              "name": "oxiquill:execution:features__rich-output__python-rich-outputs",
+              "entryType": "measure",
+              "startTime": 5883.79999999702,
+              "duration": 13.800000011920929
+            },
+            {
+              "name": "oxiquill:display-collect:features__rich-output__python-rich-outputs",
+              "entryType": "measure",
+              "startTime": 5898.20000000298,
+              "duration": 66.5
+            }
+          ]
+        }
+      ],
+      "observed": {
+        "requests": [
+          {
+            "requestId": 1,
+            "at": 1788590439608.3
+          },
+          {
+            "requestId": 2,
+            "at": 1788590445491.5
+          }
+        ],
+        "responses": [
+          {
+            "requestId": 1,
+            "at": 1788590445405,
+            "ok": true
+          },
+          {
+            "requestId": 2,
+            "at": 1788590445578.3,
+            "ok": true
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/tests/performance/python-startup.mjs
+++ b/tests/performance/python-startup.mjs
@@ -75,7 +75,22 @@ async function timingEntries(scope) {
     entries: performance
       .getEntries()
       .filter((entry) => entry.name.startsWith('oxiquill:') || entry.entryType === 'resource')
-      .map((entry) => entry.toJSON())
+      .map((entry) => {
+        if (entry.entryType !== 'resource') return entry.toJSON();
+        const resource = entry.toJSON();
+        return Object.fromEntries(
+          [
+            'name',
+            'entryType',
+            'startTime',
+            'duration',
+            'initiatorType',
+            'transferSize',
+            'encodedBodySize',
+            'decodedBodySize'
+          ].map((key) => [key, resource[key]])
+        );
+      })
   }));
 }
 
@@ -121,7 +136,7 @@ async function measure(page, example, condition, run) {
     triggerMs: trigger,
     outputMs: rendered.startTime,
     latencyMs: condition === 'repeat' ? rendered.startTime - trigger : rendered.startTime,
-    renderMs: main.timeOrigin + rendered.startTime - response.at,
+    renderObserverDeltaMs: main.timeOrigin + rendered.startTime - response.at,
     main,
     workers,
     observed

--- a/tests/performance/python-startup.mjs
+++ b/tests/performance/python-startup.mjs
@@ -1,0 +1,217 @@
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { readFile, stat, mkdir, writeFile } from 'node:fs/promises';
+import { createServer } from 'node:http';
+import os from 'node:os';
+import path from 'node:path';
+import { gzipSync } from 'node:zlib';
+import { chromium } from '@playwright/test';
+
+const argument = (name, fallback) => {
+  const index = process.argv.indexOf(name);
+  return index < 0 ? fallback : process.argv[index + 1];
+};
+const runs = Number(argument('--runs', '5'));
+assert.ok(Number.isInteger(runs) && runs >= 5, 'Measure at least five runs per condition');
+const base = argument('--base', '/oxiquill/');
+const site = path.resolve(argument('--site', 'examples/docs-site/dist'));
+const destination = path.resolve(argument('--output', 'test-results/python-startup.json'));
+const label = argument('--label', 'measurement');
+const mime = {
+  '.html': 'text/html',
+  '.js': 'text/javascript',
+  '.mjs': 'text/javascript',
+  '.css': 'text/css',
+  '.json': 'application/json',
+  '.wasm': 'application/wasm',
+  '.svg': 'image/svg+xml',
+  '.woff': 'font/woff',
+  '.woff2': 'font/woff2',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg'
+};
+const cached = new Map();
+const server = createServer((request, response) => {
+  void (async () => {
+    const pathname = decodeURIComponent(new URL(request.url, 'http://localhost').pathname);
+    if (!pathname.startsWith(base)) {
+      response.writeHead(404).end();
+      return;
+    }
+    let file = path.resolve(site, pathname.slice(base.length));
+    if (file !== site && !file.startsWith(site + path.sep)) {
+      response.writeHead(404).end();
+      return;
+    }
+    if ((await stat(file)).isDirectory()) file = path.join(file, 'index.html');
+    if (!cached.has(file)) {
+      const bytes = await readFile(file);
+      cached.set(file, { bytes, gzip: gzipSync(bytes), type: mime[path.extname(file)] ?? 'application/octet-stream' });
+    }
+    const asset = cached.get(file);
+    const gzip = /gzip/u.test(request.headers['accept-encoding'] ?? '');
+    response.writeHead(200, {
+      'Content-Type': asset.type,
+      'Cache-Control': 'public, max-age=600',
+      Vary: 'Accept-Encoding',
+      ...(gzip ? { 'Content-Encoding': 'gzip' } : {})
+    });
+    response.end(gzip ? asset.gzip : asset.bytes);
+  })().catch(() => response.writeHead(404).end());
+});
+await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+const origin = `http://127.0.0.1:${server.address().port}`;
+const browser = await chromium.launch({
+  headless: true,
+  ...(process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH
+    ? { executablePath: process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH }
+    : {})
+});
+const samples = [];
+
+async function timingEntries(scope) {
+  return scope.evaluate(() => ({
+    timeOrigin: performance.timeOrigin,
+    entries: performance
+      .getEntries()
+      .filter((entry) => entry.name.startsWith('oxiquill:') || entry.entryType === 'resource')
+      .map((entry) => entry.toJSON())
+  }));
+}
+
+async function measure(page, example, condition, run) {
+  const cell = page.getByTestId(`cell-${example.id}`);
+  await cell.scrollIntoViewIfNeeded();
+  await page.waitForFunction(
+    (id) => !document.querySelector(`[data-cell-id="${id}"]`)?.closest('astro-island')?.hasAttribute('ssr'),
+    example.id
+  );
+  const previous =
+    condition === 'repeat' ? await page.evaluate(() => globalThis.__pythonBenchmark.responses.length) : 0;
+  const trigger = await page.evaluate(() => performance.now());
+  if (example.button) await cell.getByRole('button', { name: 'Run', exact: true }).click();
+  else if (condition === 'repeat') await cell.getByLabel('label', { exact: true }).fill(`repeat-${run}`);
+  await page.waitForFunction(
+    ({ previous, id }) => {
+      const observation = globalThis.__pythonBenchmark;
+      return (
+        observation.responses.length > previous &&
+        performance.getEntriesByName(`oxiquill:output-rendered:${id}`).length > 0 &&
+        document.querySelector(`[data-cell-id="${id}"] .doc-cell__output-region`)?.getAttribute('aria-busy') === 'false'
+      );
+    },
+    { previous, id: example.id },
+    { timeout: 180_000 }
+  );
+  const main = await timingEntries(page);
+  const workers = await Promise.all(
+    page
+      .workers()
+      .filter((worker) => worker.url().includes('python-worker'))
+      .map(timingEntries)
+  );
+  const observed = await page.evaluate(() => globalThis.__pythonBenchmark);
+  const rendered = main.entries.find((entry) => entry.name === `oxiquill:output-rendered:${example.id}`);
+  const response = observed.responses.at(-1);
+  assert.equal(response.ok, true);
+  const sample = {
+    example: example.page,
+    condition,
+    run,
+    triggerMs: trigger,
+    outputMs: rendered.startTime,
+    latencyMs: condition === 'repeat' ? rendered.startTime - trigger : rendered.startTime,
+    renderMs: main.timeOrigin + rendered.startTime - response.at,
+    main,
+    workers,
+    observed
+  };
+  samples.push(sample);
+  console.log(`${example.page} ${condition} ${run}: ${sample.latencyMs.toFixed(1)} ms`);
+}
+
+try {
+  for (const example of [
+    { page: 'features/interactive-cells/', id: 'features__interactive-cells__python-controls', button: false },
+    { page: 'features/rich-output/', id: 'features__rich-output__python-rich-outputs', button: true }
+  ]) {
+    for (let run = 1; run <= runs; run += 1) {
+      const context = await browser.newContext({
+        viewport: { width: 1280, height: 900 },
+        reducedMotion: 'no-preference'
+      });
+      const page = await context.newPage();
+      await page.addInitScript((cellId) => {
+        globalThis.__pythonBenchmark = { requests: [], responses: [] };
+        const observed = globalThis.__pythonBenchmark;
+        const seen = new WeakSet();
+        const ids = new Set();
+        const post = Worker.prototype.postMessage;
+        Worker.prototype.postMessage = function (message, ...rest) {
+          if (!seen.has(this)) {
+            seen.add(this);
+            this.addEventListener('message', (event) => {
+              if (ids.has(event.data.requestId) && (event.data.result || event.data.ok === false))
+                observed.responses.push({
+                  requestId: event.data.requestId,
+                  at: performance.timeOrigin + performance.now(),
+                  ok: event.data.ok
+                });
+            });
+          }
+          if (message.cellId === cellId && message.type !== 'prepare') {
+            ids.add(message.requestId);
+            observed.requests.push({ requestId: message.requestId, at: performance.timeOrigin + performance.now() });
+          }
+          return Reflect.apply(post, this, [message, ...rest]);
+        };
+      }, example.id);
+      await page.goto(origin + base + example.page, { waitUntil: 'domcontentloaded' });
+      await measure(page, example, 'fresh', run);
+      await page.reload({ waitUntil: 'domcontentloaded' });
+      await measure(page, example, 'reload', run);
+      await measure(page, example, 'repeat', run);
+      await context.close();
+    }
+  }
+  const medians = Object.fromEntries(
+    [...new Set(samples.map((sample) => `${sample.example}:${sample.condition}`))].map((key) => {
+      const values = samples
+        .filter((sample) => `${sample.example}:${sample.condition}` === key)
+        .map((sample) => sample.latencyMs)
+        .sort((a, b) => a - b);
+      const middle = Math.floor(values.length / 2);
+      return [key, values.length % 2 ? values[middle] : (values[middle - 1] + values[middle]) / 2];
+    })
+  );
+  await mkdir(path.dirname(destination), { recursive: true });
+  await writeFile(
+    destination,
+    JSON.stringify(
+      {
+        label,
+        date: new Date().toISOString(),
+        revision: execFileSync('git', ['rev-parse', 'HEAD'], { encoding: 'utf8' }).trim(),
+        dirty: execFileSync('git', ['status', '--porcelain'], { encoding: 'utf8' }).trim() !== '',
+        browser: browser.version(),
+        hardware: {
+          platform: os.platform(),
+          cpu: os.cpus()[0]?.model,
+          parallelism: os.availableParallelism(),
+          memoryBytes: os.totalmem()
+        },
+        network: { origin: 'loopback', gzip: true, cacheMaxAgeSeconds: 600, throttling: false },
+        base,
+        runs,
+        medians,
+        samples
+      },
+      null,
+      2
+    ) + '\n'
+  );
+  console.log(JSON.stringify(medians, null, 2));
+} finally {
+  await browser.close();
+  await new Promise((resolve) => server.close(resolve));
+}

--- a/tests/runtime/rust-codegen-smoke.mjs
+++ b/tests/runtime/rust-codegen-smoke.mjs
@@ -25,6 +25,27 @@ try {
     return JSON.parse(runtime.run_rust_cell(cell.id, JSON.stringify(inputs)));
   };
   const output = run('spaced-macros');
+  const charts = run('chart-style-overloads').outputs;
+  assert.equal(charts.length, 16);
+  for (const [index, artifact] of charts.entries()) {
+    assert.equal(artifact.kind, 'chart');
+    assert.equal(
+      artifact.spec.kind,
+      index < 4
+        ? 'line'
+        : index < 8
+          ? 'scatter'
+          : index < 10
+            ? 'bar'
+            : index < 12
+              ? 'histogram'
+              : index < 14
+                ? 'heatmap'
+                : 'line'
+    );
+    if (index % 2 === 0) assert.equal(Object.hasOwn(artifact.spec, 'style'), false);
+    else assert.deepEqual(artifact.spec.style, { animation: false, palette: { light: ['#123', '#456'] } });
+  }
   assert.equal(output.stdout, 'spaced output\n');
   assert.deepEqual(output.outputs.find((artifact) => artifact.kind === 'json')?.value, { ok: true });
   assert.equal(

--- a/tests/unit/astro-config.test.mjs
+++ b/tests/unit/astro-config.test.mjs
@@ -74,12 +74,13 @@ function aliasReplacementFor(alias, id) {
   return undefined;
 }
 
-function runConfigSetup(config, root = tempRoot) {
+function runConfigSetup(config, root = tempRoot, injectScript = vi.fn()) {
   const integration = config.integrations.flat().find((entry) => entry.name === 'oxiquill');
   let update;
 
   integration.hooks['astro:config:setup']({
     addWatchFile: vi.fn(),
+    injectScript,
     config: { root },
     updateConfig: (value) => {
       update = value;
@@ -137,6 +138,14 @@ async function compileMdxWithAstro(update, source, filePath) {
 }
 
 describe('defineOxiquillConfig', () => {
+  it('injects DOM-ready preparation only when explicitly enabled', () => {
+    const injectScript = vi.fn();
+    runConfigSetup(defineOxiquillConfig({}), tempRoot, injectScript);
+    expect(injectScript).not.toHaveBeenCalled();
+    runConfigSetup(defineOxiquillConfig({ python: { preload: true } }), tempRoot, injectScript);
+    expect(injectScript).toHaveBeenCalledExactlyOnceWith('page', expect.stringContaining('python-preload.js'));
+    expect(() => defineOxiquillConfig({ python: { preload: 'yes' } })).toThrow('python.preload must be a boolean');
+  });
   it('requires consumers to load the Starlight integration directly', () => {
     expect(() => definePackageConfig({ sidebar: [], title: 'Docs' })).toThrow(
       'requires framework.starlight to be an Astro integration factory'

--- a/tests/unit/chart-style.test.ts
+++ b/tests/unit/chart-style.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, expectTypeOf, it } from 'vitest';
+import { validateOutputArtifacts } from '../../packages/oxiquill/src/lib/doc-runtime/output-artifact-validation';
+import type {
+  AreaChartSpec,
+  BarChartSpec,
+  ChartSpec,
+  LineChartStyle,
+  ScatterChartSpec,
+  ScatterChartStyle
+} from '../../packages/oxiquill/src/lib/doc-runtime/types';
+
+const specs: ChartSpec[] = [
+  { kind: 'line', series: [] },
+  { kind: 'area', series: [] },
+  { kind: 'scatter', series: [] },
+  { kind: 'bar', categories: [], series: [] },
+  { kind: 'histogram', bins: [] },
+  { kind: 'heatmap', data: [] }
+];
+function validate(style: unknown, spec: ChartSpec = specs[0]) {
+  return validateOutputArtifacts([{ kind: 'chart', spec: { ...spec, style } }])[0];
+}
+
+describe('curated chart styles', () => {
+  it('exports the kind-specific public types', () => {
+    expectTypeOf<AreaChartSpec['style']>().toEqualTypeOf<LineChartStyle | undefined>();
+    expectTypeOf<ScatterChartSpec['style']>().toEqualTypeOf<ScatterChartStyle | undefined>();
+    expectTypeOf<NonNullable<BarChartSpec['style']>>().not.toHaveProperty('lineWidth');
+  });
+
+  it.each(specs)('accepts common styles for $kind and accounts for style bytes', (spec) => {
+    const style = {
+      palette: { light: ['#ABC', '#123456'], dark: ['#000', '#fff'] },
+      showGrid: false,
+      animation: false,
+      animationDurationMs: 2000
+    };
+    const result = validate(style, spec);
+    expect(result).toMatchObject({ status: 'valid', artifact: { spec: { style } } });
+    const plain = validateOutputArtifacts([{ kind: 'chart', spec }])[0];
+    if (result.status === 'valid' && plain.status === 'valid') {
+      expect(result.byteLength - plain.byteLength).toBe(
+        new TextEncoder().encode(',"style":' + JSON.stringify(style)).length
+      );
+    }
+    expect(validate({}, spec).status).toBe('valid');
+  });
+
+  it.each([
+    ['animationDurationMs', 0, 2000, specs[0]],
+    ['lineWidth', 1, 8, specs[0]],
+    ['lineWidth', 1, 8, specs[1]],
+    ['symbolSize', 2, 32, specs[2]]
+  ] as const)('checks exact %s bounds', (field, minimum, maximum, spec) => {
+    for (const value of [minimum, maximum, (minimum + maximum) / 2])
+      expect(validate({ [field]: value }, spec).status).toBe('valid');
+    for (const value of [minimum - 0.001, maximum + 0.001, NaN, Infinity, -Infinity, null, '2', undefined]) {
+      expect(validate({ [field]: value }, spec).status).toBe('error');
+    }
+    if (field === 'animationDurationMs') expect(validate({ [field]: 1.5 }, spec).status).toBe('error');
+  });
+
+  it.each(specs)('rejects inapplicable and unknown fields for $kind', (spec) => {
+    for (const field of ['formatter', 'html', 'options', 'smooth'])
+      expect(validate({ [field]: true }, spec).status).toBe('error');
+    if (spec.kind !== 'line' && spec.kind !== 'area') expect(validate({ lineWidth: 2 }, spec).status).toBe('error');
+    if (spec.kind !== 'scatter') expect(validate({ symbolSize: 7 }, spec).status).toBe('error');
+  });
+
+  it('rejects unsafe nested records and all invalid palette forms', () => {
+    for (const style of [
+      null,
+      undefined,
+      [],
+      'blue',
+      { animation: 1 },
+      { showGrid: 'true' },
+      { palette: {} },
+      { palette: { light: [] } },
+      { palette: { light: ['red'] } },
+      { palette: { light: ['#abcd'] } },
+      { palette: { light: ['#ABC', '#aabbcc'] } },
+      { palette: { light: ['#123'], extra: [] } },
+      { palette: { light: ['#123'], dark: null } },
+      { [Symbol('extra')]: true },
+      Object.create({ animation: true }),
+      { palette: Object.create({ light: ['#123'] }) },
+      { palette: { light: Array(2) } },
+      { palette: { light: ['#1234567'] } },
+      { palette: { light: Array.from({ length: 13 }, (_, index) => '#' + index.toString(16).padStart(6, '0')) } }
+    ]) {
+      expect(validate(style).status).toBe('error');
+    }
+    let reads = 0;
+    const accessor = Object.defineProperty({}, 'animation', {
+      get: () => {
+        reads += 1;
+        return true;
+      }
+    });
+    expect(validate(accessor).status).toBe('error');
+    expect(reads).toBe(0);
+    expect(validate({ palette: { light: ['#123'] } }).status).toBe('valid');
+    expect(validate({ palette: { dark: ['#123'] } }).status).toBe('valid');
+    expect(validate({ palette: { light: ['#123'] } }, specs[5]).status).toBe('error');
+    expect(
+      validate({
+        palette: { light: Array.from({ length: 12 }, (_, index) => '#' + index.toString(16).padStart(6, '0')) }
+      }).status
+    ).toBe('valid');
+  });
+});

--- a/tests/unit/chart-updates.test.tsx
+++ b/tests/unit/chart-updates.test.tsx
@@ -1,0 +1,235 @@
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/preact';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import ChartOutput, {
+  chartSpecToEChartsOptions,
+  chartStructuralSignature,
+  resolveChartChrome
+} from '../../packages/oxiquill/src/components/doc-runtime/ChartOutput';
+import { labelsForLanguage } from '../../packages/oxiquill/src/lib/doc-runtime/runtime-localization';
+import type { ChartSpec } from '../../packages/oxiquill/src/lib/doc-runtime/types';
+import { chart, echartsInit } from './mocks/external-runtime';
+
+const line: ChartSpec = { kind: 'line', series: [{ points: [[0, 1]] }] };
+const labels = labelsForLanguage('en');
+const disconnect = vi.fn();
+function output(spec: ChartSpec) {
+  return <ChartOutput artifact={{ kind: 'chart', spec }} idPrefix="chart" labels={labels} />;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  chart.setOption.mockReset();
+  document.documentElement.removeAttribute('data-theme');
+  vi.stubGlobal(
+    'ResizeObserver',
+    class {
+      observe() {}
+      disconnect = disconnect;
+    }
+  );
+  echartsInit.mockImplementation((element) => {
+    element?.replaceChildren(document.createElement('canvas'));
+    return chart;
+  });
+});
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe('persistent chart updates', () => {
+  it('merges data on the same canvas and instance without resetting zoom', async () => {
+    const view = render(output(line));
+    await waitFor(() => expect(chart.setOption).toHaveBeenCalledTimes(1));
+    const plot = screen.getByTestId('doc-plot');
+    const canvas = plot.querySelector('canvas');
+    expect(chart.setOption).toHaveBeenLastCalledWith(
+      expect.objectContaining({ series: [expect.objectContaining({ id: 'line:0' })] }),
+      { notMerge: true }
+    );
+    view.rerender(output({ ...line, series: [{ points: [[0, 2]] }, { points: [[1, 3]] }] }));
+    await waitFor(() => expect(chart.setOption).toHaveBeenCalledTimes(2));
+    expect(chart.setOption).toHaveBeenLastCalledWith(expect.not.objectContaining({ dataZoom: expect.anything() }), {
+      notMerge: false,
+      lazyUpdate: true,
+      replaceMerge: ['series']
+    });
+    expect(screen.getByTestId('doc-plot')).toBe(plot);
+    expect(plot.querySelector('canvas')).toBe(canvas);
+    expect(echartsInit).toHaveBeenCalledOnce();
+    expect(chart.dispose).not.toHaveBeenCalled();
+    view.rerender(output({ kind: 'bar', categories: ['a'], series: [{ values: [2] }] }));
+    await waitFor(() => expect(chart.setOption).toHaveBeenCalledTimes(3));
+    expect(chart.setOption).toHaveBeenLastCalledWith(
+      expect.objectContaining({ series: [expect.objectContaining({ id: 'bar:0' })] }),
+      { notMerge: true }
+    );
+    expect(echartsInit).toHaveBeenCalledOnce();
+    view.unmount();
+    expect(chart.dispose).toHaveBeenCalledOnce();
+    expect(disconnect).toHaveBeenCalledOnce();
+  });
+
+  it('keeps the last successful canvas and accessible summary after an update fails, and retries the latest spec', async () => {
+    const view = render(output(line));
+    await waitFor(() => expect(chart.setOption).toHaveBeenCalledOnce());
+    const canvas = screen.getByTestId('doc-plot').querySelector('canvas');
+    const summary = document.querySelector('.doc-chart-output__summary')?.textContent;
+    chart.setOption.mockImplementationOnce(() => {
+      throw new Error('update failed');
+    });
+    const latest: ChartSpec = {
+      ...line,
+      title: 'Latest',
+      series: [
+        {
+          points: [
+            [0, 7],
+            [1, 9]
+          ]
+        }
+      ]
+    };
+    view.rerender(output(latest));
+    await screen.findByRole('alert');
+    expect(document.querySelector('.doc-chart-output__summary')?.textContent).toBe(summary);
+    expect(screen.getByTestId('doc-plot').querySelector('canvas')).toBe(canvas);
+    fireEvent.click(screen.getByRole('button', { name: 'Retry chart rendering' }));
+    await waitFor(() => expect(screen.queryByRole('alert')).not.toBeInTheDocument());
+    expect(chart.setOption).toHaveBeenLastCalledWith(
+      expect.objectContaining({ title: expect.objectContaining({ text: 'Latest' }) }),
+      { notMerge: true }
+    );
+    expect(echartsInit).toHaveBeenCalledOnce();
+    expect(chart.dispose).not.toHaveBeenCalled();
+  });
+
+  it('cleans up failed initialization before retrying', async () => {
+    chart.setOption.mockImplementationOnce(() => {
+      throw new Error('initialization failed');
+    });
+    render(output(line));
+    await screen.findByRole('alert');
+    fireEvent.click(screen.getByRole('button', { name: 'Retry chart rendering' }));
+    await waitFor(() => expect(echartsInit).toHaveBeenCalledTimes(2));
+    expect(chart.dispose).toHaveBeenCalledOnce();
+    expect(disconnect).toHaveBeenCalledOnce();
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  it('reacts to reduced motion without recreating the chart and removes the listener', async () => {
+    let matches = true;
+    const events = new EventTarget();
+    const remove = vi.fn(events.removeEventListener.bind(events));
+    vi.stubGlobal(
+      'matchMedia',
+      vi.fn(() => ({
+        get matches() {
+          return matches;
+        },
+        addEventListener: events.addEventListener.bind(events),
+        removeEventListener: remove
+      }))
+    );
+    const view = render(output({ ...line, style: { animation: true, animationDurationMs: 900 } }));
+    await waitFor(() => expect(chart.setOption).toHaveBeenCalledOnce());
+    expect(chart.setOption).toHaveBeenLastCalledWith(
+      expect.objectContaining({ animation: false, animationDuration: 0, animationDurationUpdate: 0 }),
+      { notMerge: true }
+    );
+    expect(screen.getByTestId('doc-plot')).toHaveAttribute('data-chart-motion', 'reduced');
+    act(() => {
+      matches = false;
+      events.dispatchEvent(new Event('change'));
+    });
+    await waitFor(() => expect(chart.setOption).toHaveBeenCalledTimes(2));
+    expect(chart.setOption).toHaveBeenLastCalledWith(
+      expect.objectContaining({ animation: true, animationDurationUpdate: 900 }),
+      expect.anything()
+    );
+    expect(screen.getByTestId('doc-plot')).toHaveAttribute('data-chart-motion', 'full');
+    expect(echartsInit).toHaveBeenCalledOnce();
+    view.unmount();
+    expect(remove).toHaveBeenCalledWith('change', expect.any(Function));
+  });
+
+  it('compares effective structures, excluding data and cosmetic changes', () => {
+    expect(chartStructuralSignature(line)).toBe(
+      chartStructuralSignature({
+        ...line,
+        xType: 'value',
+        yType: 'value',
+        tooltip: true,
+        dataZoom: true,
+        legend: false,
+        style: { lineWidth: 8 }
+      })
+    );
+    for (const patch of [
+      { xType: 'time' },
+      { yType: 'log' },
+      { title: 'Title' },
+      { legend: true },
+      { tooltip: false },
+      { dataZoom: false }
+    ]) {
+      expect(chartStructuralSignature({ ...line, ...patch } as ChartSpec)).not.toBe(chartStructuralSignature(line));
+    }
+    expect(
+      chartStructuralSignature({
+        ...line,
+        series: [
+          { name: 'A', points: [] },
+          { name: 'B', points: [] }
+        ]
+      })
+    ).not.toBe(chartStructuralSignature(line));
+  });
+
+  it.each(['light', 'dark'] as const)('resolves Starlight chrome and curated options in %s', (theme) => {
+    const element = document.createElement('div');
+    element.style.cssText =
+      '--sl-color-text:#123456;--sl-color-gray-2:#234567;--sl-color-gray-5:#345678;--sl-color-bg:#456789;font-family:serif';
+    document.body.append(element);
+    const chrome = resolveChartChrome(theme, element);
+    expect(chrome).toEqual({
+      text: '#123456',
+      axis: '#234567',
+      border: '#345678',
+      splitLine: '#345678',
+      tooltipBackground: '#456789',
+      fontFamily: 'serif'
+    });
+    const options = chartSpecToEChartsOptions(
+      { ...line, style: { lineWidth: 8, showGrid: false, palette: { light: ['#123'], dark: ['#456'] } } },
+      theme,
+      { chrome }
+    );
+    expect(options).toMatchObject({
+      color: [theme === 'light' ? '#123' : '#456'],
+      animation: true,
+      animationDurationUpdate: 180,
+      animationEasingUpdate: 'cubicOut',
+      grid: { containLabel: true },
+      xAxis: { splitLine: { show: false }, axisLine: { show: false }, axisTick: { show: false } },
+      series: [{ lineStyle: { width: 8, cap: 'round', join: 'round' }, showSymbol: false }],
+      tooltip: { confine: true },
+      textStyle: { color: '#123456', fontFamily: 'serif' }
+    });
+    expect(chartSpecToEChartsOptions({ ...line, style: { palette: { light: ['#123'] } } }, 'dark').color).toEqual([
+      '#5eead4',
+      '#60a5fa',
+      '#c4b5fd',
+      '#f9a8d4',
+      '#fbbf24',
+      '#cbd5e1'
+    ]);
+    expect(chartSpecToEChartsOptions({ kind: 'scatter', series: [], style: { symbolSize: 32 } }, theme).animation).toBe(
+      true
+    );
+    expect(
+      chartSpecToEChartsOptions({ kind: 'heatmap', data: [], style: { palette: { [theme]: ['#123', '#456'] } } }, theme)
+    ).toMatchObject({ visualMap: { inRange: { color: ['#123', '#456'] } } });
+    element.remove();
+  });
+});

--- a/tests/unit/components.test.tsx
+++ b/tests/unit/components.test.tsx
@@ -236,7 +236,7 @@ describe('InteractiveCell', () => {
           xAxis: expect.objectContaining({ type: 'value', name: 'x' }),
           yAxis: expect.objectContaining({ type: 'value', name: 'y' })
         }),
-        true
+        { notMerge: true }
       )
     );
     expect(mocks.runInteractiveCell).toHaveBeenCalledWith(
@@ -1143,7 +1143,7 @@ describe('ChartOutput options', () => {
         ]
       })
     ).toMatchObject({
-      legend: { top: 4 },
+      legend: { top: 8 },
       tooltip: { trigger: 'axis' },
       xAxis: { type: 'value', name: 'n' },
       yAxis: { type: 'value', name: 'x' },
@@ -1161,7 +1161,7 @@ describe('ChartOutput options', () => {
       })
     ).toMatchObject({
       tooltip: { trigger: 'item' },
-      series: [{ type: 'scatter', symbolSize: 6, data: [[0, 1]] }]
+      series: [{ type: 'scatter', symbolSize: 7, data: [[0, 1]] }]
     });
 
     expect(
@@ -1208,7 +1208,7 @@ describe('ChartOutput options', () => {
       })
     ).toMatchObject({
       dataZoom: undefined,
-      series: [{ type: 'line', areaStyle: { opacity: 0.18 }, data: [[0, 1]] }]
+      series: [{ type: 'line', areaStyle: { opacity: 0.14 }, data: [[0, 1]] }]
     });
 
     expect(
@@ -1244,7 +1244,7 @@ describe('ChartOutput options', () => {
         series: [{ points: [[0, 1]] }]
       })
     ).toMatchObject({
-      legend: { top: 4 }
+      legend: { top: 8 }
     });
 
     expect(

--- a/tests/unit/components.test.tsx
+++ b/tests/unit/components.test.tsx
@@ -60,6 +60,7 @@ const {
   htmlArtifactContentSecurityPolicy,
   htmlArtifactSrcdoc,
   imageArtifactSource,
+  artifactKeys,
   LazyChartOutput
 } = await import('../../packages/oxiquill/src/components/doc-runtime/OutputRenderer');
 const chartOutputModule = await import('../../packages/oxiquill/src/components/doc-runtime/ChartOutput');
@@ -487,6 +488,74 @@ describe('InteractiveCell', () => {
     await waitFor(() => expect(screen.getByText('string failure')).toBeVisible());
     fireEvent.click(screen.getByRole('button', { name: 'Run' }));
     await waitFor(() => expect(screen.getByRole('alert')).toHaveTextContent('Cell execution failed: Unknown error.'));
+  });
+
+  it.each(['error', 'cancel', 'invalid'])(
+    'keeps the last output mounted while running and after %s',
+    async (outcome) => {
+      setManifestCells([makeCell()]);
+      mocks.runInteractiveCell.mockResolvedValueOnce({ stdout: 'retained', plots: [] });
+      render(<InteractiveCell cellId="cell-one" />);
+      fireEvent.click(screen.getByRole('button', { name: 'Run' }));
+      const previous = await screen.findByTestId('run-output');
+      const next = createDeferredResult();
+      mocks.runInteractiveCell.mockReturnValueOnce(next.promise);
+      fireEvent.click(screen.getByRole('button', { name: 'Run' }));
+      await waitFor(() => expect(mocks.runInteractiveCell).toHaveBeenCalledTimes(2));
+      expect(screen.getByTestId('run-output')).toBe(previous);
+      expect(screen.getByText('Updating…')).toHaveAttribute('aria-hidden', 'true');
+      expect(screen.getByRole('region', { name: 'Output for Cell one' })).toHaveAttribute('aria-busy', 'true');
+      if (outcome === 'invalid') {
+        fireEvent.input(screen.getByRole('spinbutton', { name: 'count' }), { target: { value: '' } });
+      } else {
+        const failure = new Error('rerun failed');
+        if (outcome === 'cancel') failure.name = 'AbortError';
+        await act(async () => {
+          next.reject(failure);
+          await next.promise.catch(() => undefined);
+        });
+      }
+      await waitFor(() =>
+        expect(screen.getByRole('region', { name: 'Output for Cell one' })).toHaveAttribute('aria-busy', 'false')
+      );
+      expect(screen.getByTestId('run-output')).toBe(previous);
+      expect(screen.getByTestId('run-output')).toHaveTextContent('retained');
+      expect(screen.queryByText('Updating…')).not.toBeInTheDocument();
+      expect(within(screen.getByRole('region', { name: 'Output for Cell one' })).getByRole('status')).toHaveTextContent(
+        /^$/u
+      );
+      if (outcome === 'error') {
+        expect(screen.getByRole('alert')).toHaveTextContent('rerun failed');
+        mocks.runInteractiveCell.mockResolvedValueOnce({ stdout: 'recovered', plots: [] });
+        fireEvent.click(screen.getByRole('button', { name: 'Retry cell' }));
+        await waitFor(() => expect(previous).toHaveTextContent('recovered'));
+        expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+      }
+    }
+  );
+
+  it('retains charts when unrelated artifacts are inserted and makes duplicate IDs unique', async () => {
+    const chartArtifact = { kind: 'chart', spec: { kind: 'line', series: [] } };
+    const { rerender } = render(<OutputRenderer outputs={validateOutputArtifacts([chartArtifact])} />);
+    const plot = await screen.findByTestId('doc-plot');
+    const outputs = validateOutputArtifacts([
+      { kind: 'text', stream: 'stdout', content: 'new diagnostic' },
+      null,
+      chartArtifact,
+      { kind: 'text', stream: 'stdout', content: 'one', id: 'duplicate' },
+      { kind: 'text', stream: 'stdout', content: 'two', id: 'duplicate' },
+      { kind: 'text', stream: 'stdout', content: 'three', id: 'duplicate:2' }
+    ]);
+    rerender(<OutputRenderer outputs={outputs} />);
+    expect(screen.getByTestId('doc-plot')).toBe(plot);
+    const keys = artifactKeys(outputs);
+    expect(new Set(keys).size).toBe(outputs.length);
+    expect(keys[2]).toBe(artifactKeys(validateOutputArtifacts([chartArtifact]))[0]);
+    expect(keys[3]).toBe(
+      artifactKeys(
+        validateOutputArtifacts([{ kind: 'text', stream: 'stdout', content: 'replacement', id: 'duplicate' }])
+      )[0]
+    );
   });
 
   it('announces localized timeout failures as an alert', async () => {

--- a/tests/unit/components.test.tsx
+++ b/tests/unit/components.test.tsx
@@ -43,6 +43,8 @@ vi.mock('../../packages/oxiquill/src/lib/doc-runtime/manifest', () => ({
   })
 }));
 vi.mock('../../packages/oxiquill/src/lib/doc-runtime/runtime-client', () => ({
+  getPythonPreparationState: () => 'idle',
+  subscribePythonPreparation: () => () => undefined,
   runInteractiveCell: runtimeMocks.runInteractiveCell
 }));
 
@@ -795,6 +797,35 @@ describe('InteractiveCell', () => {
     await waitFor(() => expect(mocks.runInteractiveCell).toHaveBeenCalled());
     expect(screen.queryByTestId('run-output')).not.toBeInTheDocument();
     expect(screen.queryByTestId('value-output')).not.toBeInTheDocument();
+  });
+
+  it('distinguishes Python preparation from execution without announcing completion early', async () => {
+    setManifestCells([makeCell({ language: 'python', inputs: [] })]);
+    let reportPhase: ((phase: 'preparing' | 'executing') => void) | undefined;
+    let finish: ((value: CellExecutionResult) => void) | undefined;
+    mocks.runInteractiveCell.mockImplementation((_cell, _inputs, _version, _signal, phase) => {
+      reportPhase = phase;
+      return new Promise((resolve) => {
+        finish = resolve;
+      });
+    });
+    render(<InteractiveCell cellId="cell-one" />);
+    fireEvent.click(screen.getByRole('button', { name: 'Run' }));
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Preparing Python…' })).toBeVisible());
+    expect(screen.getByRole('status')).toHaveTextContent('Preparing Python…');
+    act(() => reportPhase?.('executing'));
+    expect(screen.getByRole('button', { name: 'Running' })).toBeVisible();
+    expect(screen.getByRole('region', { name: labelsForLanguage('en').cellOutput(makeCell().title) })).toHaveAttribute(
+      'aria-busy',
+      'true'
+    );
+    act(() => finish?.({ stdout: 'done', plots: [], outputs: [{ kind: 'text', stream: 'stdout', content: 'done' }] }));
+    await waitFor(() =>
+      expect(
+        screen.getByRole('region', { name: labelsForLanguage('en').cellOutput(makeCell().title) })
+      ).toHaveAttribute('aria-busy', 'false')
+    );
+    expect(screen.getByTestId('run-output')).toHaveTextContent('done');
   });
 
   it('refreshes rendered cell data when the generated manifest changes without a runtime rebuild', async () => {

--- a/tests/unit/project-config.test.mjs
+++ b/tests/unit/project-config.test.mjs
@@ -38,7 +38,7 @@ describe('Oxiquill project configuration', () => {
         publicDir: path.join(root, 'public'),
         publicAssetsDir: path.join(root, 'public/oxiquill')
       },
-      python: { offline: false }
+      python: { offline: false, preload: false }
     });
     expect(Object.isFrozen(projectConfig)).toBe(true);
     expect(Object.isFrozen(projectConfig.paths)).toBe(true);
@@ -127,6 +127,7 @@ describe('Oxiquill project configuration', () => {
 
     expect(projectConfig.python).toEqual({
       offline: true,
+      preload: false,
       packageMirror: 'https://packages.example/pyodide/'
     });
     expect(Object.isFrozen(projectConfig.python)).toBe(true);

--- a/tests/unit/project-config.test.mjs
+++ b/tests/unit/project-config.test.mjs
@@ -308,6 +308,38 @@ describe('Oxiquill project configuration', () => {
     expect(projectConfig.astroConfigArgs).toEqual(['--root', root, '--config', 'custom config.mts']);
   });
 
+  it.each([undefined, '', 'caller-value', 'development', 'production'])(
+    'restores NODE_ENV=%j after successful and failed discovery',
+    async (nodeEnv) => {
+      const original = process.env.NODE_ENV;
+      const hadOriginal = Object.hasOwn(process.env, 'NODE_ENV');
+      const root = await temporaryDirectory();
+      try {
+        for (const fails of [false, true]) {
+          if (nodeEnv === undefined) delete process.env.NODE_ENV;
+          else process.env.NODE_ENV = nodeEnv;
+          const configFile = `environment-${fails}.mjs`;
+          await writeFile(
+            path.join(root, configFile),
+            [
+              `import { oxiquillIntegration } from ${JSON.stringify(astroModuleUrl)};`,
+              'process.env.NODE_ENV = "config-mutation";',
+              fails ? 'throw new Error("config failed");' : 'export default { integrations: [oxiquillIntegration()] };'
+            ].join('\n')
+          );
+          const discovery = loadOxiquillProjectConfig({ cwd: root, configFile });
+          if (fails) await expect(discovery).rejects.toThrow('Unable to load Oxiquill project config');
+          else await discovery;
+          expect(Object.hasOwn(process.env, 'NODE_ENV')).toBe(nodeEnv !== undefined);
+          expect(process.env.NODE_ENV).toBe(nodeEnv);
+        }
+      } finally {
+        if (hadOriginal) process.env.NODE_ENV = original;
+        else delete process.env.NODE_ENV;
+      }
+    }
+  );
+
   it('fails clearly for missing, invalid, absent, and duplicate integrations', async () => {
     const root = await temporaryDirectory();
     await expect(loadOxiquillProjectConfig({ cwd: root })).rejects.toThrow('No Astro config was found');

--- a/tests/unit/python-preload.test.ts
+++ b/tests/unit/python-preload.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it, vi } from 'vitest';
+import { installPythonPreloader } from '../../packages/oxiquill/src/lib/doc-runtime/python-preload';
+
+function page(html: string, readyState = 'complete') {
+  const document = globalThis.document.implementation.createHTMLDocument();
+  document.body.innerHTML = html;
+  Object.defineProperty(document, 'readyState', { value: readyState });
+  return document;
+}
+const cell =
+  '<section class="doc-cell" data-language="python" data-python-packages=\'["numpy"]\' data-python-timeout="60000"></section>';
+
+describe('Python page preparation', () => {
+  it('waits for DOM readiness and prepares just the first Python cell without any source', async () => {
+    const document = page(cell + cell.replace('numpy', 'pandas'), 'loading');
+    const preparePythonRuntime = vi.fn();
+    const load = vi.fn(async () => ({ preparePythonRuntime }));
+    const dispose = installPythonPreloader(document, load);
+    expect(load).not.toHaveBeenCalled();
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+    await Promise.resolve();
+    expect(preparePythonRuntime).toHaveBeenCalledExactlyOnceWith(['numpy'], 60_000);
+    document.dispatchEvent(new Event('astro:page-load'));
+    expect(load).toHaveBeenCalledOnce();
+    document.body.innerHTML = cell.replace('numpy', 'pandas');
+    document.dispatchEvent(new Event('astro:page-load'));
+    await Promise.resolve();
+    expect(preparePythonRuntime).toHaveBeenLastCalledWith(['pandas'], 60_000);
+    dispose();
+    document.body.innerHTML = cell;
+    document.dispatchEvent(new Event('astro:page-load'));
+    expect(load).toHaveBeenCalledTimes(2);
+  });
+
+  it.each([
+    '',
+    '<section class="doc-cell" data-language="rust"></section>',
+    cell.replace('["numpy"]', 'invalid'),
+    cell.replace('["numpy"]', '[1]')
+  ])('does not load a runtime for missing or invalid Python metadata: %s', (html) => {
+    const load = vi.fn();
+    installPythonPreloader(page(html), load)();
+    expect(load).not.toHaveBeenCalled();
+  });
+
+  it('uses default packages/timeouts and contains background failures', async () => {
+    const preparePythonRuntime = vi.fn().mockRejectedValue(new Error('unavailable'));
+    const dispose = installPythonPreloader(
+      page('<section class="doc-cell" data-language="python"></section>'),
+      async () => ({ preparePythonRuntime })
+    );
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(preparePythonRuntime).toHaveBeenCalledWith([], undefined);
+    dispose();
+  });
+
+  it('does not start preparation if disposed during module loading', async () => {
+    const preparePythonRuntime = vi.fn();
+    const dispose = installPythonPreloader(page(cell), async () => ({ preparePythonRuntime }));
+    dispose();
+    await Promise.resolve();
+    expect(preparePythonRuntime).not.toHaveBeenCalled();
+    const load = vi.fn();
+    const loading = page(cell, 'loading');
+    installPythonPreloader(loading, load)();
+    loading.dispatchEvent(new Event('DOMContentLoaded'));
+    expect(load).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/python-worker.test.ts
+++ b/tests/unit/python-worker.test.ts
@@ -97,6 +97,18 @@ describe('python input conversion', () => {
 });
 
 describe('python worker asset URLs', () => {
+  it('starts the first declared packages inside the shared initialization', async () => {
+    const loadPyodide = vi.fn(async () => ({ runPythonAsync: vi.fn() }));
+    const loader = createPythonRuntimeLoader({
+      indexUrl: '/local/',
+      moduleUrl: '/local/pyodide.mjs',
+      importModule: async () => ({ loadPyodide: loadPyodide as never })
+    });
+    const first = loader(['numpy', 'matplotlib']);
+    expect(loader(['pandas'])).toBe(first);
+    await first;
+    expect(loadPyodide).toHaveBeenCalledExactlyOnceWith({ indexURL: '/local/', packages: ['numpy', 'matplotlib'] });
+  });
   it('resolves Pyodide files under the configured site base', () => {
     expect(resolvePyodideUrls('/')).toEqual({
       indexUrl: '/oxiquill/pyodide/',
@@ -134,7 +146,7 @@ describe('python worker asset URLs', () => {
     expect(importModule).toHaveBeenCalledOnce();
     expect(importModule).toHaveBeenCalledWith('/runtime/pyodide.mjs');
     expect(loadPyodide).toHaveBeenCalledOnce();
-    expect(loadPyodide).toHaveBeenCalledWith({ indexURL: '/runtime/' });
+    expect(loadPyodide).toHaveBeenCalledWith({ indexURL: '/runtime/', packages: [] });
     expect(pyodide.runPythonAsync).toHaveBeenCalledOnce();
     expect(pyodide.runPythonAsync).toHaveBeenCalledWith(pythonDisplaySupportCode);
   });
@@ -242,6 +254,21 @@ describe('python worker asset URLs', () => {
 });
 
 describe('python worker request handling', () => {
+  it('prepares only dependencies, skips loaded packages, and reports readiness without evaluating a cell', async () => {
+    const loadPackage = vi.fn();
+    const ensurePyodide = vi.fn(async () => ({ loadedPackages: { numpy: 'default channel' }, loadPackage }) as never);
+    const postMessage = vi.fn();
+    const handle = createPythonWorkerRequestHandler({ ensurePyodide, postMessage });
+    await handle({ type: 'prepare', requestId: 1, packages: ['numpy', 'pandas'] });
+    expect(ensurePyodide).toHaveBeenCalledWith(['numpy', 'pandas']);
+    expect(loadPackage).toHaveBeenCalledExactlyOnceWith(['pandas']);
+    expect(postMessage.mock.calls).toEqual([
+      [{ type: 'progress', requestId: 1, phase: 'preparing' }],
+      [{ type: 'ready', requestId: 1, ok: true }]
+    ]);
+    await handle({ type: 'prepare', requestId: 2, packages: ['numpy'] });
+    expect(loadPackage).toHaveBeenCalledOnce();
+  });
   it('loads packages, evaluates source, destroys proxies, and posts normalized output', async () => {
     const globals = { destroy: vi.fn() };
     const valueProxy = pythonProxy({ answer: 42 });
@@ -263,7 +290,9 @@ describe('python worker request handling', () => {
     const responses: RuntimeWorkerResponse[] = [];
     const handleRequest = createPythonWorkerRequestHandler({
       ensurePyodide: async () => pyodide as never,
-      postMessage: (response) => responses.push(response)
+      postMessage: (response) => {
+        if (!('type' in response)) responses.push(response);
+      }
     });
     const request = pythonRequest();
 
@@ -303,7 +332,9 @@ describe('python worker request handling', () => {
       ensurePyodide: async () => {
         throw new Error('Pyodide startup failed');
       },
-      postMessage: (response) => startupResponses.push(response)
+      postMessage: (response) => {
+        if (!('type' in response)) startupResponses.push(response);
+      }
     });
     await startupHandler(pythonRequest());
     expect(startupResponses).toEqual([{ requestId: 7, ok: false, error: 'Pyodide startup failed' }]);
@@ -323,7 +354,9 @@ describe('python worker request handling', () => {
           setStdout: vi.fn(),
           toPy: () => globals
         }) as never,
-      postMessage: (response) => evaluationResponses.push(response)
+      postMessage: (response) => {
+        if (!('type' in response)) evaluationResponses.push(response);
+      }
     });
     await evaluationHandler(pythonRequest({ packages: [] }));
     expect(globals.destroy).toHaveBeenCalledOnce();
@@ -334,7 +367,9 @@ describe('python worker request handling', () => {
       ensurePyodide: async () => {
         throw Object.create(null);
       },
-      postMessage: (response) => unstringifiableResponses.push(response)
+      postMessage: (response) => {
+        if (!('type' in response)) unstringifiableResponses.push(response);
+      }
     });
     await unstringifiableHandler(pythonRequest());
     expect(unstringifiableResponses).toEqual([{ requestId: 7, ok: false, error: 'Unknown error.' }]);

--- a/tests/unit/runtime-client.test.ts
+++ b/tests/unit/runtime-client.test.ts
@@ -1,6 +1,9 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   createInteractiveCellRunner,
+  preparePythonRuntime,
+  getPythonPreparationState,
+  subscribePythonPreparation,
   resetInteractiveRuntime,
   runtimeHaskellFingerprintHash,
   runInteractiveCell
@@ -105,6 +108,73 @@ afterEach(() => {
 });
 
 describe('runtime client', () => {
+  it('shares preparation with execution, deduplicates dependencies, and keeps progress pending', async () => {
+    const { runner, workers } = makeRunner();
+    const listener = vi.fn();
+    const unsubscribe = runner.subscribePythonPreparation(listener);
+    const prepared = runner.preparePythonRuntime(['pandas', 'numpy', 'numpy']);
+    expect(runner.preparePythonRuntime(['numpy', 'pandas'])).toBe(prepared);
+    expect(runner.getPythonPreparationState()).toBe('preparing');
+    const phase = vi.fn();
+    const execution = runner.runInteractiveCell(makeCell('python'), {}, undefined, undefined, phase);
+    expect(workers).toHaveLength(1);
+    expect(workers[0].messages[0]).toEqual({ type: 'prepare', requestId: 1, packages: ['numpy', 'pandas'] });
+    workers[0].emitMessage({ type: 'progress', requestId: 1, phase: 'preparing' });
+    workers[0].emitMessage({ type: 'ready', requestId: 1, ok: true });
+    await prepared;
+    expect(runner.getPythonPreparationState()).toBe('ready');
+    workers[0].emitMessage({ type: 'progress', requestId: 2, phase: 'preparing' });
+    workers[0].emitMessage({ type: 'progress', requestId: 2, phase: 'executing' });
+    expect(phase.mock.calls).toEqual([['preparing'], ['executing']]);
+    workers[0].emitMessage({ requestId: 2, ok: true, result });
+    await expect(execution).resolves.toEqual(normalizedResult);
+    expect(runner.preparePythonRuntime(['pandas', 'numpy'])).toBe(prepared);
+    unsubscribe();
+    runner.resetWorker('python');
+    expect(runner.getPythonPreparationState()).toBe('idle');
+    expect(listener).toHaveBeenCalledTimes(2);
+  });
+
+  it.each(['error', 'timeout', 'reset', 'cancel', 'invalid', 'unexpected'] as const)(
+    'recovers preparation and execution together after %s',
+    async (failure) => {
+      vi.useFakeTimers();
+      const { runner, workers } = makeRunner();
+      const prepared = runner.preparePythonRuntime(['numpy'], 50);
+      const abort = new AbortController();
+      const execution = runner.runInteractiveCell(makeCell('python'), {}, undefined, abort.signal);
+      const settled = Promise.allSettled([prepared, execution]);
+      const worker = workers[0];
+      if (failure === 'error') worker.emitError('failed');
+      if (failure === 'timeout') vi.advanceTimersByTime(50);
+      if (failure === 'reset') runner.resetWorker('python');
+      if (failure === 'cancel') abort.abort();
+      if (failure === 'invalid') worker.emitMessage({ type: 'progress', requestId: 1, phase: 'unknown' });
+      if (failure === 'unexpected') worker.emitMessage({ requestId: 1, ok: true, result });
+      expect((await settled).every((entry) => entry.status === 'rejected')).toBe(true);
+      expect(worker.terminated).toBe(true);
+      const retry = runner.preparePythonRuntime(['numpy']);
+      worker.emitMessage({ requestId: 3, ok: true, result });
+      workers[1].emitMessage({ type: 'ready', requestId: 3, ok: true });
+      await retry;
+      expect(runner.getPythonPreparationState()).toBe('ready');
+      runner.resetWorker('python');
+      expect(vi.getTimerCount()).toBe(0);
+    }
+  );
+
+  it('retries a rejected preparation on the same worker and accepts new dependency sets', async () => {
+    const { runner, workers } = makeRunner();
+    const prepared = runner.preparePythonRuntime(['numpy']);
+    workers[0].emitMessage({ requestId: 1, ok: false, error: 'download failed' });
+    await expect(prepared).rejects.toThrow('download failed');
+    expect(runner.getPythonPreparationState()).toBe('idle');
+    const retry = runner.preparePythonRuntime(['pandas']);
+    workers[0].emitMessage({ requestId: 2, type: 'ready', ok: true });
+    await retry;
+    runner.resetWorker('python');
+  });
+
   it('delegates the default browser runner to Worker adapters', async () => {
     const originalWorker = globalThis.Worker;
     const defaultWorkers: DefaultFakeWorker[] = [];
@@ -144,6 +214,29 @@ describe('runtime client', () => {
     expect(defaultWorkers[1].terminated).toBe(true);
     expect(defaultWorkers[2].terminated).toBe(true);
     globalThis.Worker = originalWorker;
+  });
+
+  it('exposes background preparation through the default browser adapter', async () => {
+    const worker = new FakeWorker();
+    vi.stubGlobal(
+      'Worker',
+      vi.fn(function () {
+        return worker;
+      })
+    );
+    try {
+      const listener = vi.fn();
+      const unsubscribe = subscribePythonPreparation(listener);
+      const prepared = preparePythonRuntime([]);
+      expect(getPythonPreparationState()).toBe('preparing');
+      worker.emitMessage({ requestId: worker.messages[0].requestId, type: 'ready', ok: true });
+      await prepared;
+      expect(getPythonPreparationState()).toBe('ready');
+      unsubscribe();
+      resetInteractiveRuntime('python');
+    } finally {
+      vi.unstubAllGlobals();
+    }
   });
 
   it('sends Python source and resolves successful worker responses', async () => {

--- a/tests/unit/runtime-timing.test.ts
+++ b/tests/unit/runtime-timing.test.ts
@@ -1,0 +1,33 @@
+import { afterEach, expect, it, vi } from 'vitest';
+import { markRuntimeEvent, measureRuntimePhase } from '../../packages/oxiquill/src/lib/doc-runtime/runtime-timing';
+
+afterEach(() => vi.unstubAllGlobals());
+it('records local timings on success and failure and replaces earlier observations', async () => {
+  const performance = {
+    mark: vi.fn(),
+    measure: vi.fn(),
+    clearMarks: vi.fn(),
+    clearMeasures: vi.fn(),
+    now: vi.fn().mockReturnValueOnce(10).mockReturnValueOnce(20).mockReturnValue(30)
+  };
+  vi.stubGlobal('performance', performance);
+  markRuntimeEvent('hydrated', 'cell');
+  expect(performance.clearMarks).toHaveBeenCalledWith('oxiquill:hydrated:cell');
+  expect(await measureRuntimePhase('execution', 'cell', () => 42)).toBe(42);
+  expect(performance.measure).toHaveBeenCalledWith('oxiquill:execution:cell', {
+    start: 10,
+    end: 20,
+    detail: { phase: 'execution', cellId: 'cell' }
+  });
+  await expect(
+    measureRuntimePhase('execution', 'cell', () => {
+      throw new Error('failed');
+    })
+  ).rejects.toThrow('failed');
+  expect(performance.clearMeasures).toHaveBeenCalledTimes(2);
+});
+it('executes normally when User Timing is unavailable', async () => {
+  vi.stubGlobal('performance', undefined);
+  markRuntimeEvent('hydrated', 'cell');
+  expect(await measureRuntimePhase('execution', 'cell', () => 'ok')).toBe('ok');
+});

--- a/tests/unit/toolchain-process-output.test.mjs
+++ b/tests/unit/toolchain-process-output.test.mjs
@@ -1,0 +1,64 @@
+import { EventEmitter } from 'node:events';
+import { describe, expect, it, vi } from 'vitest';
+import { runCommandWithCapturedOutput } from '../../packages/oxiquill/src/generator/doc-runtime/toolchain-preflight.mjs';
+
+function processDouble() {
+  const child = new EventEmitter();
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
+  return child;
+}
+
+describe('toolchain process output', () => {
+  it('waits for stdout to finish after process exit', async () => {
+    const child = processDouble();
+    const spawn = vi.fn(() => child);
+    const output = runCommandWithCapturedOutput('rustc', ['--version'], spawn);
+    const settled = vi.fn();
+    void output.then(settled);
+
+    child.emit('exit', 0, null);
+    await Promise.resolve();
+    expect(settled).not.toHaveBeenCalled();
+    child.stdout.emit('data', Buffer.from('rustc '));
+    child.stdout.emit('data', Buffer.from('1.95.0\n'));
+    child.emit('close', 0, null);
+
+    await expect(output).resolves.toBe('rustc 1.95.0\n');
+    expect(spawn).toHaveBeenCalledWith('rustc', ['--version'], { stdio: ['ignore', 'pipe', 'pipe'] });
+  });
+
+  it('retains stderr that arrives after a failed process exits', async () => {
+    const child = processDouble();
+    const output = runCommandWithCapturedOutput('rustc', ['--version'], () => child);
+    const rejected = expect(output).rejects.toThrow('toolchain unavailable');
+    child.emit('exit', 1, null);
+    child.stderr.emit('data', Buffer.from('toolchain '));
+    child.stderr.emit('data', Buffer.from('unavailable\n'));
+    child.emit('close', 1, null);
+    await rejected;
+  });
+
+  it.each([
+    [1, null, '1'],
+    [null, 'SIGTERM', 'SIGTERM']
+  ])('reports an empty failure with code %s and signal %s', async (code, signal, detail) => {
+    const child = processDouble();
+    const output = runCommandWithCapturedOutput('cargo', ['--version'], () => child);
+    child.emit('close', code, signal);
+    await expect(output).rejects.toThrow(`cargo exited with ${detail}`);
+  });
+
+  it('rejects spawn errors', async () => {
+    const child = processDouble();
+    const output = runCommandWithCapturedOutput('missing-tool', [], () => child);
+    child.emit('error', new Error('spawn ENOENT'));
+    await expect(output).rejects.toThrow('spawn ENOENT');
+  });
+
+  it('captures output from a real child process', async () => {
+    await expect(runCommandWithCapturedOutput(process.execPath, ['-e', 'process.stdout.write("ready")'])).resolves.toBe(
+      'ready'
+    );
+  });
+});


### PR DESCRIPTION
Reactive reruns should retain usable output, and production builds should preserve production search and correct math sizing. This change also reduces the first Python result's latency by sharing preparation with execution and overlapping declared package downloads with Pyodide initialization.

- Preserve successful cell output through reruns, failures, cancellation, and invalid inputs. Keep ECharts instances and canvas nodes across compatible updates, add bounded retry handling, theme-aware styles, reduced-motion support, and compatible Rust macro style arguments.
- Restore the exact previous `NODE_ENV` after Vite configuration discovery, including failure paths. Exercise production Pagefind search with the environment variable unset.
- Align the direct KaTeX dependency with the renderer at 0.16.47, and verify upstream script sizing and dependency resolution in packed npm/pnpm consumers.
- Wait for toolchain process output streams to close before checking captured versions, preventing fast process exits from producing empty diagnostics. Cover delayed stdout/stderr, process failures, and real child-process output.
- Add opt-in `python.preload` (enabled in the documentation site), typed preparation/progress messages, shared worker recovery, localized preparation states, and lazy optional display imports. Keep authored execution rules and same-origin asset loading intact.
- Document the public API in English and Japanese and retain reproducible startup measurements. Across five runs per condition on a localhost gzip-served `/oxiquill/` production build, rich-output cold median latency fell from 8998.4 ms to 5779.3 ms (35.8%). See `tests/performance/README.md` for conditions, phase timings, and raw samples.

Local validation passed: `pnpm test` and `pnpm check`, including strict linting, unit/Rust coverage, generated Rust/Wasm and Haskell tests, package and npm/pnpm consumer checks, packed browser execution, development HMR, documentation/bundle contracts, and Chromium/Firefox/WebKit E2E tests (82 passed, 2 browser-specific skips). The latest unit coverage run passed 1146 tests with 1 platform-specific skip.

Closes #126
Closes #131
Closes #132
Closes #133
