### PR TITLE
chore: release v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Changed
 
-- Contributor and CI tooling now requires Node.js 24.15.0 or newer; the published package and generated starter continue to support Node.js 24.0.0 or newer.
+- Nothing yet.
 
 ### Deprecated
 
@@ -29,6 +29,28 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ### Security
 
 - Nothing yet.
+
+## [0.3.1] - 2026-09-05
+
+### Added
+
+- Optional `python.preload` preparation with localized progress states and shared runtime initialization.
+- Development HMR, generated Rust execution, documentation, and browser bundle contract checks in CI.
+
+### Changed
+
+- Contributor and CI tooling now requires Node.js 24.15.0 or newer; the published package and generated starter continue to support Node.js 24.0.0 or newer.
+- Successful cell output and compatible chart instances persist through reactive reruns, failures, cancellation, and invalid inputs, with theme-aware chart styles and reduced-motion support.
+- Python startup overlaps declared package downloads with Pyodide initialization and loads optional display helpers on demand.
+- Updated development test tools and GitHub Actions dependencies.
+
+### Fixed
+
+- Runtime watcher startup ordering, pending rebuilds after synchronization failures, manifest refresh coordination, initialization recovery, and helper-crate input tracking.
+- Error normalization, numeric input validation, authoring metadata boundaries, public asset paths, collision-free MDX bindings, and multiline Haskell preambles.
+- Rust output macro discovery, generated collector isolation, and empty `println!` output handling.
+- MDX math discovery, production Pagefind search, KaTeX script sizing, and categorical heatmap validation and rendering.
+- Toolchain version checks for fast-exiting processes.
 
 ## [0.3.0] - 2026-08-30
 
