### PR TITLE
fix: rerun cells after source refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ### Fixed
 
 - Runtime watcher startup ordering, pending rebuilds after synchronization failures, manifest refresh coordination, initialization recovery, and helper-crate input tracking.
+- Reactive and autorun cell execution after out-of-order source and runtime-version updates during development.
 - Error normalization, numeric input validation, authoring metadata boundaries, public asset paths, collision-free MDX bindings, and multiline Haskell preambles.
 - Rust output macro discovery, generated collector isolation, and empty `println!` output handling.
 - MDX math discovery, production Pagefind search, KaTeX script sizing, and categorical heatmap validation and rendering.

--- a/examples/docs-site/content/docs/features/interactive-cells.mdx
+++ b/examples/docs-site/content/docs/features/interactive-cells.mdx
@@ -34,7 +34,7 @@ Haskell cells use standard-library code only and accept neither `packages` nor `
 
 - `button`: show inputs and a Run button; do not execute on mount.
 - `reactive`: show inputs, hide the Run button, execute once on mount, then use a 150 ms trailing debounce. At most one execution and one newest replacement are retained.
-- `autorun`: show neither inputs nor Run button and execute exactly once for each `cell.id + runtimeVersion`.
+- `autorun`: show neither inputs nor Run button and execute exactly once for each `cell.id + runtimeVersion + source`. Source updates during development invalidate the previous execution even if the runtime-version update arrives first.
 
 This button cell waits for an explicit run even when its input changes.
 

--- a/examples/docs-site/content/docs/ja/features/interactive-cells.mdx
+++ b/examples/docs-site/content/docs/ja/features/interactive-cells.mdx
@@ -34,7 +34,7 @@ Haskell cell は standard-library code のみで `packages`/`crates` を受け�
 
 - `button`: input と Run button を表示し、mount 時は実行しません。
 - `reactive`: input を表示して Run button を隠し、mount 時に一度実行します。その後は 150 ms trailing debounce を使い、active execution 一つと最新 replacement 一つだけを保持します。
-- `autorun`: input/Run button を表示せず、各 `cell.id + runtimeVersion` について正確に一度だけ実行します。
+- `autorun`: input/Run button を表示せず、各 `cell.id + runtimeVersion + source` について正確に一度だけ実行します。開発中は runtime-version の更新が先に届いた場合も、source の更新によって前回の実行結果を無効化します。
 
 次の button cell は、input を変更しても明示的に実行するまで待機します。
 

--- a/packages/oxiquill/src/components/doc-runtime/useInteractiveCellRun.ts
+++ b/packages/oxiquill/src/components/doc-runtime/useInteractiveCellRun.ts
@@ -71,12 +71,12 @@ export function useInteractiveCellRun(cell: CellManifest, runtimeVersion: string
   }, []);
 
   useEffect(() => {
-    if (cell.run === 'reactive') {
+    if (cell.run === 'reactive' && invalidInputsRef.current.size === 0) {
       schedule(valuesRef.current);
     } else if (cell.run === 'autorun') {
-      schedule(valuesRef.current, 0, JSON.stringify([cell.id, runtimeVersion]));
+      schedule(valuesRef.current, 0, JSON.stringify([cell.id, runtimeVersion, cell.source]));
     }
-  }, [cell.id, cell.run, runtimeVersion]);
+  }, [cell.id, cell.run, cell.source, runtimeVersion]);
 
   function schedule(nextValues: InputValues, delayMs = 0, autorunKey?: string): void {
     schedulerRef.current?.schedule({ autorunKey, cell, runtimeVersion, values: nextValues }, delayMs);

--- a/tests/unit/components.test.tsx
+++ b/tests/unit/components.test.tsx
@@ -577,7 +577,7 @@ describe('InteractiveCell', () => {
     expect(screen.getAllByRole('alert')).toHaveLength(1);
   });
 
-  it('runs autorun exactly once per cell and runtime version without rendering execution controls', async () => {
+  it('runs autorun exactly once per cell, source, and runtime version without rendering execution controls', async () => {
     mocks.runInteractiveCell.mockResolvedValue({ stdout: 'auto', plots: [] });
     setManifestCells([makeCell({ run: 'autorun' })], 'autorun-v1');
 
@@ -619,27 +619,35 @@ describe('InteractiveCell', () => {
     );
   });
 
-  it('blocks invalid reactive edits and schedules the latest values once validity returns', async () => {
+  it('blocks invalid reactive edits and source updates until validity returns', async () => {
     mocks.runInteractiveCell.mockResolvedValue({ stdout: 'auto', plots: [] });
-    setManifestCells([
-      makeCell({
-        run: 'reactive',
-        inputs: [{ name: 'count', type: 'number', label: 'count', value: 1, min: 0, max: 4, step: 0.5, options: [] }]
-      })
-    ]);
+    const cell = makeCell({
+      run: 'reactive',
+      inputs: [{ name: 'count', type: 'number', label: 'count', value: 1, min: 0, max: 4, step: 0.5, options: [] }]
+    });
+    setManifestCells([cell]);
 
     render(<InteractiveCell cellId="cell-one" />);
     await waitFor(() => expect(mocks.runInteractiveCell).toHaveBeenCalledOnce());
     const input = screen.getByRole('spinbutton', { name: 'count' });
 
     fireEvent.input(input, { target: { value: '' } });
+    act(() => {
+      setManifestCells([{ ...cell, source: 'println!("updated");' }]);
+      mocks.manifestListeners[0]();
+    });
     await new Promise((resolve) => globalThis.setTimeout(resolve, 200));
     expect(mocks.runInteractiveCell).toHaveBeenCalledOnce();
 
     fireEvent.input(input, { target: { value: '2' } });
     fireEvent.input(input, { target: { value: '3' } });
     await waitFor(() => expect(mocks.runInteractiveCell).toHaveBeenCalledTimes(2));
-    expect(mocks.runInteractiveCell).toHaveBeenLastCalledWith(expect.anything(), { count: 3 }, 'v1', expect.anything());
+    expect(mocks.runInteractiveCell).toHaveBeenLastCalledWith(
+      expect.objectContaining({ source: 'println!("updated");' }),
+      { count: 3 },
+      'v1',
+      expect.anything()
+    );
   });
 
   it('cancels an active reactive request and runs only the final replacement', async () => {
@@ -841,6 +849,33 @@ describe('InteractiveCell', () => {
 
     await waitFor(() => expect(screen.getByText('println!("new");')).toBeVisible());
   });
+
+  it.each(['reactive', 'autorun'] as const)(
+    'reruns %s cells when source arrives after the runtime version update',
+    async (run) => {
+      mocks.runInteractiveCell.mockImplementation((cell: CellManifest) =>
+        Promise.resolve({ stdout: cell.source, plots: [] })
+      );
+      const cell = makeCell({ language: 'python', run, source: 'print(7.5)', inputs: [] });
+      setManifestCells([cell], `source-refresh-${run}-v1`);
+      render(<InteractiveCell cellId="cell-one" />);
+      await waitFor(() => expect(screen.getByTestId('run-output')).toHaveTextContent('print(7.5)'));
+
+      act(() => {
+        setManifestCells([cell], `source-refresh-${run}-v2`);
+        mocks.manifestListeners[0]();
+      });
+      await waitFor(() => expect(mocks.runInteractiveCell).toHaveBeenCalledTimes(2));
+      await waitFor(() => expect(screen.getByTestId('run-output')).toHaveTextContent('print(7.5)'));
+
+      act(() => {
+        setManifestCells([{ ...cell, source: 'print(75.0)' }], `source-refresh-${run}-v2`);
+        mocks.manifestListeners[0]();
+      });
+      await waitFor(() => expect(screen.getByTestId('run-output')).toHaveTextContent('print(75.0)'));
+      expect(mocks.runInteractiveCell).toHaveBeenCalledTimes(3);
+    }
+  );
 
   it('requests shared manifest refreshes and unsubscribes each mounted consumer independently', () => {
     setManifestCells([makeCell()]);


### PR DESCRIPTION
When a development runtime-version update arrives before the corresponding cell manifest, a reactive or autorun cell can execute the old source under the new version and then keep that stale result after the source refreshes. The v0.3.1 release dry run caught this with Python output remaining `7.5` instead of changing to `75.0`.

Schedule automatic execution when the source changes and include the source in the autorun cache identity. Preserve invalid-input blocking during source updates, and clarify the autorun identity in English and Japanese documentation.

Validation completed locally:

- Reproduced both reactive and autorun failures with deterministic version-first/source-second component tests; both pass after the fix.
- `pnpm lint`, `pnpm check`, and `pnpm test:unit:coverage`: passed (1,148 tests passed, 1 platform-specific skip).
- `pnpm test:package`: passed.
- npm/pnpm consumers, packed-browser, development HMR, and `pnpm build`: passed. Chromium E2E: 28 passed. The local Chromium executable override is required because the Nix browser bundle is older than Playwright 1.62.1.
- `git diff --check` and formatting: passed.

Failing tagged dry run: https://github.com/kakune/oxiquill/actions/runs/33957799402

All 17 CI jobs passed, including development HMR and the exact pinned Chromium/Firefox/WebKit matrix: https://github.com/kakune/oxiquill/actions/runs/33960109972
