### PR TITLE
fix: isolate release control sparse checkout

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -56,7 +56,8 @@ jobs:
           path: .release-control
           persist-credentials: false
           ref: ${{ github.workflow_sha }}
-          sparse-checkout: .github/scripts
+          sparse-checkout: /.github/scripts/
+          sparse-checkout-cone-mode: false
 
       - name: Verify the release tag is on main
         env:
@@ -175,7 +176,8 @@ jobs:
           path: .release-control
           persist-credentials: false
           ref: ${{ github.workflow_sha }}
-          sparse-checkout: .github/scripts
+          sparse-checkout: /.github/scripts/
+          sparse-checkout-cone-mode: false
 
       - name: Set up Node.js
         uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
@@ -223,7 +225,8 @@ jobs:
           path: .release-control
           persist-credentials: false
           ref: ${{ github.workflow_sha }}
-          sparse-checkout: .github/scripts
+          sparse-checkout: /.github/scripts/
+          sparse-checkout-cone-mode: false
 
       - name: Set up Node.js
         uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0

--- a/tests/unit/release-workflow.test.mjs
+++ b/tests/unit/release-workflow.test.mjs
@@ -108,6 +108,15 @@ describe('release identity verification', () => {
     expect(workflow.match(/path: \.release-control/gu)).toHaveLength(3);
     expect(workflow).toContain('node .release-control/.github/scripts/verify-release.mjs');
     expect(workflow).toContain('Workflow commit $GITHUB_WORKFLOW_SHA is not contained in origin/main');
+
+    const { jobs } = parseYaml(workflow);
+    for (const job of [jobs.verify, jobs['release-assets'], jobs.publish]) {
+      const checkout = job.steps.find((step) => step.name === 'Check out the release control plane');
+      expect(checkout.with).toMatchObject({
+        'sparse-checkout': '/.github/scripts/',
+        'sparse-checkout-cone-mode': false
+      });
+    }
   });
 
   it('accepts an exact stable tag and matching package versions', () => {


### PR DESCRIPTION
The v0.3.1 tagged dry run failed with 82 ESLint parsing errors because the nested `.release-control` checkout included root ESLint and TypeScript configuration files. Git sparse checkout in cone mode includes ancestor-directory files even when `.github/scripts` is the requested directory.

Use the anchored `/.github/scripts/` pattern with cone mode disabled for all three release-control checkouts. The control scripts remain pinned to the workflow commit, and package source remains pinned to the release tag. Add a workflow contract assertion for all three checkouts.

Validation:

- Reproduced the exact 82 lint errors using a nested cone-mode checkout of v0.3.1.
- Switched that same checkout to the new pattern, confirmed only `.git` and `.github` remained at its root, and passed `pnpm lint` with the nested checkout present.
- Focused release-workflow tests: 64 passed.
- Unit coverage with the nested checkout present: 1,146 passed, 1 platform-specific skip. A first aggregate run hit temporary filesystem-operation timeouts; the unchanged rerun passed.
- `git diff --check`: passed.

Failing tagged dry run: https://github.com/kakune/oxiquill/actions/runs/33956263090

All 17 CI jobs passed: https://github.com/kakune/oxiquill/actions/runs/33956772989