@@ -69,6 +91,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 This release predates the maintained changelog. See the [v0.2.0 GitHub Release](https://github.com/kakune/oxiquill/releases/tag/v0.2.0) and tagged source for its complete contents.
 
-[Unreleased]: https://github.com/kakune/oxiquill/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/kakune/oxiquill/compare/v0.3.1...HEAD
+[0.3.1]: https://github.com/kakune/oxiquill/releases/tag/v0.3.1
 [0.3.0]: https://github.com/kakune/oxiquill/releases/tag/v0.3.0
 [0.2.0]: https://github.com/kakune/oxiquill/releases/tag/v0.2.0

--- a/README.md
+++ b/README.md
@@ -103,8 +103,8 @@ pnpm preview
 For an existing project, install Oxiquill together with the Astro and Starlight packages imported by the project:
 
 ```sh
-pnpm add oxiquill@0.3.0 astro@7.2.9 @astrojs/starlight@0.41.9
-npm install oxiquill@0.3.0 astro@7.2.9 @astrojs/starlight@0.41.9
+pnpm add oxiquill@0.3.1 astro@7.2.9 @astrojs/starlight@0.41.9
+npm install oxiquill@0.3.1 astro@7.2.9 @astrojs/starlight@0.41.9
 ```
 
 Route project scripts through the CLI:
@@ -114,7 +114,7 @@ Route project scripts through the CLI:
   "dependencies": {
     "@astrojs/starlight": "0.41.9",
     "astro": "7.2.9",
-    "oxiquill": "0.3.0"
+    "oxiquill": "0.3.1"
   },
   "scripts": {
     "dev": "oxiquill dev",
@@ -420,8 +420,8 @@ pnpm preview
 既存 project では、project が直接 import する Astro および Starlight とともに Oxiquill を追加します。
 
 ```sh
-pnpm add oxiquill@0.3.0 astro@7.2.9 @astrojs/starlight@0.41.9
-npm install oxiquill@0.3.0 astro@7.2.9 @astrojs/starlight@0.41.9
+pnpm add oxiquill@0.3.1 astro@7.2.9 @astrojs/starlight@0.41.9
+npm install oxiquill@0.3.1 astro@7.2.9 @astrojs/starlight@0.41.9
 ```
 
 project script は CLI 経由にします。
@@ -431,7 +431,7 @@ project script は CLI 経由にします。
   "dependencies": {
     "@astrojs/starlight": "0.41.9",
     "astro": "7.2.9",
-    "oxiquill": "0.3.0"
+    "oxiquill": "0.3.1"
   },
   "scripts": {
     "dev": "oxiquill dev",

--- a/examples/docs-site/content/docs/guides/getting-started.mdx
+++ b/examples/docs-site/content/docs/guides/getting-started.mdx
@@ -19,13 +19,13 @@ Omit `my-docs` to initialize the current directory. The target must not exist or
 You can also install Oxiquill into an existing static documentation project:
 
 ```sh
-pnpm add oxiquill@0.3.0 astro@7.2.9 @astrojs/starlight@0.41.9
+pnpm add oxiquill@0.3.1 astro@7.2.9 @astrojs/starlight@0.41.9
 ```
 
 or:
 
 ```sh
-npm install oxiquill@0.3.0 astro@7.2.9 @astrojs/starlight@0.41.9
+npm install oxiquill@0.3.1 astro@7.2.9 @astrojs/starlight@0.41.9
 ```
 
 Add these scripts to `package.json` if the starter did not create them:

--- a/examples/docs-site/content/docs/ja/guides/getting-started.mdx
+++ b/examples/docs-site/content/docs/ja/guides/getting-started.mdx
@@ -19,13 +19,13 @@ cd my-docs
 既存 static documentation project に Oxiquill を追加する場合:
 
 ```sh
-pnpm add oxiquill@0.3.0 astro@7.2.9 @astrojs/starlight@0.41.9
+pnpm add oxiquill@0.3.1 astro@7.2.9 @astrojs/starlight@0.41.9
 ```
 
 または:
 
 ```sh
-npm install oxiquill@0.3.0 astro@7.2.9 @astrojs/starlight@0.41.9
+npm install oxiquill@0.3.1 astro@7.2.9 @astrojs/starlight@0.41.9
 ```
 
 starter が作成していない場合は `package.json` に次の script を追加します。

--- a/examples/docs-site/crates/Cargo.lock
+++ b/examples/docs-site/crates/Cargo.lock
@@ -4,14 +4,14 @@ version = 4
 
 [[package]]
 name = "doc-rust"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "doc-rust-text"
-version = "0.3.0"
+version = "0.3.1"
 
 [[package]]
 name = "proc-macro2"

--- a/examples/docs-site/crates/doc-rust-text/Cargo.toml
+++ b/examples/docs-site/crates/doc-rust-text/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "doc-rust-text"
-version = "0.3.0"
+version = "0.3.1"
 description = "Small text helpers available to generated documentation cells."
 edition.workspace = true
 rust-version.workspace = true

--- a/examples/docs-site/crates/doc-rust/Cargo.toml
+++ b/examples/docs-site/crates/doc-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "doc-rust"
-version = "0.3.0"
+version = "0.3.1"
 description = "Pure Rust helpers available to generated documentation cells."
 edition.workspace = true
 rust-version.workspace = true

--- a/examples/docs-site/package.json
+++ b/examples/docs-site/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oxiquill-docs-site",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oxiquill-workspace",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@11.2.2",

--- a/packages/oxiquill/README.md
+++ b/packages/oxiquill/README.md
@@ -22,11 +22,11 @@ pnpm preview
 For an existing project, use either package manager:
 
 ```sh
-pnpm add oxiquill@0.3.0 astro@7.2.9 @astrojs/starlight@0.41.9
+pnpm add oxiquill@0.3.1 astro@7.2.9 @astrojs/starlight@0.41.9
 ```
 
 ```sh
-npm install oxiquill@0.3.0 astro@7.2.9 @astrojs/starlight@0.41.9
+npm install oxiquill@0.3.1 astro@7.2.9 @astrojs/starlight@0.41.9
 ```
 
 Route documentation scripts through the CLI:

--- a/packages/oxiquill/package.json
+++ b/packages/oxiquill/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oxiquill",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Interactive Astro/Starlight notes with Rust, Python, math, Mermaid, WebAssembly, and Pyodide",
   "author": "kakune",
   "private": false,

--- a/packages/oxiquill/src/generator/license-data/rust/runtime-Cargo.lock
+++ b/packages/oxiquill/src/generator/license-data/rust/runtime-Cargo.lock
@@ -59,14 +59,14 @@ dependencies = [
 
 [[package]]
 name = "doc-rust"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "doc-rust-cells"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "console_error_panic_hook",
  "doc-rust",
@@ -79,7 +79,7 @@ dependencies = [
 
 [[package]]
 name = "doc-rust-text"
-version = "0.3.0"
+version = "0.3.1"
 
 [[package]]
 name = "find-msvc-tools"

--- a/templates/basic/package.json
+++ b/templates/basic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oxiquill-docs",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@11.2.2",
@@ -17,6 +17,6 @@
   "dependencies": {
     "@astrojs/starlight": "0.41.9",
     "astro": "7.2.9",
-    "oxiquill": "^0.3.0"
+    "oxiquill": "^0.3.1"
   }
 }

--- a/tests/unit/release-workflow.test.mjs
+++ b/tests/unit/release-workflow.test.mjs
@@ -38,51 +38,51 @@ afterEach(async () => {
 });
 
 describe('release-bound version verification', () => {
-  it('accepts every current v0.3.0 release reference', async () => {
-    await expect(verifyReleaseVersions({ repositoryRoot })).resolves.toMatchObject({ version: '0.3.0' });
+  it('accepts every current v0.3.1 release reference', async () => {
+    await expect(verifyReleaseVersions({ repositoryRoot })).resolves.toMatchObject({ version: '0.3.1' });
   });
 
   it.each([
     [
       'templates/basic/package.json',
-      '"oxiquill": "^0.3.0"',
+      '"oxiquill": "^0.3.1"',
       '"oxiquill": "^0.2.0"',
       'templates/basic/package.json oxiquill dependency'
     ],
-    ['README.md', '"oxiquill": "0.3.0"', '"oxiquill": "0.2.0"', 'README.md contains stale'],
+    ['README.md', '"oxiquill": "0.3.1"', '"oxiquill": "0.2.0"', 'README.md contains stale'],
     [
       'packages/oxiquill/README.md',
-      'npm install oxiquill@0.3.0',
+      'npm install oxiquill@0.3.1',
       'npm install oxiquill@0.2.0',
       'package README contains stale'
     ],
     [
       'examples/docs-site/content/docs/guides/getting-started.mdx',
-      'pnpm add oxiquill@0.3.0',
+      'pnpm add oxiquill@0.3.1',
       'pnpm add oxiquill@0.2.0',
       'English getting-started guide contains stale'
     ],
     [
       'examples/docs-site/content/docs/ja/guides/getting-started.mdx',
-      'pnpm add oxiquill@0.3.0',
+      'pnpm add oxiquill@0.3.1',
       'pnpm add oxiquill@0.2.0',
       'Japanese getting-started guide contains stale'
     ],
     [
       'examples/docs-site/crates/doc-rust/Cargo.toml',
-      'version = "0.3.0"',
+      'version = "0.3.1"',
       'version = "0.2.0"',
       'doc-rust Cargo.toml version'
     ],
     [
       'examples/docs-site/crates/Cargo.lock',
-      'name = "doc-rust"\nversion = "0.3.0"',
+      'name = "doc-rust"\nversion = "0.3.1"',
       'name = "doc-rust"\nversion = "0.2.0"',
       'helper Cargo.lock doc-rust version'
     ],
     [
       'packages/oxiquill/src/generator/license-data/rust/runtime-Cargo.lock',
-      'name = "doc-rust-cells"\nversion = "0.3.0"',
+      'name = "doc-rust-cells"\nversion = "0.3.1"',
       'name = "doc-rust-cells"\nversion = "0.2.0"',
       'generated runtime Cargo.lock doc-rust-cells version'
     ]


### PR DESCRIPTION
Prepare the current `main` (`75c8faa0bf67ede6870bfd60c6a4a97427d570ab`) for Oxiquill v0.3.1. Synchronize package, starter, helper-crate, pinned runtime lock, installation-guide, and release-test versions, and document the runtime, rendering, Python startup, and tooling changes since the published v0.3.0 tag.

Validation completed locally:

- Frozen pnpm install and production dependency audit: passed; no known vulnerabilities.
- `pnpm verify:release-version`, `pnpm check`, `pnpm lint`, and `pnpm wasm:dev`: passed.
- Unit coverage: 1,146 passed, 1 platform-specific skip; Rust coverage, generated Wasm/Haskell execution, production build, documentation and bundle checks, package checks, and packed npm/pnpm consumers: passed.
- `pnpm test` passed through packed npm/pnpm consumers, then stopped because the Nix browser path contains older revisions than Playwright 1.62.1 expects. Resumed the remaining packed-browser and development HMR checks with the supported Chromium executable override: passed; Chromium E2E: 28 passed. The exact pinned Chromium/Firefox/WebKit matrix runs in required CI, and the tagged publication workflow runs the complete `pnpm test` suite before publishing.

Release checklist:

- [x] Prepare the release branch from the latest main and synchronize release metadata.
- [x] Restore empty Unreleased categories and add dated v0.3.1 notes.
- [x] Confirm no open release blockers or Dependabot alerts.
- [x] Complete local release validation (Nix browser limitation documented above) and all required PR checks. All 17 CI jobs passed: https://github.com/kakune/oxiquill/actions/runs/33955225958.
- [x] Squash-merge and retain `release/v0.3.1`. After fixing the tagged-validation blockers in #137 and #138, the maintainer authorized correcting the unpublished `v0.3.1` tag to validated main commit `f36c6e93c6ae9f0fc19594b95b71aca3e349e2f8`. Tag protection was restored immediately.
- [ ] Run the tagged publication dry run and inspect the immutable archive.
- [ ] Publish the stable GitHub Release, inspect that workflow's exact artifact, and approve trusted npm publication.
- [ ] Verify npm provenance, archive integrity, and npm/pnpm registry consumers.

Publication status: tagged validation exposed two blockers, fixed and squash-merged in #137 (release-control checkout isolation) and #138 (HMR source execution). All 17 CI jobs and the final local package/browser checks passed.

With explicit maintainer approval, the unpublished tag was corrected from `5382930` to `f36c6e9`; the protection exception was limited to `v0.3.1` and restored immediately. Final-tag dry run: https://github.com/kakune/oxiquill/actions/runs/33961961687. GitHub Release and npm publication will follow successful archive verification.
